### PR TITLE
Two more cultivation setups, and stop the unit strings diverging (#183)

### DIFF
--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -220,33 +220,49 @@ ecological_interactions:
 cultivation_setup:
 - system_type: STIRRED_TANK_BIOREACTOR
   instrument_detail: >-
-    A stirred-tank bioreactor in which hydrogen is generated in situ by water electrolysis
-    rather than supplied from a cylinder, so the electrode is part of the cultivation
-    apparatus rather than a downstream measurement.
+    The AiO arm. A stirred-tank bioreactor in which hydrogen is generated in situ by water
+    electrolysis rather than supplied from a cylinder, so the electrode is part of the
+    cultivation apparatus rather than instrumentation around it.
   electrode_detail: >-
-    An "All-in-One" electrode performing in situ water electrolysis. The paper attributes
-    the ceiling on the process to this electrode - its cathode surface area, and the fact
-    that there is one of it - rather than to the organisms.
+    An "All-in-One" (AiO) electrode performing in situ water electrolysis. The paper
+    identifies hydrogen limitation in this arm and points at the electrode - cathode
+    surface area, and the fact that there is one of it - rather than at the organisms.
   notes: >-
-    Deliberately incomplete. `cultivation_mode` is not set: the source establishes the
-    vessel and the hydrogen supply but never states batch, fed-batch or continuous, and
-    guessing would put an unevidenced enum value where a curator would read it as read from
-    the paper. Likewise no `applied_potential` - the electrode is described, its operating
-    voltage is not. Recorded from an abstract-only cache entry; if full text is fetched
-    later these are the two fields to revisit.
+    One of two hydrogen-supply arms, and the lower-yielding one: 0.5 g/L lactate here
+    against 8.1 g/L with direct sparging. Recorded as a separate entry rather than merged,
+    because the comparison is the paper's result and a single setup would attribute the
+    coculture's behaviour to whichever arm happened to be written down. `cultivation_mode`
+    and `applied_potential` are left unset - the source names the vessel and the electrode
+    but never the feeding regime or the operating voltage, and an unevidenced enum value
+    reads to the next curator as taken from the paper. Recorded from an abstract-only
+    cache entry; those two fields are what full text would fill.
   evidence:
-  - reference: PMID:36619880
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: woodii mutants and a Clostridium drakei wild-type strain in a stirred-tank bioreactor
-      for the production of caproic acid from CO2 and H2 via the intermediate lactic acid
-    explanation: Names the vessel the coculture was grown in.
   - reference: PMID:36619880
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: Hydrogen for the process was supplied using an All-in-One electrode for in situ
       water electrolysis
     explanation: The electrode is part of the cultivation setup, supplying the H2 substrate.
+  - reference: PMID:36619880
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Hydrogen limitation was identified in the AiO process
+    explanation: Sources the ceiling to hydrogen supply, stated rather than inferred.
+- system_type: STIRRED_TANK_BIOREACTOR
+  instrument_detail: >-
+    The comparison arm. The same stirred-tank bioreactor with hydrogen sparged in directly
+    from a supply rather than generated at an electrode.
+  notes: >-
+    The higher-yielding arm, at 8.1 g/L lactate against 0.5 g/L for the AiO electrode. It
+    carries no `electrode_detail` because it has no electrode; that absence is the
+    difference between the two entries.
+  evidence:
+  - reference: PMID:36619880
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Lactate concentrations as high as 0.5 g L-1 were achieved with the AiO-electrode,
+      whereas 8.1 g L-1 lactate were produced with direct H2 sparging in a stirred-tank bioreactor
+    explanation: Establishes that there were two arms, and which produced more.
 
 environmental_factors:
 - name: Gas substrate

--- a/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
+++ b/kb/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.yaml
@@ -217,6 +217,37 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: Hydrogen limitation was identified in the AiO process
     explanation: Supports hydrogen limitation as a curated environmental or engineering factor.
+cultivation_setup:
+- system_type: STIRRED_TANK_BIOREACTOR
+  instrument_detail: >-
+    A stirred-tank bioreactor in which hydrogen is generated in situ by water electrolysis
+    rather than supplied from a cylinder, so the electrode is part of the cultivation
+    apparatus rather than a downstream measurement.
+  electrode_detail: >-
+    An "All-in-One" electrode performing in situ water electrolysis. The paper attributes
+    the ceiling on the process to this electrode - its cathode surface area, and the fact
+    that there is one of it - rather than to the organisms.
+  notes: >-
+    Deliberately incomplete. `cultivation_mode` is not set: the source establishes the
+    vessel and the hydrogen supply but never states batch, fed-batch or continuous, and
+    guessing would put an unevidenced enum value where a curator would read it as read from
+    the paper. Likewise no `applied_potential` - the electrode is described, its operating
+    voltage is not. Recorded from an abstract-only cache entry; if full text is fetched
+    later these are the two fields to revisit.
+  evidence:
+  - reference: PMID:36619880
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: woodii mutants and a Clostridium drakei wild-type strain in a stirred-tank bioreactor
+      for the production of caproic acid from CO2 and H2 via the intermediate lactic acid
+    explanation: Names the vessel the coculture was grown in.
+  - reference: PMID:36619880
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Hydrogen for the process was supplied using an All-in-One electrode for in situ
+      water electrolysis
+    explanation: The electrode is part of the cultivation setup, supplying the H2 substrate.
+
 environmental_factors:
 - name: Gas substrate
   value: CO2 and H2

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -237,6 +237,36 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: H2 yields on glucose exceeded those of either organism alone
     explanation: Supports increased hydrogen yield from the coculture relative to pure cultures.
+cultivation_setup:
+- cultivation_mode: CONTINUOUS
+  system_type: STIRRED_TANK_BIOREACTOR
+  feed_or_dilution_rate: 0.06
+  feed_or_dilution_rate_unit: 1/h
+  instrument_detail: >-
+    A continuous-flow stirred tank reactor fed glucose and xylose. The run began as a batch
+    start-up phase before continuous operation, and the coculture was held across a range
+    of dilution rates - the recorded 0.06 per hour is the one at which the reported maximum
+    H2 yield was obtained, not the only one used.
+  notes: >-
+    The dilution rate is the experimental variable here, not a fixed setting: species ratio
+    tracked it, with C. saccharolyticus prevailing at higher rates. One value cannot carry
+    that, so the field holds the rate the headline yield is attributed to and this note
+    records that the sweep existed. Recorded from an abstract-only cache entry; the full
+    range, working volume and temperature are in the methods and remain unfetched.
+  evidence:
+  - reference: PMID:21192828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: kristjanssonii DSM 12137 were combined in a co-culture for H2 production from
+      glucose and xylose in a continuous-flow stirred tank reactor
+    explanation: Establishes both the continuous mode and the stirred-tank vessel.
+  - reference: PMID:21192828
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A maximum H2 yield of 3.7 mol (mol glucose)(-1) was obtained by the co-culture
+      at a dilution rate of 0.06 h(-1)
+    explanation: The recorded dilution rate, and what it is the rate for.
+
 environmental_factors:
 - name: Extreme thermophilic cultivation
   value: extreme thermophiles

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -249,7 +249,8 @@ cultivation_setup:
     H2 yield was obtained, not the only one used.
   notes: >-
     The dilution rate is the experimental variable here, not a fixed setting: species ratio
-    tracked it, with C. saccharolyticus prevailing at higher rates. One value cannot carry
+    tracked it, with C. kristjanssonii outgrowing C. saccharolyticus in the batch start-up
+    phase and prevailing at higher rates. One value cannot carry
     that, so the field holds the rate the headline yield is attributed to and this note
     records that the sweep existed. Recorded from an abstract-only cache entry; the full
     range, working volume and temperature are in the methods and remain unfetched.

--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -207,7 +207,7 @@ cultivation_setup:
 - cultivation_mode: CONTINUOUS
   system_type: STIRRED_TANK_BIOREACTOR
   retention_time: 12.0
-  retention_time_unit: HOURS
+  retention_time_unit: h
   retention_time_type: HYDRAULIC
   instrument_detail: >-
     Five 1-L water-jacketed continuous stirred-tank reactors (R1-R5), stirred at 270 rpm


### PR DESCRIPTION
## What

Two more records from #183's growth-conditions gap, both curated from cached sources.

**`Acetobacterium_Clostridium_CO2_Electrolysis_Coculture`** — now **two** `cultivation_setup` entries, because the paper ran two hydrogen-supply arms in the same stirred-tank system: an "All-in-One" electrode doing in-situ water electrolysis (0.5 g/L lactate), and direct H2 sparging (8.1 g/L). The absence of `electrode_detail` on the second entry is the difference between them.

**`Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture`** — a continuous-flow stirred tank reactor at 0.06/h.

## What is deliberately left empty

- No `cultivation_mode` or `applied_potential` on the electrolysis record. The source names the vessel and the electrode; it never states the feeding regime or the operating voltage. An unevidenced enum value is worse than an absent one — it reads as taken from the paper.
- The Caldicellulosiruptor dilution rate is the **experimental variable**, not a setting: *C. kristjanssonii* outgrows *C. saccharolyticus* in start-up and prevails at higher rates. The field holds the rate the headline yield is attributed to; the note records that a sweep existed.

Both were curated from abstract-only caches, stated in the notes with the fields full text would fill.

## Review found two prose errors, fixed here (#516)

All snippets validated clean from the first commit. The sentences beside them did not:

1. **The electrolysis record described one setup where there were two.** It carried only the electrode arm — the one that yielded 16× less. `cultivation_setup` is multivalued, so both are now represented; collapsing them lost the comparison that is the paper's actual result. The ceiling claim is also re-sourced: "Hydrogen limitation was identified in the AiO process" is stated outright, replacing my inference from a sentence about enlarging cathode area.
2. **The Caldicellulosiruptor note named the wrong species** as prevailing at higher dilution rates. I read the second-named organism as the subject of the sentence.

## The unit strings (#514)

I wrote `retention_time_unit: HOURS` and `feed_or_dilution_rate_unit: PER_HOUR` — enum-shaped, because `cultivation_mode` and `system_type` beside them *are* enums. The corpus used symbols: `h`, `d`, `L/day`, `mL`, `L`. Nothing failed: all five `*_unit` slots have no range, so `linkml-validate` accepts either. Found only by grepping what other records had written.

Normalized to symbols here, including the `HOURS` merged in #512, so all populated unit slots agree. That is a snapshot, not a fix — #514 files the options.

## Checks

- `just validate` on both records — no issues
- `just validate-references` on both — 0 issues; all five snippets verbatim
- `just validate-strict`, `just lint` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped
- Second review pass: every number in prose (0.5 g/L, 8.1 g/L, 0.06/h) and both species names re-checked against the cached source

Part of #183. Found #514, closes #516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)