### PR TITLE
Encode interaction type by shape as well as colour (#270)

### DIFF
--- a/docs/communities/AMD_Acidophile_Heterotroph_Network.html
+++ b/docs/communities/AMD_Acidophile_Heterotroph_Network.html
@@ -773,17 +773,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for AMD Acidophile Heterotroph Network</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1533,6 +1537,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1952,14 +1977,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/AMD_Nitrososphaerota_Archaeal.html
+++ b/docs/communities/AMD_Nitrososphaerota_Archaeal.html
@@ -680,20 +680,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for AMD Nitrososphaerota Archaeal Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1385,6 +1391,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1726,14 +1753,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.html
+++ b/docs/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.html
@@ -712,14 +712,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for ANME/SRB Anaerobic Methanotrophic Syntrophic Consortia</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -972,6 +974,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1205,14 +1228,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
+++ b/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
@@ -554,14 +554,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for ANME-SRB Marine Methane Seep Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1066,6 +1068,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1249,14 +1272,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -642,20 +642,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Aalborg East Full-Scale EBPR Activated Sludge Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1044,6 +1050,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1269,14 +1296,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
+++ b/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Acetobacterium woodii-Clostridium drakei CO2 Electrolysis Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1172,6 +1176,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1395,14 +1420,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
+++ b/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
@@ -550,17 +550,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Acetylene-Fueled Trichloroethene Dechlorination Groundwater Enrichment</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -852,6 +856,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1029,14 +1054,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Aerobic Denitrification Disturbance-Stable SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -772,6 +774,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -906,14 +929,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Aerobic Denitrification Quorum-Quenching SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -759,6 +761,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -893,14 +916,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
+++ b/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
@@ -577,20 +577,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Alaska Tundra Permafrost Iron-Redox Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -964,6 +970,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1207,14 +1234,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
+++ b/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
@@ -640,20 +640,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Altered Schaedler Flora Gnotobiotic Mouse Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1003,6 +1009,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1192,14 +1219,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.html
+++ b/docs/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.html
@@ -506,17 +506,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Anabaena / MGS-1 Anaerobic-Digestion Methanogen Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -936,6 +940,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1106,14 +1131,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -550,17 +550,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Anammox Bioreactor DNRA Destabilization Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -814,6 +818,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -985,14 +1010,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
+++ b/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
@@ -592,17 +592,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Anammox Granule Metabolic Interaction Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1038,6 +1042,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1295,14 +1320,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
+++ b/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
@@ -504,17 +504,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Angelarchaeales Thermoplasmata CuMMO Soil and Sediment Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -797,6 +801,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -973,14 +998,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
+++ b/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Arabidopsis Coumarin Root SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -683,6 +685,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -803,14 +826,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
+++ b/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Arabidopsis Phyllosphere SynCom7</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -714,6 +716,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -834,14 +857,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
+++ b/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
@@ -577,17 +577,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Asgard Archaea Wetland Soil Methanogenesis-Substrate Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -928,6 +932,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1152,14 +1177,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/At_RSPHERE_SynCom.html
+++ b/docs/communities/At_RSPHERE_SynCom.html
@@ -701,14 +701,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for At-RSPHERE SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1406,6 +1408,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1739,14 +1762,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Australian_Lead_Zinc_Polymetallic.html
+++ b/docs/communities/Australian_Lead_Zinc_Polymetallic.html
@@ -780,20 +780,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Australian Lead Zinc Polymetallic Tailings Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1707,6 +1713,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2115,14 +2142,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
+++ b/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
@@ -653,17 +653,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Avena Rhizosphere Cross-Kingdom 13C-SIP Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -1006,6 +1010,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1250,14 +1275,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
+++ b/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
@@ -493,17 +493,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Avena Rhizosphere and Detritusphere Niche-Differentiated Decomposer Guilds</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -804,6 +808,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -976,14 +1001,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.html
+++ b/docs/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.html
@@ -574,17 +574,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Black Soldier Fly Larvae Gut SynCom (Bacillus + Lactobacillus + Issatchenkia)</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -815,6 +819,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -973,14 +998,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
+++ b/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bacillus-Bradyrhizobium Straw Humification SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -661,6 +663,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -789,14 +812,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
+++ b/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bacteroides-Eubacterium Gnotobiotic Gut Model</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1010,6 +1014,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1233,14 +1258,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
+++ b/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
@@ -589,20 +589,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bacteroides-Methanobrevibacter Gnotobiotic Mouse Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -964,6 +970,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1190,14 +1217,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
+++ b/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Banana Fusarium Wilt Biocontrol SynCom1.2</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -772,6 +774,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -906,14 +929,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
+++ b/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
@@ -485,14 +485,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for San Francisco Bay Area Sewage SARS-CoV-2 Metagenomic Surveillance Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -719,6 +721,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -863,14 +886,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
+++ b/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
@@ -582,20 +582,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bayan Obo REE Tailings Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1215,6 +1221,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1547,14 +1574,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
+++ b/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bifidobacterium-Ruminococcus Infant HMO Cross-Feeding Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -794,6 +796,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -965,14 +988,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
+++ b/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bifidobacterium breve-Trichomonas vaginalis Vaginal Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -922,6 +926,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1094,14 +1119,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html
+++ b/docs/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html
@@ -570,20 +570,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioAsteroid ISS Chondrite Biomining Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1216,6 +1222,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1434,14 +1461,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
+++ b/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
@@ -505,14 +505,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250003 Spittlebug Sulcia-Sodalis Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -788,6 +790,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -978,14 +1001,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
+++ b/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
@@ -505,14 +505,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250004 Sharpshooter Sulcia-Baumannia Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -788,6 +790,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -978,14 +1001,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
+++ b/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
@@ -505,14 +505,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL1806250005 Cicada Sulcia-Hodgkinia Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -788,6 +790,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -978,14 +1001,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
+++ b/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
@@ -715,17 +715,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL2204300001 Kefir Community Model</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1196,6 +1200,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1471,14 +1496,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
+++ b/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
@@ -494,14 +494,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL2209060002 D pigrum - S aureus Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -872,6 +874,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1013,14 +1036,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -800,14 +800,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL2405300001 Infant Gut HMO SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1217,6 +1219,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1500,14 +1523,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
+++ b/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
@@ -562,20 +562,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioModels MODEL2407300002 Sponge Holobiont Network</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -905,6 +911,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1099,14 +1126,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/BioRock_ISS_Basalt_Biomining_Consortium.html
+++ b/docs/communities/BioRock_ISS_Basalt_Biomining_Consortium.html
@@ -617,17 +617,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for BioRock ISS Basalt Biomining Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1224,6 +1228,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1444,14 +1469,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
+++ b/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
@@ -617,17 +617,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Brachypodium Young Root Rhizosphere EcoFAB Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -930,6 +934,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1119,14 +1144,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
+++ b/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
@@ -537,20 +537,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Buchnera-Serratia Cinara cedri Endosymbiont Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -874,6 +880,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1091,14 +1118,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.html
+++ b/docs/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.html
@@ -591,14 +591,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Butyrivibrio fibrisolvens + Selenomonas ruminantium + Ruminococcus albus Lignocellulolytic Rumen Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -719,6 +721,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -888,14 +911,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/CRC_Fusobacterium_Control_SynCom.html
+++ b/docs/communities/CRC_Fusobacterium_Control_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for CRC Fusobacterium Control SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -688,6 +690,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -808,14 +831,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
+++ b/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
@@ -579,17 +579,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Cable Bacteria beneath Photosynthetic Biofilm Sediment Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1027,6 +1031,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1261,14 +1286,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
+++ b/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
@@ -537,17 +537,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Caldibacillus-Clostridium Aerotolerant Cellulose Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1018,6 +1022,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1250,14 +1275,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
+++ b/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
@@ -537,20 +537,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Caldicellulosiruptor Two-Species Hydrogen Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1170,6 +1176,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1403,14 +1430,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
+++ b/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
@@ -493,20 +493,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for California Grassland Precipitation Legacy Soil Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -907,6 +913,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1093,14 +1120,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
+++ b/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
@@ -502,14 +502,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Candida parapsilosis Hospitalized Infant Gut Microbiome Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -736,6 +738,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -880,14 +903,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
+++ b/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
@@ -540,20 +540,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for CeMbio Caenorhabditis elegans Microbiome</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1155,6 +1161,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1413,14 +1440,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
+++ b/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Cellulomonas-Rhodobacter Cellulose Photohydrogen Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1062,6 +1068,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1275,14 +1302,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
+++ b/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
@@ -616,20 +616,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Cellulose-to-Methane Quad-Culture SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1253,6 +1259,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1600,14 +1627,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
+++ b/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
@@ -608,17 +608,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Cheese Rind In Situ-In Vitro Model Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1001,6 +1005,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1202,14 +1227,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
+++ b/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
@@ -617,17 +617,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlamydomonas-Bacterial Hydrogen Production Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1143,6 +1147,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1387,14 +1412,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
+++ b/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlamydomonas-Methylobacterium Mutualistic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1084,6 +1086,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1308,14 +1331,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
+++ b/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlorella-Azospirillum Synthetic Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1354,6 +1360,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1633,14 +1660,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
+++ b/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
@@ -555,20 +555,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlorella-Ecoli Mixotrophic Biofuel Precursor Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1107,6 +1113,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1338,14 +1365,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
+++ b/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
@@ -751,17 +751,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlorella fusca CHK0059 Keystone-Taxa Antifungal SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1077,6 +1081,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1277,14 +1302,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
+++ b/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
@@ -533,17 +533,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlorella-Rhizobium Bioflocculation</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -964,6 +968,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1176,14 +1201,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
+++ b/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
@@ -558,17 +558,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chlorochromatium aggregatum Phototrophic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -949,6 +953,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1172,14 +1197,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
+++ b/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
@@ -624,20 +624,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Chromium Sulfur Reduction Enrichment</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1372,6 +1378,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1664,14 +1691,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Cinnamate_Degradation_Consortium.html
+++ b/docs/communities/Cinnamate_Degradation_Consortium.html
@@ -575,17 +575,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Cinnamate β-Oxidation Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -950,6 +954,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1183,14 +1208,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
+++ b/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
@@ -555,14 +555,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium autoethanogenum-Clostridium kluyveri Syngas Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1196,6 +1198,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1430,14 +1453,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
+++ b/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
@@ -559,14 +559,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium-Caldicellulosiruptor Minimal Medium Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1185,6 +1187,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1380,14 +1403,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
+++ b/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium carboxidivorans-Clostridium kluyveri CO Chain-Elongation Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1173,6 +1177,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1406,14 +1431,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
+++ b/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium cellulolyticum-Geobacter sulfurreducens Cellulose MFC Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1146,6 +1152,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1381,14 +1408,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium cellulovorans-Methanosarcina barkeri Cellulose Methane Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1146,6 +1152,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1390,14 +1417,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium cellulovorans-Rhodopseudomonas palustris Cellulose Biohydrogen Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1060,6 +1064,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1275,14 +1300,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
+++ b/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium ljungdahlii-Clostridium kluyveri Syngas Alcohol Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1236,6 +1240,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1527,14 +1552,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
+++ b/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium phytofermentans-E. coli Cellobiose Biofilm Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1252,6 +1256,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1485,14 +1510,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
+++ b/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium-Saccharomyces Cellulose Ethanol Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1164,6 +1168,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1395,14 +1420,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium-Thermoanaerobacter Cellulosic Bioethanol Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1120,6 +1124,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1353,14 +1378,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
@@ -537,17 +537,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium-Thermoanaerobacterium JN4-GD17 Cellulosic Biofuel Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1113,6 +1117,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1342,14 +1367,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
@@ -559,14 +559,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Clostridium Thermocellum-Saccharoperbutylacetonicum Cellulosic Butanol Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1237,6 +1239,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1472,14 +1495,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
+++ b/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
@@ -607,17 +607,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Coastal Forested Wetland Seawater-Ion Microcosm Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1165,6 +1169,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1423,14 +1448,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.html
+++ b/docs/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Five-member bacterial-fungal composting SynCom for lignocellulose degradation</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -670,6 +672,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -797,14 +820,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
+++ b/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
@@ -612,17 +612,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Coniochaeta-Sphingobacterium-Citrobacter Wheat Straw Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1354,6 +1358,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1591,14 +1616,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Copper_Biomining_Heap_Leach.html
+++ b/docs/communities/Copper_Biomining_Heap_Leach.html
@@ -709,20 +709,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Copper Biomining Heap Leach Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1577,6 +1583,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1906,14 +1933,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.html
+++ b/docs/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.html
@@ -534,14 +534,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Corynebacterium glutamicum + Shewanella oneidensis Succinic-acid Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -715,6 +717,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -856,14 +879,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Coscinodiscus_Synthetic_Community.html
+++ b/docs/communities/Coscinodiscus_Synthetic_Community.html
@@ -659,20 +659,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Coscinodiscus Synthetic Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1457,6 +1463,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1788,14 +1815,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.html
+++ b/docs/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.html
@@ -556,14 +556,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Crucian Carp Gut Disease-resistance SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -714,6 +716,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -853,14 +876,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
+++ b/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
@@ -533,20 +533,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Crystal Geyser CO2-Rich Aquifer Autotrophic CPR Lysolipid Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -872,6 +878,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1065,14 +1092,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
+++ b/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
@@ -620,20 +620,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Cyprus Copper Sulphide Bioleaching Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, commensalism, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, commensalism, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -923,6 +929,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1112,14 +1139,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.html
+++ b/docs/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.html
@@ -590,14 +590,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for DIET-based Simplified Lignocellulose-to-Methane Consortia (DIETsimp)</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -901,6 +903,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1107,14 +1130,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/DVM_Triculture.html
+++ b/docs/communities/DVM_Triculture.html
@@ -577,17 +577,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for DVM Tri-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1178,6 +1182,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1456,14 +1481,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dangl_SynComm_35.html
+++ b/docs/communities/Dangl_SynComm_35.html
@@ -747,23 +747,31 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Jeff Dangl&#39;s SynComm 35</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1603,6 +1611,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2021,14 +2050,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
+++ b/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
@@ -681,20 +681,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Deepwater Horizon Deep-Sea Oil Plume Succession</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1308,6 +1314,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1538,14 +1565,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
@@ -561,20 +561,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dehalococcoides-Desulfovibrio Lactate-Fed TCE Dechlorination Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1317,6 +1323,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1564,14 +1591,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
@@ -616,17 +616,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dehalococcoides-Desulfovibrio-Pelosinus Corrinoid Triculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1262,6 +1266,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1512,14 +1537,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
+++ b/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
@@ -555,17 +555,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dehalococcoides-Methanosarcina DMB-Guided Cobalamin Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1187,6 +1191,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1424,14 +1449,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
+++ b/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dehalococcoides-Pelobacter Acetylene TCE Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1160,6 +1166,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1388,14 +1415,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -537,20 +537,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dehalococcoides-Syntrophomonas TCE Dechlorination Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1230,6 +1236,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1473,14 +1500,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dehalococcoides_mccartyi_CWV2_Dechlorinating_Consortium.html
+++ b/docs/communities/Dehalococcoides_mccartyi_CWV2_Dechlorinating_Consortium.html
@@ -492,14 +492,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dehalococcoides mccartyi CWV2 Dechlorinating Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -640,6 +642,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -769,14 +792,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
+++ b/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Desert-Derived Tomato Salt Stress SynCom5</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -675,6 +677,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -795,14 +818,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
@@ -535,14 +535,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Desulfovibrio-Methanococcus Syntrophic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1279,6 +1281,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1468,14 +1491,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
@@ -537,20 +537,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Desulfovibrio-Methanosarcina Lactate Syntrophy</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -943,6 +949,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1175,14 +1202,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
+++ b/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
@@ -595,20 +595,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Drosophila Five-Species Gnotobiotic Gut Microbiota</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1032,6 +1038,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1262,14 +1289,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
+++ b/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
@@ -493,20 +493,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Drought-Induced Rhizosphere Iron-Enriched Actinobacteria Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -868,6 +874,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1050,14 +1077,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Dual_Bacillus_coagulans_Pseudomonas_putida_Lactic_Acid_Coculture.html
+++ b/docs/communities/Dual_Bacillus_coagulans_Pseudomonas_putida_Lactic_Acid_Coculture.html
@@ -574,17 +574,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Dual Bacillus coagulans + Pseudomonas putida Lactic-acid Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -863,6 +867,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1079,14 +1104,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/ENIGMA_Denitrifying_SynCom.html
+++ b/docs/communities/ENIGMA_Denitrifying_SynCom.html
@@ -558,17 +558,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for ENIGMA Denitrifying SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -978,6 +982,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1159,14 +1184,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/East_River_Floodplain_Core_Microbiome.html
+++ b/docs/communities/East_River_Floodplain_Core_Microbiome.html
@@ -629,14 +629,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for East River Floodplain Core Microbiome</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -942,6 +944,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1139,14 +1162,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
+++ b/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
@@ -645,14 +645,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for East River Hillslope Riparian Transect Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1173,6 +1175,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1405,14 +1428,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -1085,17 +1085,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for EcoFAB 2.0 Root Microbiome Ring Trial SynCom17</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -2146,6 +2150,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2922,14 +2947,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.html
+++ b/docs/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.html
@@ -536,14 +536,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Escherichia coli + Bifidobacterium bifidum Infant-gut Mutualistic Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -780,6 +782,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -961,14 +984,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.html
+++ b/docs/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.html
@@ -580,14 +580,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Electrostimulated Mixotrophic VFA-producing Enrichment Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -692,6 +694,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -841,14 +864,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.html
+++ b/docs/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.html
@@ -584,14 +584,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Shewanella-Acetogen Electrosynthetic Consortia for CO2-to-Acetate</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -810,6 +812,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -998,14 +1021,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
+++ b/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
@@ -537,20 +537,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Emiliania huxleyi-Phaeobacter inhibens Dynamic Interaction</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -920,6 +926,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1143,14 +1170,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
+++ b/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
@@ -621,17 +621,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Engineered Gut Amino Acid Cross-Feeding Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1017,6 +1021,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1224,14 +1249,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.html
+++ b/docs/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.html
@@ -570,17 +570,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Ensifer YF2 + Sphingobacterium Y2 Polyethylene-degrading Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -755,6 +759,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -934,14 +959,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
+++ b/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
@@ -586,17 +586,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Episymbiotic CPR Bacteria and DPANN Archaea Groundwater Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -840,6 +844,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1008,14 +1033,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
+++ b/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
@@ -665,14 +665,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Eucalyptus Nursery Five-Strain Bacterial Inoculant Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -991,6 +993,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1146,14 +1169,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ewaste_Bioleaching_Consortium.html
+++ b/docs/communities/Ewaste_Bioleaching_Consortium.html
@@ -698,23 +698,31 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for E-waste Bioleaching Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1392,6 +1400,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1732,14 +1761,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
+++ b/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
@@ -561,17 +561,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Ferroplasma-Leptospirillum Iron-Cycling Syntrophy</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1425,6 +1429,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1736,14 +1761,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
+++ b/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for GLBRC Exometabolite Transwell SynCom System</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -688,6 +690,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -808,14 +831,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
+++ b/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
@@ -1624,20 +1624,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for GLBRC Populus Variovorax SynCom28</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning, colonization facilitation, strain competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning, colonization facilitation, strain competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf30b7;"></span> Strain competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolAsterisk"
+                             data-color="#cf30b7"></svg> Strain competition
                     </div>
                 </div>
             </div>
@@ -2118,6 +2124,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2483,14 +2510,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -894,14 +894,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for GLBRC Ultra-Filtered Milk Permeate Fermentation Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1278,6 +1280,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1545,14 +1568,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/GOM_Oil_Degrading_Consortium.html
+++ b/docs/communities/GOM_Oil_Degrading_Consortium.html
@@ -617,14 +617,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Gulf of Mexico Oil-Degrading Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -906,6 +908,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1111,14 +1134,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Garlic_Pseudomonas_SynCom6.html
+++ b/docs/communities/Garlic_Pseudomonas_SynCom6.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Garlic Rhizosphere Pseudomonas SynCom6</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -675,6 +677,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -795,14 +818,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.html
+++ b/docs/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.html
@@ -558,17 +558,21 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Geobacter-Clostridium Interspecies Electron Transfer Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1269,6 +1273,27 @@ The competing mechanism is NOT asserted in its place. The follow-up (PMID:349391
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1460,14 +1485,27 @@ The competing mechanism is NOT asserted in its place. The follow-up (PMID:349391
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Geobacter_Methanosaeta_DIET.html
+++ b/docs/communities/Geobacter_Methanosaeta_DIET.html
@@ -535,17 +535,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Geobacter-Methanosaeta DIET Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -994,6 +998,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1179,14 +1204,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Geobacter_Methanosarcina_DIET.html
+++ b/docs/communities/Geobacter_Methanosarcina_DIET.html
@@ -535,20 +535,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Geobacter-Methanosarcina DIET Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1168,6 +1174,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1386,14 +1413,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
+++ b/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
@@ -548,17 +548,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Geobacter-Pseudomonas Formate-Fumarate Electroactive Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1150,6 +1154,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1425,14 +1450,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
+++ b/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
@@ -527,14 +527,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Grassland Soil Wet-Up Virus-Host Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -836,6 +838,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1005,14 +1028,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
+++ b/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
@@ -537,17 +537,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Groundwater Elusimicrobia Diverse Metabolisms Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -867,6 +871,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1062,14 +1087,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
+++ b/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
@@ -618,14 +618,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Hanford 300 Area Unconfined Aquifer Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -902,6 +904,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1101,14 +1124,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -684,17 +684,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for High-Solids Switchgrass Methanogenic Microbiome</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1357,6 +1361,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1607,14 +1632,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Honeybee_Core20_Defined_Microbiota.html
+++ b/docs/communities/Honeybee_Core20_Defined_Microbiota.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Honeybee Core-20 Defined Microbiota</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -680,6 +682,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -800,14 +823,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
+++ b/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
@@ -535,20 +535,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Horonobe and Mizunami Underground Research Laboratory Subsurface Microbiome</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -947,6 +953,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1160,14 +1187,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
+++ b/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
@@ -608,14 +608,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Human Gut Four-Member Proteome-Complementarity Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -982,6 +984,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1131,14 +1154,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
+++ b/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
@@ -870,17 +870,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Iberian Pit Lake Stratified Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1560,6 +1564,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1917,14 +1942,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Industrial_Bioreactor_Consortium.html
+++ b/docs/communities/Industrial_Bioreactor_Consortium.html
@@ -863,23 +863,31 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Industrial Bioleaching Reactor Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1885,6 +1893,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2386,14 +2415,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
+++ b/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
@@ -632,20 +632,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Industrial Milk-Line Four-Species Model Biofilm</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1082,6 +1088,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1290,14 +1317,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
+++ b/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
@@ -521,17 +521,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Infant Gut DNA Phageome Succession Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -849,6 +853,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1038,14 +1063,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Infant_Gut_Prebiotic_Response_SynCom.html
+++ b/docs/communities/Infant_Gut_Prebiotic_Response_SynCom.html
@@ -620,17 +620,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Infant-gut Prebiotic-response SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -895,6 +899,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1104,14 +1129,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
+++ b/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
@@ -577,17 +577,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Infant Gut Strain Persistence and Maternal Seeding Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -931,6 +935,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1143,14 +1168,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
+++ b/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
@@ -813,20 +813,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Ion-Adsorption REE Indigenous Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1487,6 +1493,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1836,14 +1863,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Jala_Maize_PGPB_SynCom.html
+++ b/docs/communities/Jala_Maize_PGPB_SynCom.html
@@ -616,14 +616,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Jala Maize PGPB SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -814,6 +816,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -955,14 +978,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
+++ b/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
@@ -585,17 +585,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for KB-1 Chlorinated Ethene Dechlorinating Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -932,6 +936,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1121,14 +1146,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
+++ b/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
@@ -616,17 +616,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for KBase Models for Zahmeeth Original PLOS</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -840,6 +844,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1019,14 +1044,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/KBase_ORT_Workflow_Community_Model.html
+++ b/docs/communities/KBase_ORT_Workflow_Community_Model.html
@@ -616,14 +616,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for KBase ORT Workflow Community Model</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -911,6 +913,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1104,14 +1127,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
+++ b/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
@@ -517,17 +517,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for KBase Synthetic Bacterial Community in R2A Medium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -922,6 +926,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1134,14 +1159,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
+++ b/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
@@ -617,20 +617,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Kombucha KMC-IMBG1 Fermentation Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1037,6 +1043,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1245,14 +1272,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
+++ b/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for LBNL Brachypodium Drought SynCom15</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -688,6 +690,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -808,14 +831,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
+++ b/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for LBNL Human Gut Interaction SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -693,6 +695,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -813,14 +836,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
+++ b/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for LBNL Switchgrass Soil SynCom16</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -693,6 +695,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -813,14 +836,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
+++ b/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
@@ -575,14 +575,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Lac Pavin Permanently Stratified Lake Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -847,6 +849,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1021,14 +1044,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
+++ b/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
@@ -842,17 +842,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Lake Washington Methane-Oxygen Methylotroph Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1389,6 +1393,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1652,14 +1677,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
+++ b/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
@@ -548,14 +548,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Legume-Rhizobia Mars Simulant Symbiosis</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -738,6 +740,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -881,14 +904,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Lotus_LjSC3.html
+++ b/docs/communities/Lotus_LjSC3.html
@@ -869,17 +869,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Lotus Lj-SC3 Synthetic Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1768,6 +1772,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2299,14 +2324,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.html
+++ b/docs/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.html
@@ -652,20 +652,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Lunar and Martian Simulant PGPB Lettuce SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, commensalism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, commensalism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1241,6 +1247,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1448,14 +1475,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.html
+++ b/docs/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.html
@@ -677,17 +677,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Lunar Regolith Simulant Phosphorus-Solubilizing Bacteria for Nicotiana benthamiana</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1181,6 +1185,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1374,14 +1399,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/MAMC_M48_Lignocellulose.html
+++ b/docs/communities/MAMC_M48_Lignocellulose.html
@@ -659,14 +659,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for MAMC-M48 Lignocellulose-Degrading Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1213,6 +1215,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1465,14 +1488,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/MSC1_Dominant_Core.html
+++ b/docs/communities/MSC1_Dominant_Core.html
@@ -995,14 +995,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for MSC-1 Dominant Core</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1816,6 +1818,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2438,14 +2461,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -634,17 +634,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Model Soil Consortium-2 (MSC-2)</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -969,6 +973,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1171,14 +1196,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
+++ b/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
@@ -669,17 +669,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for MUCC Freshwater Wetland Methane-Cycling Network Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1310,6 +1314,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1579,14 +1604,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
+++ b/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Maize Benzoxazinoid-Metabolizing SynComs</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -688,6 +690,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -808,14 +831,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Maize_Drought_Response_SynCom.html
+++ b/docs/communities/Maize_Drought_Response_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Maize Drought Response SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -683,6 +685,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -803,14 +826,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Maize_Root_Simplified_Community.html
+++ b/docs/communities/Maize_Root_Simplified_Community.html
@@ -769,20 +769,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Maize Root Simplified Bacterial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, competition, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1577,6 +1583,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2137,14 +2164,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
+++ b/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Medicago Nodule Biofertilizer SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -738,6 +740,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -865,14 +888,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
+++ b/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Mediterranean Grassland qSIP Rainfall-Gradient Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -769,6 +771,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -896,14 +919,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
+++ b/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
@@ -921,14 +921,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Mercury SFA East Fork Poplar Creek Sediment Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1221,6 +1223,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1467,14 +1490,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
+++ b/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
@@ -614,17 +614,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Mesorhizobium TaiHu-Synechococcus PCC 7002 Vitamin B12 Synthetic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -977,6 +981,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1156,14 +1181,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
+++ b/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methane Oxidation-Cr(VI) Reduction SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -772,6 +774,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -906,14 +929,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
+++ b/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
@@ -555,20 +555,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methylacidiphilum-Galdieria Thermoacidophilic Methane Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1125,6 +1131,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1364,14 +1391,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methylocaldum-Cupriavidus Methane Acetate Cross-Feeding Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1062,6 +1066,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1255,14 +1280,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
@@ -557,14 +557,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methylocaldum-Methyloceanibacter Methane Cross-Feeding Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1040,6 +1042,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1235,14 +1258,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
+++ b/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methylocystis-Rhodococcus Methane VFA PHBV Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1043,6 +1045,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1194,14 +1217,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
+++ b/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methylomicrobium-Chlorella Methane Sequestration Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1228,6 +1234,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1465,14 +1492,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
+++ b/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
@@ -555,17 +555,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Methylotuvimicrobium-Synechococcus Gas Feedstock Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1047,6 +1051,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1240,14 +1265,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
+++ b/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Microcoleus-Massilia Cyanosphere Urea Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1105,6 +1111,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1342,14 +1369,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
+++ b/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
@@ -658,14 +658,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Miscanthus REE Tailings Nitrogen SynCom10</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -787,6 +789,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -936,14 +959,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
+++ b/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
@@ -603,20 +603,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Mixed Gallium LED Recovery Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1176,6 +1182,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1458,14 +1485,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
+++ b/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
@@ -535,20 +535,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Model Cyanobacterial Consortia Core Microbiome</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -931,6 +937,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1128,14 +1155,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
+++ b/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
@@ -628,20 +628,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Model Lignocellulose Formaldehyde Cross-Feeding Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1173,6 +1179,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1450,14 +1477,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html
+++ b/docs/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html
@@ -572,17 +572,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Moss-Microbe Complex Regolith Biofertilizer</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -759,6 +763,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -927,14 +952,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Multi_stage_Anaerobic_Digestion_SynCom_YSJ_and_SynCom_J.html
+++ b/docs/communities/Multi_stage_Anaerobic_Digestion_SynCom_YSJ_and_SynCom_J.html
@@ -431,20 +431,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Multi-stage Anaerobic-Digestion SynCom-YSJ and SynCom-J</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -654,6 +660,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -815,14 +842,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
+++ b/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Multiomics Corn Straw Degradation SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -670,6 +672,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -790,14 +813,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
+++ b/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
@@ -665,14 +665,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Mushroom Spring Hot-Spring Phototrophic Mat Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1118,6 +1120,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1361,14 +1384,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
+++ b/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for N-Cycle Bioflocculation Model Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -675,6 +677,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -795,14 +818,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
+++ b/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
@@ -745,17 +745,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Naica Deep Subsurface Thermophilic Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1285,6 +1289,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1618,14 +1643,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
+++ b/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Neocallimastix-Methanobrevibacter Xylanolytic Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -979,6 +981,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1216,14 +1239,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
+++ b/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
@@ -575,17 +575,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Ngawha Geothermal Acidic Springs Mercury Cycling Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -861,6 +865,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1029,14 +1054,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
+++ b/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
@@ -501,17 +501,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for OMM12 Gnotobiotic Mouse Gut Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -820,6 +824,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -972,14 +997,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
+++ b/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
@@ -614,20 +614,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for ORNL Clostridium-Desulfovibrio-Geobacter Trophic Model Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1290,6 +1296,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1556,14 +1583,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
+++ b/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
@@ -872,17 +872,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for ORNL PMI Populus PD10 SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1649,6 +1653,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2166,14 +2191,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
+++ b/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
@@ -629,17 +629,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Oak Ridge FRC Uranium-Nitrate Groundwater Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -931,6 +935,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1128,14 +1153,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
+++ b/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
@@ -659,14 +659,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Okeke-Lu Cellulolytic-Xylanolytic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1237,6 +1239,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1493,14 +1516,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
+++ b/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
@@ -550,17 +550,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Ostreococcus-Dinoroseobacter B-Vitamin Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -972,6 +976,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1205,14 +1230,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
+++ b/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
@@ -665,17 +665,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for PET Artificial Four-Species Degradation Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1263,6 +1267,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1540,14 +1565,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
+++ b/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
@@ -689,20 +689,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for PGM Spent Catalyst Bioleaching Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1560,6 +1566,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1948,14 +1975,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
+++ b/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
@@ -700,14 +700,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for PMI Variovorax Thermotolerance Collection</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -980,6 +982,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1149,14 +1172,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -577,17 +577,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for PSY Transgenic Rice Rhizosphere Methane-Mitigating Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -950,6 +954,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1166,14 +1191,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
+++ b/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
@@ -755,20 +755,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Panzhihua Vanadium Titanium Tailings Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1688,6 +1694,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2094,14 +2121,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.html
+++ b/docs/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.html
@@ -534,17 +534,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Parachlorella kessleri + Saccharomyces cerevisiae Mutualistic Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -786,6 +790,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -997,14 +1022,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
+++ b/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Peanut Seed Bacterial CS SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -620,6 +622,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -740,14 +763,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pelotomaculum-Methanocella Propionate RNA-Seq Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1280,6 +1286,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1553,14 +1580,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
+++ b/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
@@ -535,14 +535,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pelotomaculum-Methanothermobacter Syntrophic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1316,6 +1318,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1505,14 +1528,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
+++ b/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pepper Growth Rhizosphere SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -688,6 +690,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -808,14 +831,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pepper_Phytophthora_SynCom5.html
+++ b/docs/communities/Pepper_Phytophthora_SynCom5.html
@@ -616,14 +616,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pepper Phytophthora-Resistance SynCom5</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -814,6 +816,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -955,14 +978,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Phenol_Carboxylation_Consortium.html
+++ b/docs/communities/Phenol_Carboxylation_Consortium.html
@@ -617,14 +617,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Phenol Carboxylation Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -962,6 +964,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1208,14 +1231,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Phormidium_Alkaline_Consortium.html
+++ b/docs/communities/Phormidium_Alkaline_Consortium.html
@@ -707,17 +707,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Phormidium Alkaline Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1458,6 +1462,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1882,14 +1907,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.html
+++ b/docs/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.html
@@ -536,14 +536,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Phosphitivorax-Methanoculleus Lithosyntrophic Phosphite-Oxidizing Methanogenic Culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -717,6 +719,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -858,14 +881,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
+++ b/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Phylogenetically Diverse Denitrifying SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -785,6 +787,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -912,14 +935,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.html
+++ b/docs/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.html
@@ -628,17 +628,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pinus armandii Endophytic Biocontrol SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -755,6 +759,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -928,14 +953,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.html
+++ b/docs/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.html
@@ -658,14 +658,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pleuromutilin-degrading Artificial Consortium (5-strain)</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -766,6 +768,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -919,14 +942,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
+++ b/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
@@ -689,20 +689,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Polaromonas Vanadium Reduction Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1322,6 +1328,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1617,14 +1644,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Populus_Salt_Tolerant_SynComs.html
+++ b/docs/communities/Populus_Salt_Tolerant_SynComs.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Populus Salt-Tolerant Rhizosphere SynComs</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -620,6 +622,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -740,14 +763,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -663,20 +663,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Prairie Pothole Wetland Sulfur-Carbon Virus-Host Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -1269,6 +1275,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1549,14 +1576,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
+++ b/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
@@ -491,14 +491,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Premature Infant Gut Escherichia In-Situ Physiological-Condition Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -775,6 +777,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -943,14 +966,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
+++ b/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
@@ -543,17 +543,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Prochlorococcus-Alteromonas Helper Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -916,6 +920,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1105,14 +1130,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
+++ b/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
@@ -785,17 +785,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Propanotrophic Chlorinated Ethene Cometabolism Enrichment Cultures</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1388,6 +1392,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1681,14 +1706,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
+++ b/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
@@ -555,17 +555,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pseudomonas-Pedobacter Social Spreading Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -984,6 +988,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1207,14 +1232,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
+++ b/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pseudomonas-Rhodococcus Chloronitrobenzene Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1119,6 +1123,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1339,14 +1364,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.html
+++ b/docs/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pseudomonas putida Pp-TE + Rhodococcus sp. RDK17 Terephthalic-acid Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -736,6 +738,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -911,14 +934,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.html
+++ b/docs/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.html
@@ -544,14 +544,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pseudomonas stutzeri + Rhodococcus Naphthalene-degrading Biochar-bridged Engineered Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -684,6 +686,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -860,14 +883,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
+++ b/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pseudo-nitzschia-Sulfitobacter Marine Association</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1060,6 +1062,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1249,14 +1272,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
+++ b/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
@@ -546,17 +546,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rammelsberg Cobalt-Nickel Tailings Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1118,6 +1122,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1393,14 +1418,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rhodopseudomonas-E. coli Cross-Feeding Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -748,6 +750,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -875,14 +898,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rhodopseudomonas-Geobacter Magnetite Redox Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1196,6 +1202,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1453,14 +1480,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
+++ b/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rice Acid Soil Bioinoculant SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -620,6 +622,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -740,14 +763,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
+++ b/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
@@ -616,17 +616,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rice-Duckweed Bacillus Biocontrol SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -864,6 +868,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1051,14 +1076,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
+++ b/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
@@ -616,14 +616,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rice Phosphorus Uptake Intercropping SynCom4</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -801,6 +803,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -942,14 +965,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Richmond_Mine_AMD_Biofilm.html
+++ b/docs/communities/Richmond_Mine_AMD_Biofilm.html
@@ -769,20 +769,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Richmond Mine AMD Biofilm</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1961,6 +1967,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2343,14 +2370,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
+++ b/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
@@ -760,17 +760,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rifle Aquifer Bioanode Extracellular Electron Transfer Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1055,6 +1059,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1249,14 +1274,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Rifle_Uranium_Reducing_Community.html
+++ b/docs/communities/Rifle_Uranium_Reducing_Community.html
@@ -696,23 +696,31 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Rifle Uranium-Reducing Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1454,6 +1462,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1834,14 +1863,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SF356_Cellulose_Degrader.html
+++ b/docs/communities/SF356_Cellulose_Degrader.html
@@ -659,23 +659,31 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SF356 Thermophilic Cellulose-Degrading Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1222,6 +1230,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1529,14 +1558,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
+++ b/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
@@ -785,17 +785,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SIHUMIx Human Intestinal Model Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1183,6 +1187,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1394,14 +1419,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
+++ b/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
@@ -520,17 +520,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Streptococcus mutans - Candida albicans ECC Biofilm Model</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -783,6 +787,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -988,14 +1013,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
+++ b/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
@@ -520,14 +520,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Streptococcus mutans - Selenomonas sputigena ECC Pathobiont Model</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -726,6 +728,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -897,14 +920,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SMutans_VParvula_ASC_Biofilm.html
+++ b/docs/communities/SMutans_VParvula_ASC_Biofilm.html
@@ -520,14 +520,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Streptococcus mutans - Veillonella parvula Adult Severe Caries Model</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -726,6 +728,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -897,14 +920,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
@@ -578,17 +578,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SPRUCE Peatland Methane-Cycling Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -905,6 +909,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1085,14 +1110,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SPRUCE_Peatland_Warming_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Warming_Community.html
@@ -654,20 +654,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SPRUCE Peatland Warming Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, niche partitioning, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning, predation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #913079;"></span> Predation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolStar"
+                             data-color="#913079"></svg> Predation
                     </div>
                 </div>
             </div>
@@ -1240,6 +1246,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1509,14 +1536,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
+++ b/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
@@ -587,17 +587,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Saanich Inlet Oxygen Minimum Zone Redox-Gradient Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -974,6 +978,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1219,14 +1244,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
+++ b/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
@@ -533,17 +533,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Saccharomyces-Acinetobacter Lignocellulose Hydrolysate Detoxification Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -831,6 +835,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1016,14 +1041,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
+++ b/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
@@ -537,14 +537,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Saccharomyces-Chlamydomonas Fungal-Algal Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1031,6 +1033,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1266,14 +1289,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
+++ b/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
@@ -718,20 +718,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Salar de Atacama Lithium Brine Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1360,6 +1366,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1699,14 +1726,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
+++ b/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Shewanella Denitrifying Richness SynComs</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -693,6 +695,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -813,14 +836,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
+++ b/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
@@ -603,20 +603,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Shewanella-Geobacter Three-Species Exoelectrogenic Biofilm Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -998,6 +1004,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1214,14 +1241,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.html
+++ b/docs/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.html
@@ -562,14 +562,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Shewanella oneidensis + Pseudomonas aeruginosa Fe0-dependent Electro-syntrophic Denitrifying Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -785,6 +787,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -922,14 +945,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
+++ b/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
@@ -557,14 +557,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Shewanella-Streptococcus Starch-Fueled Microbial Fuel Cell Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -1115,6 +1117,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1350,14 +1373,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.html
+++ b/docs/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.html
@@ -540,14 +540,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Shewanella oneidensis MR-1 - Rhodopseudomonas palustris Electro-syntrophic Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -631,6 +633,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -769,14 +792,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SkinCom_Synthetic_Skin_Community.html
+++ b/docs/communities/SkinCom_Synthetic_Skin_Community.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SkinCom Synthetic Skin Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -688,6 +690,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -808,14 +831,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
+++ b/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
@@ -617,14 +617,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Soil Biosynthetic Gene Cluster Phylum-Depth-Vegetation Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -877,6 +879,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1042,14 +1065,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
+++ b/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Soil CPR Bacteria and Nanoarchaea Rare-Biosphere Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -767,6 +769,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -918,14 +941,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
+++ b/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
@@ -575,17 +575,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Soil Corrinoid Reservoir Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -857,6 +861,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1023,14 +1048,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Sorghum_SRC1_Subset.html
+++ b/docs/communities/Sorghum_SRC1_Subset.html
@@ -743,14 +743,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Sorghum SRC1 Subset Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1232,6 +1234,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1604,14 +1627,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -590,20 +590,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for South Bay Salt Pond Methane Restoration Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1151,6 +1157,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1389,14 +1416,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
+++ b/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Soybean Chlorophyll-Selected Biofertilizer SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -738,6 +740,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -865,14 +888,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Soybean_N_Fixation_sfSynCom.html
+++ b/docs/communities/Soybean_N_Fixation_sfSynCom.html
@@ -617,14 +617,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Soybean N-Fixation Simplified SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1400,6 +1402,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1653,14 +1676,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
+++ b/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Sphingobium-Rhodococcus Lignin-Dimer Valorization Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1026,6 +1030,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1227,14 +1252,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
+++ b/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
@@ -625,20 +625,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Stordalen Mire Methylotrophic Methanogenesis Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1164,6 +1170,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1402,14 +1429,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
+++ b/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
@@ -491,17 +491,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Subsurface Carboxydocella CO-Oxidation Aquifer Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -754,6 +758,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -898,14 +923,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.html
+++ b/docs/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.html
@@ -606,20 +606,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Suillus clintonianus-Bacillus altitudinis Thiamine Cross-Feeding SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1255,6 +1261,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1523,14 +1550,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
+++ b/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
@@ -579,14 +579,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Sulfide Spring Autotrophic CPR-Hosting Biofilm</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -853,6 +855,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1040,14 +1063,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
+++ b/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SynComBac10 Chicken Intestinal SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -693,6 +695,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -813,14 +836,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
+++ b/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
@@ -629,17 +629,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SynCom ARC Peanut Aflatoxin-Control and Nodulation-Coupling Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -798,6 +802,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -971,14 +996,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.html
+++ b/docs/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.html
@@ -532,17 +532,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SynCom BsBv Cigar Tobacco Leaf Fermentation</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -736,6 +740,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -887,14 +912,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.html
+++ b/docs/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SynCom + Chlorella sorokiniana Biogas-slurry Coupling System</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -685,6 +687,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -817,14 +840,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.html
+++ b/docs/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.html
@@ -526,17 +526,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SynCom MetG2 Rhizobacteria Sugarcane Stress Resilience</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -674,6 +678,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -846,14 +871,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.html
+++ b/docs/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Pseudomonas-Rahnella native rhizosphere SynCom for Artemisia argyi phytoremediation</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -623,6 +625,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -761,14 +784,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.html
+++ b/docs/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.html
@@ -994,14 +994,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Sesame-flavor Baijiu Fuqu SynCom (13-genus)</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions.</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction.</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #929caa;"></span> Other
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -1152,6 +1154,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -1361,14 +1384,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.html
+++ b/docs/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.html
@@ -532,17 +532,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SynCom Y Agrobacterium-Bacillus Biofilm Biocontrol Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -835,6 +839,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1056,14 +1081,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
+++ b/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-Azotobacter Photoproduction Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1160,6 +1164,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1393,14 +1418,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Bacillus_SPC.html
+++ b/docs/communities/Synechococcus_Bacillus_SPC.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-Bacillus Synthetic Photosynthetic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -793,6 +795,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -972,14 +995,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Ecoli_SPC.html
+++ b/docs/communities/Synechococcus_Ecoli_SPC.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-E.coli Synthetic Photosynthetic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -887,6 +889,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1066,14 +1089,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
+++ b/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
@@ -557,14 +557,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-Halomonas Light-Driven PHB Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -995,6 +997,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1186,14 +1209,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
+++ b/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
@@ -568,17 +568,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-Pseudomonas Phototrophic PHA and DNT Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1357,6 +1361,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1622,14 +1647,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
+++ b/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-Shewanella D-Lactate Biophotovoltaic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1140,6 +1144,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1369,14 +1394,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synechococcus_Yarrowia_SPC.html
+++ b/docs/communities/Synechococcus_Yarrowia_SPC.html
@@ -533,14 +533,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synechococcus-Yarrowia Synthetic Photosynthetic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -798,6 +800,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -981,14 +1004,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
+++ b/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
@@ -537,17 +537,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synthetic Lichen Synechococcus-Rhodotorula Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -959,6 +963,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1189,14 +1214,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
+++ b/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Synthetic Periphyton Freshwater Biofilm</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -785,6 +787,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -919,14 +942,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
@@ -546,14 +546,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Syntrophobacter-Methanobacterium Syntrophic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1117,6 +1119,27 @@ Still open: carrier apportionment between H2 and formate for the M. formicicum p
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1306,14 +1329,27 @@ Still open: carrier apportionment between H2 and formate for the M. formicicum p
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
@@ -535,14 +535,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Syntrophobacter-Methanospirillum Syntrophic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1275,6 +1277,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1464,14 +1487,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
+++ b/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
@@ -559,20 +559,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Syntrophomonas-Methanococcus Butyrate Growth Coordination Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1207,6 +1213,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1432,14 +1459,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
@@ -535,14 +535,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Syntrophomonas-Methanospirillum Syntrophic Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1293,6 +1295,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1478,14 +1501,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Syntrophus_Benzoate_Degrader.html
+++ b/docs/communities/Syntrophus_Benzoate_Degrader.html
@@ -535,14 +535,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Syntrophus Benzoate Degrader</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -963,6 +965,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1150,14 +1173,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Syntrophus-Methanospirillum Gentianae Benzoate Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1230,6 +1234,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1469,14 +1494,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/THOR_Rhizosphere_Model_Community.html
+++ b/docs/communities/THOR_Rhizosphere_Model_Community.html
@@ -575,17 +575,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for THOR Rhizosphere Model Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -966,6 +970,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1188,14 +1213,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -785,17 +785,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for TYQ1 Nematode Biocontrol SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1113,6 +1117,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1369,14 +1394,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
+++ b/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
@@ -616,14 +616,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Teosinte-Derived Maize Biofertilizer SynCom7</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -801,6 +803,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -942,14 +965,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
+++ b/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
@@ -550,20 +550,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thalassiosira-Marinobacter Marine Snow Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, niche partitioning, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1113,6 +1119,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1370,14 +1397,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -572,17 +572,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thalassiosira-Ruegeria Phycosphere Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1055,6 +1059,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1282,14 +1307,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
+++ b/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
@@ -570,17 +570,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thermacetogenium-Methanothermobacter Acetate Oxidation Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -1363,6 +1367,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1604,14 +1629,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.html
+++ b/docs/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.html
@@ -658,14 +658,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thermophilic Lignocellulose-degrading Composting SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -866,6 +868,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1043,14 +1066,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
+++ b/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
@@ -667,17 +667,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thermophilic Pyrite Quorum Sensing Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1663,6 +1667,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -2058,14 +2083,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
+++ b/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
@@ -559,17 +559,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thermotoga-Methanocaldococcus Hyperthermophilic Syntrophy</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1152,6 +1156,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1383,14 +1408,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
+++ b/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
@@ -594,20 +594,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Thiocyanate-Degrading Afipia and Thiobacillus Bioreactor Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -928,6 +934,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1124,14 +1151,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Tinto_River_Iron_Cycling_Community.html
+++ b/docs/communities/Tinto_River_Iron_Cycling_Community.html
@@ -714,17 +714,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Tinto River Iron Cycling Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1173,6 +1177,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1492,14 +1517,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
+++ b/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Tobacco Chemotactic Biocontrol SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -717,6 +719,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -844,14 +867,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Tomato_Oxylipin_SynCom3.html
+++ b/docs/communities/Tomato_Oxylipin_SynCom3.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Tomato Oxylipin-Protective SynCom3</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -703,6 +705,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -838,14 +861,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
+++ b/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
@@ -574,14 +574,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Tribromophenol Anaerobic Bioremediation SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -772,6 +774,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -906,14 +929,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -614,17 +614,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Trichococcus-Syntrophomonas-Methanospirillum Butyrate Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1313,6 +1317,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1545,14 +1570,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
+++ b/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
@@ -557,17 +557,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Trichoderma-E. coli Cellulosic Isobutanol Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1125,6 +1129,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1356,14 +1381,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Trichoderma_Lactate_Platform.html
+++ b/docs/communities/Trichoderma_Lactate_Platform.html
@@ -575,17 +575,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Trichoderma Lactate Platform for SCFA Production</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (syntrophy, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (syntrophy, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -980,6 +984,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1219,14 +1244,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
+++ b/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
@@ -557,20 +557,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Trichoderma-Streptomyces Filamentous Cellulose Coculture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -1092,6 +1098,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1309,14 +1336,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -577,20 +577,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Trichodesmium-Alteromonas Marine Consortium</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, commensalism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #cf7830;"></span> Commensalism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolWye"
+                             data-color="#cf7830"></svg> Commensalism
                     </div>
                 </div>
             </div>
@@ -994,6 +1000,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1228,14 +1255,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Urine_Nitrification_SynCom.html
+++ b/docs/communities/Urine_Nitrification_SynCom.html
@@ -658,14 +658,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Urine Nitrification Synthetic Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                 </div>
             </div>
@@ -851,6 +853,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -999,14 +1022,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
+++ b/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
@@ -548,17 +548,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Variovorax-Cryptococcus Vitamin Cross-Feeding Microcosm</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -984,6 +988,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1214,14 +1239,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
+++ b/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
@@ -532,14 +532,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Watermelon Rhizosphere Fusarium-Protective SynCom8</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -756,6 +758,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -883,14 +906,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -618,20 +618,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Wetland Oxygen-Sulfate Greenhouse Gas Microcosm Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, competition, niche partitioning).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, competition, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #1212ed;"></span> Niche partitioning
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare2"
+                             data-color="#1212ed"></svg> Niche partitioning
                     </div>
                 </div>
             </div>
@@ -1157,6 +1163,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1396,14 +1423,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Wheat_Consortium_C1.html
+++ b/docs/communities/Wheat_Consortium_C1.html
@@ -575,14 +575,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Wheat Synthetic Consortium C1</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -847,6 +849,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1037,14 +1060,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Wheat_Consortium_C6.html
+++ b/docs/communities/Wheat_Consortium_C6.html
@@ -575,17 +575,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Wheat Synthetic Consortium C6</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism, syntrophy).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, syntrophy).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #7f30cf;"></span> Syntrophy
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTriangle"
+                             data-color="#7f30cf"></svg> Syntrophy
                     </div>
                 </div>
             </div>
@@ -858,6 +862,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1052,14 +1077,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
+++ b/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
@@ -631,14 +631,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Wheat Straw Biogas Pretreatment SynCom</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -760,6 +762,27 @@
             "PREDATION": "#913079"
         };
         var unmappedColor = "#929caa";
+
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
 
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
@@ -902,14 +925,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -574,20 +574,26 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Yogurt Two-Species Starter Culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism, colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -1259,6 +1265,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1530,14 +1557,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
+++ b/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
@@ -555,17 +555,21 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Zymomonas-E. coli Exometabolomics-Designed Obligate Mutualism</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (cross-feeding, mutualism).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #57c7ab;"></span> Cross-feeding
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolDiamond"
+                             data-color="#57c7ab"></svg> Cross-feeding
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #56bbe6;"></span> Mutualism
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolSquare"
+                             data-color="#56bbe6"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1084,6 +1088,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1309,14 +1334,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/hCom2_Complex_Gut_Microbiome.html
+++ b/docs/communities/hCom2_Complex_Gut_Microbiome.html
@@ -490,14 +490,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for hCom2 Complex Gut Microbiome</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (colonization facilitation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #edab12;"></span> Colonization facilitation
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolPlus"
+                             data-color="#edab12"></svg> Colonization facilitation
                     </div>
                 </div>
             </div>
@@ -714,6 +716,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -834,14 +857,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/docs/communities/mCAFEs_Brachypodium_RCC.html
+++ b/docs/communities/mCAFEs_Brachypodium_RCC.html
@@ -868,14 +868,16 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for m-CAFEs Brachypodium Reduced Complexity Consortia</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions (competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (competition).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: #7a7a7a;"></span> Taxon
                     </div>
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: #a91919;"></span> Competition
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="symbolTimes"
+                             data-color="#a91919"></svg> Competition
                     </div>
                 </div>
             </div>
@@ -1187,6 +1189,27 @@
         };
         var unmappedColor = "#929caa";
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            "CROSS_FEEDING": "symbolDiamond",
+            "MUTUALISM": "symbolSquare",
+            "SYNTROPHY": "symbolTriangle",
+            "COMPETITION": "symbolTimes",
+            "COMMENSALISM": "symbolWye",
+            "NICHE_PARTITIONING": "symbolSquare2",
+            "COLONIZATION_FACILITATION": "symbolPlus",
+            "STRAIN_COMPETITION": "symbolAsterisk",
+            "PREDATION": "symbolStar"
+        };
+        var unmappedSymbol = "symbolTriangle2";
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         
@@ -1394,14 +1417,27 @@
             .attr("stroke", "#4a4a4a")
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -512,17 +512,26 @@
         {%- set taxon_color = "#7a7a7a" -%}
         {%- set taxon_stroke = "#4a4a4a" -%}
         {%- set unmapped_color = "#929caa" -%}
+        {#- `symbol` is the redundant channel (#270). Nine categories is past what
+            colour alone can carry: measured all-pairs, this palette drops to
+            ΔE 1.8 under tritanopia and 10.3 under NORMAL vision for
+            Mutualism-vs-Cross-feeding, so shape is not a courtesy to CVD
+            readers, it is what makes two of the commonest types separable at
+            all. Circle is reserved for taxa, so every value below is a
+            non-circle d3 symbol; the bundled d3 v7 ships 14, which is enough
+            for a 1:1 mapping without doubling up on fill. -#}
         {%- set interaction_legend = [
-            {"key": "CROSS_FEEDING", "label": "Cross-feeding", "color": "#57c7ab"},
-            {"key": "MUTUALISM", "label": "Mutualism", "color": "#56bbe6"},
-            {"key": "SYNTROPHY", "label": "Syntrophy", "color": "#7f30cf"},
-            {"key": "COMPETITION", "label": "Competition", "color": "#a91919"},
-            {"key": "COMMENSALISM", "label": "Commensalism", "color": "#cf7830"},
-            {"key": "NICHE_PARTITIONING", "label": "Niche partitioning", "color": "#1212ed"},
-            {"key": "COLONIZATION_FACILITATION", "label": "Colonization facilitation", "color": "#edab12"},
-            {"key": "STRAIN_COMPETITION", "label": "Strain competition", "color": "#cf30b7"},
-            {"key": "PREDATION", "label": "Predation", "color": "#913079"}
+            {"key": "CROSS_FEEDING", "label": "Cross-feeding", "color": "#57c7ab", "symbol": "symbolDiamond"},
+            {"key": "MUTUALISM", "label": "Mutualism", "color": "#56bbe6", "symbol": "symbolSquare"},
+            {"key": "SYNTROPHY", "label": "Syntrophy", "color": "#7f30cf", "symbol": "symbolTriangle"},
+            {"key": "COMPETITION", "label": "Competition", "color": "#a91919", "symbol": "symbolTimes"},
+            {"key": "COMMENSALISM", "label": "Commensalism", "color": "#cf7830", "symbol": "symbolWye"},
+            {"key": "NICHE_PARTITIONING", "label": "Niche partitioning", "color": "#1212ed", "symbol": "symbolSquare2"},
+            {"key": "COLONIZATION_FACILITATION", "label": "Colonization facilitation", "color": "#edab12", "symbol": "symbolPlus"},
+            {"key": "STRAIN_COMPETITION", "label": "Strain competition", "color": "#cf30b7", "symbol": "symbolAsterisk"},
+            {"key": "PREDATION", "label": "Predation", "color": "#913079", "symbol": "symbolStar"}
         ] -%}
+        {%- set unmapped_symbol = "symbolTriangle2" -%}
         {#- Mirror the script's `interaction_type or "UNKNOWN"` so a typeless
             interaction still earns the grey "Other" swatch it is drawn with. -#}
         {%- set present_types = community.ecological_interactions | default([], true)
@@ -543,20 +552,29 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for {{ community.name }}</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and colored rectangles represent ecological interactions{% if present_legend %} ({{ present_legend | map(attribute="label") | join(", ") | lower }}){% endif %}.</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction{% if present_legend %} ({{ present_legend | map(attribute="label") | join(", ") | lower }}){% endif %}.</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
                         <span class="legend-swatch legend-circle" style="background: {{ taxon_color }};"></span> Taxon
                     </div>
+                    {#- The swatch carries the shape as well as the colour, or the
+                        redundant channel is unreadable: a reader cannot match a
+                        diamond in the graph to a coloured square here (#270). Each
+                        is drawn by the same d3 symbol path as the node it stands
+                        for, so the two cannot drift. -#}
                     {%- for item in present_legend %}
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: {{ item.color }};"></span> {{ item.label }}
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="{{ item.symbol }}"
+                             data-color="{{ item.color }}"></svg> {{ item.label }}
                     </div>
                     {%- endfor %}
                     {%- if has_unmapped %}
                     <div class="legend-item">
-                        <span class="legend-swatch" style="background: {{ unmapped_color }};"></span> Other
+                        <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
+                             aria-hidden="true" data-symbol="{{ unmapped_symbol }}"
+                             data-color="{{ unmapped_color }}"></svg> Other
                     </div>
                     {%- endif %}
                 </div>
@@ -979,6 +997,21 @@
         };
         var unmappedColor = {{ unmapped_color|tojson }};
 
+        // The redundant channel for interaction type (#270). Names are resolved
+        // against d3 at use, so an unknown name falls back rather than throwing.
+        var interactionSymbols = {
+            {%- for item in interaction_legend %}
+            {{ item.key|tojson }}: {{ item.symbol|tojson }}{{ "," if not loop.last }}
+            {%- endfor %}
+        };
+        var unmappedSymbol = {{ unmapped_symbol|tojson }};
+
+        function symbolPathFor(type, size) {
+            var name = interactionSymbols[type] || unmappedSymbol;
+            var shape = d3[name] || d3[unmappedSymbol] || d3.symbolSquare;
+            return d3.symbol().type(shape).size(size)();
+        }
+
         // Build taxon lookup keyed by preferred_term
         var taxonData = {};
         {% for taxon in community.taxonomy %}
@@ -1117,14 +1150,27 @@
             .attr("stroke", {{ taxon_stroke|tojson }})
             .attr("stroke-width", 1.5);
 
+        // Paint the legend swatches with the same paths the nodes use, so the
+        // legend cannot drift from the graph (#270).
+        d3.selectAll("svg.legend-symbol").each(function() {
+            var el = d3.select(this);
+            var name = el.attr("data-symbol");
+            var colour = el.attr("data-color");
+            var shape = d3[name] || d3.symbolSquare;
+            var c = d3.color(colour);
+            el.append("path")
+                .attr("d", d3.symbol().type(shape).size(90)())
+                .attr("fill", colour)
+                .attr("stroke", c ? c.darker(0.5) : "#4b5563")
+                .attr("stroke-width", 1.2);
+        });
+
         // Interaction nodes: rounded rects
+        // One shape per interaction type, not one rect in nine colours (#270).
+        // Sized to roughly the 28x18 rect it replaces so the layout is unchanged.
         node.filter(function(d) { return d.type === "interaction"; })
-            .append("rect")
-            .attr("width", 28)
-            .attr("height", 18)
-            .attr("x", -14)
-            .attr("y", -9)
-            .attr("rx", 5)
+            .append("path")
+            .attr("d", function(d) { return symbolPathFor(d.interactionType, 320); })
             .attr("fill", function(d) { return interactionColors[d.interactionType] || unmappedColor; })
             .attr("stroke", function(d) {
                 var c = d3.color(interactionColors[d.interactionType] || unmappedColor);


### PR DESCRIPTION
Closes #270, taking its first option — distinct `d3.symbol()` per interaction type, mirroring the UMAP page's approach.

## The palette is worse than #270 assumed

Measured all-pairs in OKLab (all-pairs is the right test for a network diagram — any two interaction nodes can sit adjacent, unlike ordered series):

| | ΔE |
|---|--:|
| tritanopia, worst pair | **1.8** |
| protanopia, worst pair | **5.1** |
| **normal vision**, Mutualism ↔ Cross-feeding | **10.3** |

That last row is the one that matters. #270 frames this as a colour-vision-deficiency problem; on this measure **full-colour readers** also struggle to separate two of the commonest types. Shape is not a courtesy here — it is what makes those two distinguishable at all.

## Correcting myself

I told you **twice** that a 1:1 shape mapping was impossible because "d3 ships 7 built-in symbols" and `circle` is taken by taxa.

Wrong. That is `d3.symbolsFill`. The **bundled** d3 v7 has **14**: circle, cross, diamond, diamond2, plus, square, square2, star, times, triangle, triangle2, wye, asterisk, x. Thirteen non-circle symbols for nine types — no doubling on fill required. I grepped the vendored bundle this time instead of trusting memory.

## What changed

- Each interaction type draws its own symbol, sized to roughly the 28×18 rect it replaces so the layout is unchanged.
- **The legend swatch carries the shape too**, drawn by the same `d3.symbol()` path the node uses. A coloured square in the legend standing for a diamond in the graph would leave the redundant channel unreadable — and sharing the path function means the two cannot drift apart.
- The SVG `<desc>` no longer tells screen-reader users the interactions are *"colored rectangles"*.

## Scale in practice

Across all 312 rendered pages, the **maximum distinct symbols on any one legend is 4** (`Dangl_SynComm_35`). So the distinguishability question is far easier than the nine-way worst case suggests.

## What is deliberately unchanged

The palette. It still fails the OKLab checks on its own, and #270's alternative — retuning to nine CVD-safe hues — remains closed: the search behind #269 established that no nine-colour set survives all three CVD types. **That is the argument for a second channel rather than a better palette**, which is what this is.

`2375 passed`, `validate-strict` 0 errors, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)