### PR TITLE
Record the bioreactor setup #183 could not reach without full text

### DIFF
--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -210,13 +210,18 @@ cultivation_setup:
   retention_time_unit: HOURS
   retention_time_type: HYDRAULIC
   instrument_detail: >-
-    Five parallel reactors (R1-R5) inoculated from one mixed community and run for 790
-    days, each on a different combination of thiocyanate loading and molasses supply.
+    Five 1-L water-jacketed continuous stirred-tank reactors (R1-R5), stirred at 270 rpm
+    with a pitched-blade impeller and sparged with filtered air at 900 mL/min, inoculated
+    from one mixed community and run for 790 days. What distinguishes them is molasses:
+    amended, unamended, or switched to unamended partway. Thiocyanate loading was ramped
+    in common, not varied between reactors.
   notes: >-
-    Retention time is the 12 h the experiment settled on; it began at 24 h and was lowered
-    later, so one value understates the history. Thiocyanate feed was ramped across the run
-    - 50 mg/L at 24 h, then 250 mg/L at 12 h, up to 2000 mg/L - and is not reduced to a
-    single number because the ramp is the experimental variable, not a setting. Extracted
+    Retention time is the 12 h the experiment was held at for most of its length, not a
+    constant. The reactors ran batch-fed for 4 days, switched to continuous feeding at a
+    48 h residence time, were lowered from 48 to 12 h over the next 131 days, and were
+    then maintained at 12 h - so `cultivation_mode: CONTINUOUS` describes all but the
+    first 4 days. Thiocyanate feed was ramped across the run, 50 to 2000 mg/L, and is not
+    reduced to a single number because that ramp is the experimental variable. Extracted
     from cached open-access full text; this record was among the 42 that #183 treated as
     access-blocked until the full-text sweep reached them.
   evidence:
@@ -229,9 +234,9 @@ cultivation_setup:
   - reference: PMID:33897653
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Residence times of 24 h were maintained early in the experiments but were later
-      lowered to 12 h
-    explanation: The hydraulic retention time, and that it changed mid-run.
+    snippet: The hydraulic retention time (HRT) of the reactors was sequentially lowered from
+      48 to 12 h, over a period of 131 days, and then maintained at 12 h
+    explanation: The recorded 12 h, and the 48 h start it was ramped down from.
 
 environmental_factors:
 - name: Thiocyanate loading

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -203,6 +203,36 @@ ecological_interactions:
     snippet: reactors without molasses did not stably degrade SCN- at high
       loading rates, perhaps due to loss of biofilm-associated niche diversity
     explanation: Supports the curated niche-diversity rationale.
+cultivation_setup:
+- cultivation_mode: CONTINUOUS
+  system_type: STIRRED_TANK_BIOREACTOR
+  retention_time: 12.0
+  retention_time_unit: HOURS
+  retention_time_type: HYDRAULIC
+  instrument_detail: >-
+    Five parallel reactors (R1-R5) inoculated from one mixed community and run for 790
+    days, each on a different combination of thiocyanate loading and molasses supply.
+  notes: >-
+    Retention time is the 12 h the experiment settled on; it began at 24 h and was lowered
+    later, so one value understates the history. Thiocyanate feed was ramped across the run
+    - 50 mg/L at 24 h, then 250 mg/L at 12 h, up to 2000 mg/L - and is not reduced to a
+    single number because the ramp is the experimental variable, not a setting. Extracted
+    from cached open-access full text; this record was among the 42 that #183 treated as
+    access-blocked until the full-text sweep reached them.
+  evidence:
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Five reactors (R1–R5) were inoculated from the same mixed microbial community and
+      were operated continuously for 790 days
+    explanation: Establishes continuous mode, the parallel design and the duration.
+  - reference: PMID:33897653
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Residence times of 24 h were maintained early in the experiments but were later
+      lowered to 12 h
+    explanation: The hydraulic retention time, and that it changed mid-run.
+
 environmental_factors:
 - name: Thiocyanate loading
   value: systematically increased SCN- input concentration


### PR DESCRIPTION
## What

Adds a `cultivation_setup` block to `Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community`, one of the 42 records #183 had classified as blocked on institutional access.

It isn't blocked. PMID:33897653 is open access and the full-text sweep (PR #509) cached it. The abstract says nothing about reactor operation, which is why the record looked unenrichable — the setup is in the methods.

Recorded: five 1-L continuous stirred-tank reactors, 790 days, 12 h hydraulic retention time.

## What is deliberately not a number

- **Retention time** was not constant: batch-fed for 4 days, continuous at 48 h, lowered 48 → 12 h over 131 days, then held at 12 h. The field carries the 12 h it was held at for most of the run; `notes` carries the history, and says explicitly that `CONTINUOUS` describes all but the first 4 days.
- **Thiocyanate loading** was ramped 50 → 2,000 mg/L. That ramp is the experimental variable, not a setting, so it stays in prose rather than being averaged into a value the paper never claims.

## Review found two errors in the prose, both fixed here (#513)

The snippets validated clean from the start; the *summaries beside them* were wrong, which no validator can see:

1. The note said retention time "began at 24 h." It began at 48 h — 24 h is a point on the ramp, and it became "the start" because it was the value in the quoted sentence. That snippet is now replaced by the one stating the ramp, so the evidence supports the claim rather than a reading of it.
2. `instrument_detail` said the five reactors differed in "thiocyanate loading and molasses supply." Loading was ramped in common; **molasses** is the variable — amended, unamended, or switched partway. That is the paper's finding (the *Afipia* variant dominates the molasses-free reactor), so having it backwards undercut the reason this record is curated.

## Checks

- `just validate` — no issues (`cultivation_setup` is multivalued; the block is a list)
- `just validate-references` — 0 issues; both snippets verbatim in the cached full text
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped
- Every added claim (270 rpm, 900 mL/min, water-jacketed, 1-L, 4 days batch-fed, 131 days, 790 days) re-checked verbatim against the cache

Part of #183. Closes #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)