### PR TITLE
Constrain the CultivationSetup unit slots, and make a new enum declare itself (#514, #518)

### DIFF
--- a/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
+++ b/kb/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.yaml
@@ -208,7 +208,7 @@ cultivation_setup:
   system_type: STIRRED_TANK_BIOREACTOR
   retention_time: 12.0
   retention_time_unit: h
-  retention_time_type: HYDRAULIC
+  retention_time_type: HRT
   instrument_detail: >-
     Five 1-L water-jacketed continuous stirred-tank reactors (R1-R5), stirred at 270 rpm
     with a pitched-blade impeller and sparged with filtered air at 900 mL/min, inoculated

--- a/src/communitymech/datamodel/communitymech.py
+++ b/src/communitymech/datamodel/communitymech.py
@@ -1,5 +1,5 @@
 # Auto generated from communitymech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-08T01:28:55
+# Generation date: 2026-08-10T15:01:31
 # Schema: communitymech
 #
 # id: https://w3id.org/communitymech
@@ -1297,16 +1297,16 @@ class CultivationSetup(YAMLRoot):
     instrument_detail: Optional[str] = None
     manufacturer_model: Optional[str] = None
     working_volume: Optional[float] = None
-    working_volume_unit: Optional[str] = None
+    working_volume_unit: Optional[Union[str, "VolumeUnitEnum"]] = None
     operating_temperature: Optional[float] = None
-    operating_temperature_unit: Optional[str] = None
+    operating_temperature_unit: Optional[Union[str, "TemperatureUnitEnum"]] = None
     feed_or_dilution_rate: Optional[float] = None
-    feed_or_dilution_rate_unit: Optional[str] = None
+    feed_or_dilution_rate_unit: Optional[Union[str, "RateUnitEnum"]] = None
     retention_time: Optional[float] = None
-    retention_time_unit: Optional[str] = None
-    retention_time_type: Optional[str] = None
+    retention_time_unit: Optional[Union[str, "TimeUnitEnum"]] = None
+    retention_time_type: Optional[Union[str, "RetentionTimeTypeEnum"]] = None
     applied_potential: Optional[float] = None
-    applied_potential_unit: Optional[str] = None
+    applied_potential_unit: Optional[Union[str, "PotentialUnitEnum"]] = None
     electrode_detail: Optional[str] = None
     ph_controlled: Optional[Union[bool, Bool]] = None
     do_controlled: Optional[Union[bool, Bool]] = None
@@ -1336,8 +1336,10 @@ class CultivationSetup(YAMLRoot):
         if self.working_volume is not None and not isinstance(self.working_volume, float):
             self.working_volume = float(self.working_volume)
 
-        if self.working_volume_unit is not None and not isinstance(self.working_volume_unit, str):
-            self.working_volume_unit = str(self.working_volume_unit)
+        if self.working_volume_unit is not None and not isinstance(
+            self.working_volume_unit, VolumeUnitEnum
+        ):
+            self.working_volume_unit = VolumeUnitEnum(self.working_volume_unit)
 
         if self.operating_temperature is not None and not isinstance(
             self.operating_temperature, float
@@ -1345,9 +1347,9 @@ class CultivationSetup(YAMLRoot):
             self.operating_temperature = float(self.operating_temperature)
 
         if self.operating_temperature_unit is not None and not isinstance(
-            self.operating_temperature_unit, str
+            self.operating_temperature_unit, TemperatureUnitEnum
         ):
-            self.operating_temperature_unit = str(self.operating_temperature_unit)
+            self.operating_temperature_unit = TemperatureUnitEnum(self.operating_temperature_unit)
 
         if self.feed_or_dilution_rate is not None and not isinstance(
             self.feed_or_dilution_rate, float
@@ -1355,26 +1357,30 @@ class CultivationSetup(YAMLRoot):
             self.feed_or_dilution_rate = float(self.feed_or_dilution_rate)
 
         if self.feed_or_dilution_rate_unit is not None and not isinstance(
-            self.feed_or_dilution_rate_unit, str
+            self.feed_or_dilution_rate_unit, RateUnitEnum
         ):
-            self.feed_or_dilution_rate_unit = str(self.feed_or_dilution_rate_unit)
+            self.feed_or_dilution_rate_unit = RateUnitEnum(self.feed_or_dilution_rate_unit)
 
         if self.retention_time is not None and not isinstance(self.retention_time, float):
             self.retention_time = float(self.retention_time)
 
-        if self.retention_time_unit is not None and not isinstance(self.retention_time_unit, str):
-            self.retention_time_unit = str(self.retention_time_unit)
+        if self.retention_time_unit is not None and not isinstance(
+            self.retention_time_unit, TimeUnitEnum
+        ):
+            self.retention_time_unit = TimeUnitEnum(self.retention_time_unit)
 
-        if self.retention_time_type is not None and not isinstance(self.retention_time_type, str):
-            self.retention_time_type = str(self.retention_time_type)
+        if self.retention_time_type is not None and not isinstance(
+            self.retention_time_type, RetentionTimeTypeEnum
+        ):
+            self.retention_time_type = RetentionTimeTypeEnum(self.retention_time_type)
 
         if self.applied_potential is not None and not isinstance(self.applied_potential, float):
             self.applied_potential = float(self.applied_potential)
 
         if self.applied_potential_unit is not None and not isinstance(
-            self.applied_potential_unit, str
+            self.applied_potential_unit, PotentialUnitEnum
         ):
-            self.applied_potential_unit = str(self.applied_potential_unit)
+            self.applied_potential_unit = PotentialUnitEnum(self.applied_potential_unit)
 
         if self.electrode_detail is not None and not isinstance(self.electrode_detail, str):
             self.electrode_detail = str(self.electrode_detail)
@@ -2137,6 +2143,120 @@ class Dataset(YAMLRoot):
 
 
 # Enumerations
+class TimeUnitEnum(EnumDefinitionImpl):
+    """
+    Unit for a duration slot such as `retention_time`. Symbols, matching how the corpus already writes them (#514).
+    """
+
+    h = PermissibleValue(text="h", description="Hours.")
+    d = PermissibleValue(text="d", description="Days.")
+    min = PermissibleValue(text="min", description="Minutes.")
+
+    _defn = EnumDefinition(
+        name="TimeUnitEnum",
+        description="""Unit for a duration slot such as `retention_time`. Symbols, matching how the corpus already writes them (#514).""",
+    )
+
+
+class VolumeUnitEnum(EnumDefinitionImpl):
+    """
+    Unit for a volume slot such as `working_volume` (#514).
+    """
+
+    L = PermissibleValue(text="L", description="Litres.")
+    mL = PermissibleValue(text="mL", description="Millilitres.")
+    uL = PermissibleValue(
+        text="uL",
+        description="Microlitres. Spelled `uL` rather than with a mu, so the value is typeable.",
+    )
+
+    _defn = EnumDefinition(
+        name="VolumeUnitEnum",
+        description="Unit for a volume slot such as `working_volume` (#514).",
+    )
+
+
+class RateUnitEnum(EnumDefinitionImpl):
+    """
+    Unit for `feed_or_dilution_rate`. Two shapes are legitimate here: a dilution rate is a reciprocal time, a feed
+    rate is a volume per time, and the slot carries both (#514).
+    """
+
+    _defn = EnumDefinition(
+        name="RateUnitEnum",
+        description="""Unit for `feed_or_dilution_rate`. Two shapes are legitimate here: a dilution rate is a reciprocal time, a feed rate is a volume per time, and the slot carries both (#514).""",
+    )
+
+    @classmethod
+    def _addvals(cls):
+        setattr(cls, "1/h", PermissibleValue(text="1/h", description="Per hour - a dilution rate."))
+        setattr(cls, "1/d", PermissibleValue(text="1/d", description="Per day - a dilution rate."))
+        setattr(
+            cls,
+            "L/day",
+            PermissibleValue(text="L/day", description="Litres per day - a feed rate."),
+        )
+        setattr(
+            cls,
+            "mL/min",
+            PermissibleValue(text="mL/min", description="Millilitres per minute - a feed rate."),
+        )
+
+
+class PotentialUnitEnum(EnumDefinitionImpl):
+    """
+    Unit for `applied_potential`. The unit only: the reference electrode a potential is quoted against ("vs SHE", "vs
+    Ag/AgCl") is not a unit and belongs in `electrode_detail`, where it can be stated in full (#514).
+    """
+
+    V = PermissibleValue(text="V", description="Volts.")
+    mV = PermissibleValue(text="mV", description="Millivolts.")
+
+    _defn = EnumDefinition(
+        name="PotentialUnitEnum",
+        description="""Unit for `applied_potential`. The unit only: the reference electrode a potential is quoted against (\"vs SHE\", \"vs Ag/AgCl\") is not a unit and belongs in `electrode_detail`, where it can be stated in full (#514).""",
+    )
+
+
+class RetentionTimeTypeEnum(EnumDefinitionImpl):
+    """
+    Which retention time `retention_time` reports. Not a unit, but the same drift: the slot description has always
+    said "HRT" or "SRT", and a record still arrived saying HYDRAULIC because nothing checked (#514).
+    """
+
+    HRT = PermissibleValue(
+        text="HRT",
+        description="Hydraulic retention time - how long the liquid phase stays in the system.",
+    )
+    SRT = PermissibleValue(
+        text="SRT",
+        description="""Solids retention time - how long biomass stays, which decouples from HRT whenever cells are retained.""",
+    )
+
+    _defn = EnumDefinition(
+        name="RetentionTimeTypeEnum",
+        description="""Which retention time `retention_time` reports. Not a unit, but the same drift: the slot description has always said \"HRT\" or \"SRT\", and a record still arrived saying HYDRAULIC because nothing checked (#514).""",
+    )
+
+
+class TemperatureUnitEnum(EnumDefinitionImpl):
+    """
+    Unit for `operating_temperature`. Symbols, matching how the corpus already writes them, rather than SCREAMING_CASE
+    names (#514).
+    """
+
+    K = PermissibleValue(text="K", description="Kelvin.")
+
+    _defn = EnumDefinition(
+        name="TemperatureUnitEnum",
+        description="""Unit for `operating_temperature`. Symbols, matching how the corpus already writes them, rather than SCREAMING_CASE names (#514).""",
+    )
+
+    @classmethod
+    def _addvals(cls):
+        setattr(cls, "°C", PermissibleValue(text="°C", description="Degrees Celsius."))
+
+
 class EvidenceItemSupportEnum(EnumDefinitionImpl):
     """
     How the cited reference relates to the curated claim. Distinct from the validity of the claim itself: REFUTE means
@@ -4573,7 +4693,7 @@ slots.cultivationSetup__working_volume_unit = Slot(
     curie=COMMUNITYMECH.curie("working_volume_unit"),
     model_uri=COMMUNITYMECH.cultivationSetup__working_volume_unit,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[str, "VolumeUnitEnum"]],
 )
 
 slots.cultivationSetup__operating_temperature = Slot(
@@ -4591,7 +4711,7 @@ slots.cultivationSetup__operating_temperature_unit = Slot(
     curie=COMMUNITYMECH.curie("operating_temperature_unit"),
     model_uri=COMMUNITYMECH.cultivationSetup__operating_temperature_unit,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[str, "TemperatureUnitEnum"]],
 )
 
 slots.cultivationSetup__feed_or_dilution_rate = Slot(
@@ -4609,7 +4729,7 @@ slots.cultivationSetup__feed_or_dilution_rate_unit = Slot(
     curie=COMMUNITYMECH.curie("feed_or_dilution_rate_unit"),
     model_uri=COMMUNITYMECH.cultivationSetup__feed_or_dilution_rate_unit,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[str, "RateUnitEnum"]],
 )
 
 slots.cultivationSetup__retention_time = Slot(
@@ -4627,7 +4747,7 @@ slots.cultivationSetup__retention_time_unit = Slot(
     curie=COMMUNITYMECH.curie("retention_time_unit"),
     model_uri=COMMUNITYMECH.cultivationSetup__retention_time_unit,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[str, "TimeUnitEnum"]],
 )
 
 slots.cultivationSetup__retention_time_type = Slot(
@@ -4636,7 +4756,7 @@ slots.cultivationSetup__retention_time_type = Slot(
     curie=COMMUNITYMECH.curie("retention_time_type"),
     model_uri=COMMUNITYMECH.cultivationSetup__retention_time_type,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[str, "RetentionTimeTypeEnum"]],
 )
 
 slots.cultivationSetup__applied_potential = Slot(
@@ -4654,7 +4774,7 @@ slots.cultivationSetup__applied_potential_unit = Slot(
     curie=COMMUNITYMECH.curie("applied_potential_unit"),
     model_uri=COMMUNITYMECH.cultivationSetup__applied_potential_unit,
     domain=None,
-    range=Optional[str],
+    range=Optional[Union[str, "PotentialUnitEnum"]],
 )
 
 slots.cultivationSetup__electrode_detail = Slot(

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -36,6 +36,70 @@ types:
     uri: xsd:string
 
 enums:
+  TimeUnitEnum:
+    description: >-
+      Unit for a duration slot such as `retention_time`. Symbols, matching how the corpus
+      already writes them (#514).
+    permissible_values:
+      h:
+        description: Hours.
+      d:
+        description: Days.
+      min:
+        description: Minutes.
+  VolumeUnitEnum:
+    description: Unit for a volume slot such as `working_volume` (#514).
+    permissible_values:
+      L:
+        description: Litres.
+      mL:
+        description: Millilitres.
+      uL:
+        description: Microlitres. Spelled `uL` rather than with a mu, so the value is typeable.
+  RateUnitEnum:
+    description: >-
+      Unit for `feed_or_dilution_rate`. Two shapes are legitimate here: a dilution rate is
+      a reciprocal time, a feed rate is a volume per time, and the slot carries both (#514).
+    permissible_values:
+      1/h:
+        description: Per hour - a dilution rate.
+      1/d:
+        description: Per day - a dilution rate.
+      L/day:
+        description: Litres per day - a feed rate.
+      mL/min:
+        description: Millilitres per minute - a feed rate.
+  PotentialUnitEnum:
+    description: >-
+      Unit for `applied_potential`. The unit only: the reference electrode a potential is
+      quoted against ("vs SHE", "vs Ag/AgCl") is not a unit and belongs in
+      `electrode_detail`, where it can be stated in full (#514).
+    permissible_values:
+      V:
+        description: Volts.
+      mV:
+        description: Millivolts.
+  RetentionTimeTypeEnum:
+    description: >-
+      Which retention time `retention_time` reports. Not a unit, but the same drift: the
+      slot description has always said "HRT" or "SRT", and a record still arrived saying
+      HYDRAULIC because nothing checked (#514).
+    permissible_values:
+      HRT:
+        description: Hydraulic retention time - how long the liquid phase stays in the system.
+      SRT:
+        description: >-
+          Solids retention time - how long biomass stays, which decouples from HRT whenever
+          cells are retained.
+  TemperatureUnitEnum:
+    description: >-
+      Unit for `operating_temperature`. Symbols, matching how the corpus already writes
+      them, rather than SCREAMING_CASE names (#514).
+    permissible_values:
+      "°C":
+        description: Degrees Celsius.
+      K:
+        description: Kelvin.
   EvidenceItemSupportEnum:
     description: >-
       How the cited reference relates to the curated claim. Distinct from the
@@ -1547,11 +1611,13 @@ classes:
         range: float
       working_volume_unit:
         description: Unit for working_volume (e.g. mL, L).
+        range: VolumeUnitEnum
       operating_temperature:
         description: Operating/setpoint temperature of the cultivation system.
         range: float
       operating_temperature_unit:
         description: Unit for operating_temperature (e.g. C, K).
+        range: TemperatureUnitEnum
       feed_or_dilution_rate:
         description: >-
           Feed rate (fed-batch) or dilution rate (continuous/chemostat); disambiguated
@@ -1559,18 +1625,24 @@ classes:
         range: float
       feed_or_dilution_rate_unit:
         description: Unit for feed_or_dilution_rate (e.g. h^-1, mL/h).
+        range: RateUnitEnum
       retention_time:
         description: Hydraulic or solids retention time (see retention_time_type).
         range: float
       retention_time_unit:
         description: Unit for retention_time (e.g. h, d).
+        range: TimeUnitEnum
       retention_time_type:
         description: Which retention time is reported (e.g. "HRT" or "SRT").
+        range: RetentionTimeTypeEnum
       applied_potential:
         description: Applied electrode potential (bioelectrochemical / fuel-cell systems).
         range: float
       applied_potential_unit:
-        description: Unit/reference for applied_potential (e.g. "mV vs SHE", V).
+        description: >-
+          Unit for applied_potential. The unit only - the reference electrode a potential is
+          quoted against goes in electrode_detail (#514).
+        range: PotentialUnitEnum
       electrode_detail:
         description: >-
           Electrode configuration/materials for bioelectrochemical systems

--- a/tests/test_cultivation_units_are_constrained.py
+++ b/tests/test_cultivation_units_are_constrained.py
@@ -1,0 +1,174 @@
+"""The `CultivationSetup` unit slots are enums now, not free text (#514).
+
+Six slots on `CultivationSetup` carry a unit or a kind — `working_volume_unit`,
+`operating_temperature_unit`, `feed_or_dilution_rate_unit`,
+`retention_time_unit`, `applied_potential_unit`, `retention_time_type` — and
+every one of them had **no range**, so `linkml-validate` accepted any string.
+
+That is not hypothetical drift. Adding two records to the #183 sweep I wrote
+`retention_time_unit: HOURS` and `feed_or_dilution_rate_unit: PER_HOUR`,
+enum-shaped because `cultivation_mode` and `system_type` sit right beside them
+and *are* enums. The corpus had been writing symbols: `h`, `d`, `L/day`, `mL`.
+Nothing failed. I found it by grepping what other records had used.
+
+`retention_time_type` is the sharper case, because there the convention was
+never ambiguous — the slot description has said `"HRT" or "SRT"` since it was
+written, and a record still arrived saying `HYDRAULIC`. A description is not a
+constraint. Setting the range caught it on the first `just validate-all`.
+
+Why symbols rather than SCREAMING_CASE, given the neighbouring enums: a unit is
+not a category. `°C` and `1/h` are the notation every source and every reader
+already uses, and a slot that says `PER_HOUR` has to be translated back before
+it means anything. The cost is that permissible values here are not valid Python
+identifiers — LinkML emits them through `_addvals`/`setattr` rather than as
+class attributes, which is why `test_the_generated_datamodel_carries_them`
+below checks the runtime enum rather than `dir()`.
+
+What this file defends is that the ranges stay attached. Deleting a `range:`
+line is a one-character-looking edit that silently reopens free text, and no
+existing test would notice — the corpus would still validate, because every
+value in it is already legal.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
+COMMUNITIES = REPO / "kb/communities"
+
+# slot -> the enum it must be ranged to.
+CONSTRAINED = {
+    "working_volume_unit": "VolumeUnitEnum",
+    "operating_temperature_unit": "TemperatureUnitEnum",
+    "feed_or_dilution_rate_unit": "RateUnitEnum",
+    "retention_time_unit": "TimeUnitEnum",
+    "applied_potential_unit": "PotentialUnitEnum",
+    "retention_time_type": "RetentionTimeTypeEnum",
+}
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(("slot", "enum_name"), sorted(CONSTRAINED.items()))
+def test_the_slot_is_ranged_to_its_enum(schema, slot: str, enum_name: str):
+    """The whole point: a missing `range` is free text again, silently."""
+    attributes = schema["classes"]["CultivationSetup"]["attributes"]
+    assert slot in attributes, f"{slot} is gone from CultivationSetup"
+    assert attributes[slot].get("range") == enum_name, (
+        f"`{slot}` is no longer ranged to {enum_name}. Without a range the slot "
+        f"accepts any string, which is how `HOURS`, `PER_HOUR` and `HYDRAULIC` "
+        f"got in (#514). If the enum was genuinely too narrow, widen the enum "
+        f"rather than dropping the range."
+    )
+
+
+def test_every_value_in_the_corpus_is_permissible(schema):
+    """Guard the other way: the enums must cover what curation actually writes.
+
+    If this fails the fix is usually to add a permissible value, not to relax
+    the slot — but it should fail loudly either way rather than have someone
+    reach for `range:` deletion.
+    """
+    enums = schema["enums"]
+    offenders = []
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        for entry in (yaml.safe_load(path.read_text()) or {}).get("cultivation_setup") or []:
+            for slot, enum_name in CONSTRAINED.items():
+                value = entry.get(slot)
+                if value is None:
+                    continue
+                if value not in enums[enum_name]["permissible_values"]:
+                    offenders.append(f"{path.name}: {slot}={value!r} not in {enum_name}")
+    assert offenders == [], "\n".join(offenders)
+
+
+def test_the_corpus_actually_uses_these_slots():
+    """Guard: at zero populated slots the test above passes on nothing."""
+    populated = sum(
+        1
+        for path in COMMUNITIES.glob("*.yaml")
+        for entry in (yaml.safe_load(path.read_text()) or {}).get("cultivation_setup") or []
+        for slot in CONSTRAINED
+        if entry.get(slot) is not None
+    )
+    assert populated >= 10, (
+        f"only {populated} constrained unit slots are populated across the "
+        f"corpus; the coverage test above is close to vacuous"
+    )
+
+
+def test_the_generated_datamodel_carries_them():
+    """`°C` and `1/h` are not Python identifiers, so check the runtime enum.
+
+    LinkML emits them via a `_addvals` classmethod using `setattr`, not as
+    class attributes — `dir()` and a static import both miss them, which is
+    exactly the sort of check that would pass while the value was absent.
+    """
+    from communitymech.datamodel.communitymech import RateUnitEnum, TemperatureUnitEnum
+
+    assert getattr(TemperatureUnitEnum, "°C", None) is not None
+    assert getattr(RateUnitEnum, "1/h", None) is not None
+
+
+def test_a_wrong_unit_is_actually_rejected(tmp_path):
+    """Mutation check, run against the real validator.
+
+    Every test above reads the schema and would pass if `linkml-validate`
+    ignored these ranges entirely. This one asserts the gate bites: it takes a
+    real record, writes the exact string this issue was filed about, and
+    requires a non-zero exit.
+    """
+    source = next(
+        p
+        for p in sorted(COMMUNITIES.glob("*.yaml"))
+        if "operating_temperature_unit: °C" in p.read_text()
+    )
+    broken = tmp_path / "broken.yaml"
+    broken.write_text(
+        source.read_text().replace(
+            "operating_temperature_unit: °C", "operating_temperature_unit: CELSIUS", 1
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["uv", "run", "linkml-validate", "-s", str(SCHEMA), str(broken)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+        timeout=900,
+    )
+    assert result.returncode != 0, (
+        "`operating_temperature_unit: CELSIUS` validated clean, so the enum "
+        "range is not being enforced and #514 is open again"
+    )
+    assert "CELSIUS" in result.stdout + result.stderr
+
+
+def test_the_reference_electrode_is_not_smuggled_into_the_unit(schema):
+    """`applied_potential_unit` is a unit; "vs SHE" is not part of one.
+
+    The slot description used to offer `"mV vs SHE"` as an example, which makes
+    the value a unit *and* a reference electrode at once — unjoinable across
+    records, and unconvertible. The enum is {V, mV}; the reference belongs in
+    `electrode_detail`. Asserted positively, on the description saying where it
+    goes, because a check that "SHE" is absent would also pass on a description
+    rewritten to say nothing at all.
+    """
+    attributes = schema["classes"]["CultivationSetup"]["attributes"]
+    values = schema["enums"]["PotentialUnitEnum"]["permissible_values"]
+    assert set(values) == {"V", "mV"}
+    described = schema["enums"]["PotentialUnitEnum"]["description"]
+    assert "electrode_detail" in described, (
+        "PotentialUnitEnum no longer says where the reference electrode goes, "
+        "so the next curator will put it back in the unit (#514)"
+    )
+    assert "applied_potential_unit" in attributes

--- a/tests/test_cultivation_vocab_sync.py
+++ b/tests/test_cultivation_vocab_sync.py
@@ -16,6 +16,47 @@ VOCAB = Path("vocab/cultivation_terms.yaml")
 ENUMS = ("CultivationModeEnum", "CultivationSystemEnum")
 VALID_STATUS = {"proposed", "mapped", "minted"}
 
+# Every other enum in the schema, with why it is not staged for METPO. The point
+# is not the exemption but that one has to be written: `ENUMS` above is a
+# hardcoded tuple, so before #518 a new enum simply fell outside the invariant
+# `vocab/cultivation_terms.yaml` claims in its own header, and nothing went red.
+# Same shape as #471 — a constant whose value was pinned but whose completeness
+# was not.
+_NOT_STAGED_FOR_METPO = {
+    "CommunityOriginEnum": "structural metadata about the record, not a lab term",
+    "CommunityCategoryEnum": "structural metadata about the record, not a lab term",
+    # Units (#514). If these map anywhere it is UO or UCUM, not METPO.
+    "TimeUnitEnum": "a unit",
+    "VolumeUnitEnum": "a unit",
+    "RateUnitEnum": "a unit",
+    "TemperatureUnitEnum": "a unit",
+    "PotentialUnitEnum": "a unit",
+    "RetentionTimeTypeEnum": "which retention time is reported; a modelling kind, not a term",
+    # Already grounded in an ontology, so there is nothing to propose: every
+    # permissible value carries a `meaning:` CURIE (17 and 16 respectively).
+    "MetalElementEnum": "fully mapped in-schema via meaning: CURIEs",
+    "RareEarthElementEnum": "fully mapped in-schema via meaning: CURIEs",
+    # Curation bookkeeping — how this repo records a claim, not what was
+    # observed at a bench. METPO would have nothing to say about them.
+    "EvidenceItemSupportEnum": "how a reference relates to a claim; curation bookkeeping",
+    "EvidenceSourceEnum": "where a claim came from; curation bookkeeping",
+    "ExternalResourceRepositoryEnum": "which repository a link points at; bookkeeping",
+    "GtdbGroundingStatusEnum": "state of this repo's grounding workflow; bookkeeping",
+    "ComputationalPredictionTypeEnum": "how a model produced a value; provenance, not a lab term",
+    "CultureCollectionEnum": "strain-repository names (DSM, ATCC, ...); registry identifiers",
+    "MetalRelevanceEnum": "whether metals matter to a record; a curation judgement",
+    "AbundanceEnum": "qualitative abundance banding; a modelling convention here",
+    "InteractionScopeEnum": "pairwise vs community-level; a graph-modelling distinction",
+    # Genuine ontology candidates that are simply not staged yet. Named here
+    # rather than silently omitted: the exemption is "not done", not "not
+    # applicable", and #518 exists so that difference stays visible.
+    "FunctionalRoleEnum": "candidate, not yet staged; see #301 for values it is missing",
+    "InteractionTypeEnum": "candidate, not yet staged; overlaps the #270/#307 modelling questions",
+    "AtmosphereEnum": "candidate, not yet staged; plausibly ENVO/METPO",
+    "MediaRelationshipEnum": "candidate, not yet staged; adjacent to the growth-media work in #183",
+    "EcologicalStateEnum": "candidate, not yet staged; plausibly ENVO",
+}
+
 
 def _schema():
     return yaml.safe_load(Path(SCHEMA).read_text())
@@ -108,3 +149,37 @@ def test_cultivation_setup_validates(tmp_path):
         text=True,
     )
     assert res.returncode == 0, f"cultivation_setup smoke test failed:\n{res.stdout}\n{res.stderr}"
+
+
+def test_every_enum_is_either_staged_or_explicitly_exempt():
+    """A new enum must be classified when it is added, not in a later audit (#518).
+
+    `ENUMS` is a hardcoded tuple, so the invariant the vocab file states in its
+    header only ever applied to the two names typed into it. #517 added six
+    enums at once and none of them went red — correctly, since they are units,
+    but the repo could not tell "deliberately exempt" from "nobody noticed".
+
+    Listing every schema enum here forces the author of the next one to say
+    which it is. The exemption reasons are required to be non-empty so the
+    dictionary cannot become a silent allow-list.
+    """
+    schema_enums = set(_schema()["enums"])
+    classified = set(ENUMS) | set(_NOT_STAGED_FOR_METPO)
+
+    unclassified = sorted(schema_enums - classified)
+    assert unclassified == [], (
+        "these enums are neither staged in vocab/cultivation_terms.yaml (add "
+        "them to ENUMS) nor exempted (add them to _NOT_STAGED_FOR_METPO with a "
+        "reason):\n" + "\n".join(f"  {name}" for name in unclassified)
+    )
+
+    stale = sorted(classified - schema_enums)
+    assert (
+        stale == []
+    ), "these are classified here but no longer exist in the schema:\n" + "\n".join(
+        f"  {name}" for name in stale
+    )
+
+    assert not (set(ENUMS) & set(_NOT_STAGED_FOR_METPO)), "an enum cannot be both"
+    blank = sorted(name for name, why in _NOT_STAGED_FOR_METPO.items() if not (why or "").strip())
+    assert blank == [], f"exemptions need a reason: {blank}"

--- a/tests/test_cultivation_vocab_sync.py
+++ b/tests/test_cultivation_vocab_sync.py
@@ -76,7 +76,7 @@ def test_cultivation_setup_validates(tmp_path):
                 "working_volume": 1.5,
                 "working_volume_unit": "L",
                 "feed_or_dilution_rate": 0.1,
-                "feed_or_dilution_rate_unit": "h^-1",
+                "feed_or_dilution_rate_unit": "1/h",
                 "ph_controlled": True,
                 "do_controlled": True,
             },
@@ -84,8 +84,10 @@ def test_cultivation_setup_validates(tmp_path):
                 "cultivation_mode": "BATCH",
                 "system_type": "MICROBIAL_FUEL_CELL",
                 "applied_potential": 200.0,
-                "applied_potential_unit": "mV vs SHE",
-                "electrode_detail": "carbon-cloth anode",
+                "applied_potential_unit": "mV",
+                # The reference electrode is not part of the unit: it moved into
+                # `electrode_detail` when these slots became enums (#514).
+                "electrode_detail": "carbon-cloth anode, potential quoted vs SHE",
             },
         ],
     }


### PR DESCRIPTION
Stacked on #515 (base `enrich-cultivation-183g`), because it corrects a value that PR introduces. Review #515 first.

## What (#514)

Six `CultivationSetup` slots carry a unit or a kind — `working_volume_unit`, `operating_temperature_unit`, `feed_or_dilution_rate_unit`, `retention_time_unit`, `applied_potential_unit`, `retention_time_type` — and **none had a range**, so `linkml-validate` accepted any string. Six enums now constrain them.

**Symbols, not SCREAMING_CASE.** A unit is not a category. `°C` and `1/h` are what every source and reader already writes, and the corpus was already using symbols (`h`, `d`, `L/day`, `mL`, `mV`). A slot that says `PER_HOUR` has to be translated back before it means anything.

The cost: these aren't valid Python identifiers. LinkML emits them via an `_addvals`/`setattr` classmethod rather than as class attributes, so `dir()`, a static import, and `_defn.permissible_values` all miss them. I checked this before building the rest — my first runtime assertion reported `°C` as absent when it was present. The test now queries the runtime enum the way that actually works.

### What the gate caught on its first run

- **`retention_time_type: HYDRAULIC`** — mine, from #512, against a slot whose description has said `"HRT" or "SRT"` since it was written. A description is not a constraint. Now `HRT`.
- **`h^-1`** in the repo's own smoke-test fixture — a *third* spelling of per-hour, alongside `1/h` and the `PER_HOUR` I wrote in #515. Now `1/h`.

### ⚠️ One deliberate narrowing — a decision, not a fix

`applied_potential_unit` was documented as taking `"mV vs SHE"`, and the smoke test pinned that shape. That makes one value both a unit *and* a reference electrode: not joinable across records, not convertible, and not a unit.

**The enum is `{V, mV}`; the reference electrode moves to `electrode_detail`**, where it can be stated in full rather than compressed into a suffix. No curated record used the old shape, so nothing real is lost — but this removes something the schema allowed and a test asserted. Reversible by adding `mV vs SHE`/`V vs SHE` as permissible values if you'd rather keep it.

## What review then found (#518)

`vocab/cultivation_terms.yaml` states an invariant in its own header — vocab keys must equal enum permissible values — and enforcement was:

```python
ENUMS = ("CultivationModeEnum", "CultivationSystemEnum")
```

A hardcoded tuple with no completeness check. **Adding six enums here is the case that exposed it: none of them went red.** That's the right outcome — units belong to UO/UCUM, not METPO — but the repo could not distinguish "deliberately exempt" from "nobody noticed". Same shape as #471, where nine tests stayed green because they pinned a constant's value and never its use.

Every one of the schema's 26 enums is now either staged or exempt **with a written reason**. The five that are genuine ontology candidates (`FunctionalRoleEnum`, `InteractionTypeEnum`, `AtmosphereEnum`, `MediaRelationshipEnum`, `EcologicalStateEnum`) say *"candidate, not yet staged"* rather than being lumped in with bookkeeping — the exemption is "not done", not "not applicable". Reasons are asserted non-empty so the dictionary can't decay into an allow-list.

## Checks

- `just validate-all` — exit 0 across the corpus
- `just lint`, `just validate-strict` — exit 0
- `uv run pytest tests/` — 2387 passed, 16 skipped
- **Mutation-checked twice.** Removing the six `range:` lines turns 7 of 11 new tests red, including `test_a_wrong_unit_is_actually_rejected`, which shells out to the real validator and requires a non-zero exit on `operating_temperature_unit: CELSIUS`. Adding a `FakeNewEnum` to the schema turns the #518 guard red. Both verified by reverting, running, and restoring.

Closes #514, closes #518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)