### PR TITLE
Quote the SPRUCE abstract instead of paraphrasing it (#347)

### DIFF
--- a/docs/communities/SPRUCE_Peatland_Warming_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Warming_Community.html
@@ -471,7 +471,7 @@
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Warming promoted saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments"</div>
+                                    <div class="snippet">"Warming promoted self-reliance for resource uptake in trees and shrubs, while saprophytic fungi and putative chemoorganoheterotrophic bacteria utilizing plant-derived carbon substrates were favored in the root zone"</div>
                                     
                                 </li>
                                 
@@ -557,7 +557,7 @@
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Warming promoted saprophytic fungi; eCO2 promoted ectomycorrhizal fungal associations"</div>
+                                    <div class="snippet">"Warming promoted self-reliance for resource uptake in trees and shrubs, while saprophytic fungi and putative chemoorganoheterotrophic bacteria utilizing plant-derived carbon substrates were favored in the root zone"</div>
                                     
                                 </li>
                                 
@@ -568,7 +568,7 @@
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that targeted labile nitrogen"</div>
+                                    <div class="snippet">"Trees mostly associated with short-distance exploration-type fungi that preferentially use labile soil N"</div>
                                     
                                 </li>
                                 
@@ -741,7 +741,7 @@
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Warming promoted saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments"</div>
+                        <div class="snippet">"Warming promoted self-reliance for resource uptake in trees and shrubs, while saprophytic fungi and putative chemoorganoheterotrophic bacteria utilizing plant-derived carbon substrates were favored in the root zone"</div>
                         
                     </li>
                     
@@ -813,7 +813,7 @@
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"eCO2 promoted ectomycorrhizal fungal associations"</div>
+                        <div class="snippet">"Conversely, eCO2 promoted associations between trees and ectomycorrhizal fungi"</div>
                         
                     </li>
                     
@@ -826,7 +826,7 @@
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that targeted labile nitrogen"</div>
+                        <div class="snippet">"Trees mostly associated with short-distance exploration-type fungi that preferentially use labile soil N"</div>
                         
                     </li>
                     
@@ -874,7 +874,7 @@
                             - SUPPORT (IN_VIVO)
                         </div>
                         
-                        <div class="snippet">"Vascular plant fine root traits mediate climate change effects on microbial communities"</div>
+                        <div class="snippet">"Our results indicate that plant fine-root trait variation is a crucial mechanism through which vascular plants in peatlands respond to climate change via their influence on microbial communities that regulate biogeochemical cycles"</div>
                         
                     </li>
                     
@@ -1113,7 +1113,7 @@
                                     
                                     - SUPPORT (IN_VIVO)
                                     
-                                    <div class="snippet">"Elevated CO2 (eCO2) treatment applied"</div>
+                                    <div class="snippet">"to explore the effects of a whole-ecosystem warming gradient (+0°C to 9°C) and eCO2 on vascular plant fine roots and their associated microbes"</div>
                                     
                                 </li>
                                 

--- a/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
+++ b/kb/communities/SPRUCE_Peatland_Warming_Community.yaml
@@ -43,7 +43,7 @@ taxonomy:
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Warming promoted saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments
+    snippet: Warming promoted self-reliance for resource uptake in trees and shrubs, while saprophytic fungi and putative chemoorganoheterotrophic bacteria utilizing plant-derived carbon substrates were favored in the root zone
     explanation: Documents warming effects on bacterial community composition
 - taxon_term:
     preferred_term: Archaea
@@ -92,12 +92,12 @@ taxonomy:
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Warming promoted saprophytic fungi; eCO2 promoted ectomycorrhizal fungal associations
+    snippet: Warming promoted self-reliance for resource uptake in trees and shrubs, while saprophytic fungi and putative chemoorganoheterotrophic bacteria utilizing plant-derived carbon substrates were favored in the root zone
     explanation: Documents divergent fungal guild responses to climate treatments
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that targeted labile nitrogen
+    snippet: Trees mostly associated with short-distance exploration-type fungi that preferentially use labile soil N
     explanation: Details ECM functional response to elevated CO2
 - taxon_term:
     preferred_term: Viruses
@@ -169,7 +169,7 @@ ecological_interactions:
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Warming promoted saprophytic fungi and chemoorganoheterotrophic bacteria in root-associated environments
+    snippet: Warming promoted self-reliance for resource uptake in trees and shrubs, while saprophytic fungi and putative chemoorganoheterotrophic bacteria utilizing plant-derived carbon substrates were favored in the root zone
     explanation: Documents warming effects on decomposer communities
 - name: Elevated CO2-Enhanced Ectomycorrhizal Symbiosis
   description: 'Elevated CO2 (+500 ppm above ambient, ~900 ppm total) enhances associations between vascular plants (primarily black spruce, Picea mariana) and ectomycorrhizal (ECM) fungi. eCO2 increases plant photosynthetic carbon fixation, providing additional carbohydrate resources allocated belowground to support mycorrhizal partners. ECM fungi respond by increasing colonization of fine roots and hyphal exploration of soil. Under eCO2, trees preferentially associate with ECM fungi employing short-distance exploration strategies (limited hyphal spread, clustered near roots) that target labile nitrogen pools (amino acids, simple organic nitrogen) rather than distant or recalcitrant N sources. This represents a shift in ECM functional guild composition, with implications for nutrient cycling: short-distance explorers efficiently scavenge readily available N but may reduce ecosystem N retention compared to long-distance mat-forming ECM. The enhanced ECM symbiosis improves tree nutrient acquisition (N, P) and potentially increases tree growth and carbon allocation to roots, with cascading effects on peat carbon inputs through root exudation and turnover. The eCO2-ECM response contrasts with warming effects, suggesting divergent climate driver impacts on plant-fungal mutualisms.
@@ -217,12 +217,12 @@ ecological_interactions:
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: eCO2 promoted ectomycorrhizal fungal associations
+    snippet: Conversely, eCO2 promoted associations between trees and ectomycorrhizal fungi
     explanation: Documents elevated CO2 effects on ECM abundance
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that targeted labile nitrogen
+    snippet: Trees mostly associated with short-distance exploration-type fungi that preferentially use labile soil N
     explanation: Details ECM functional guild shifts under eCO2
 - name: Root Trait-Mediated Microbial Community Assembly
   description: 'Vascular plant fine root traits serve as critical mediators of climate change effects on microbial communities. Root trait variation (specific root length, root diameter, tissue chemistry, exudate composition) creates heterogeneous microenvironments in the rhizosphere and bulk peat, structuring microbial community composition and function. Under warming, plants shift root allocation and morphology, altering the quantity and quality of resources available to root-associated microbes. For example, increased fine root production provides fresh organic carbon substrates for decomposers, while changes in root exudate chemistry (organic acids, sugars, secondary metabolites) selectively promote or inhibit specific microbial taxa. Under eCO2, enhanced root biomass and exudation due to increased photosynthate allocation belowground fuel ectomycorrhizal fungal growth and bacterial rhizosphere communities. This plant-mediated microbial response represents a biotic feedback mechanism: climate change → plant physiological/morphological responses → altered root traits → microbial community shifts → ecosystem function changes (decomposition, nutrient cycling, carbon storage). The finding that root traits mediate climate effects suggests that plant species composition and functional diversity will strongly influence peatland microbial responses to global change, adding complexity to climate-ecosystem models.
@@ -249,8 +249,10 @@ ecological_interactions:
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Vascular plant fine root traits mediate climate change effects on microbial communities
-    explanation: Establishes root traits as key mediator of plant-microbe-climate interactions
+    snippet: Our results indicate that plant fine-root trait variation is a crucial mechanism
+      through which vascular plants in peatlands respond to climate change via their influence
+      on microbial communities that regulate biogeochemical cycles
+    explanation: The paper's own conclusion that root traits mediate the climate-microbe link.
 - name: Viral-Host Dynamics and Niche Partitioning
   description: 'Viral communities (phages) exert top-down control on bacterial and archaeal populations through predation, influencing microbial community structure, diversity, and nutrient cycling. In SPRUCE peatland, viral community composition tracks environmental gradients (peat depth, water content, carbon chemistry) rather than direct climate manipulations (temperature), suggesting viruses respond to microbial host distributions and metabolism rather than abiotic climate drivers. Viruses exhibit strong niche partitioning between aquatic (waterlogged surface peat) and terrestrial (deeper, less saturated) zones, with distinct vOTU assemblages reflecting underlying bacterial host community composition. Predicted viral hosts show narrow ranges (typically within a single bacterial genus), indicating specialized phage-host relationships and limited cross-infection. This specificity suggests viral predation may regulate specific bacterial functional guilds (e.g., methanogens, cellulose degraders) with cascading effects on ecosystem processes. Viral lysis releases intracellular nutrients and organic carbon (viral shunt), making them available for microbial uptake and potentially accelerating nutrient cycling. The lack of viral community response to temperature during initial warming (first 2 years) suggests viral dynamics may lag behind bacterial responses or require threshold climate changes to trigger shifts.
 
@@ -304,8 +306,9 @@ environmental_factors:
   - reference: PMID:38515239
     supports: SUPPORT
     evidence_source: IN_VIVO
-    snippet: Elevated CO2 (eCO2) treatment applied
-    explanation: Documents eCO2 experimental design
+    snippet: to explore the effects of a whole-ecosystem warming gradient (+0°C to 9°C) and
+      eCO2 on vascular plant fine roots and their associated microbes
+    explanation: Documents the eCO2 arm of the experimental design, and the warming gradient.
 - name: Peat Depth Gradient
   value: 0-200
   unit: cm depth


### PR DESCRIPTION
## Result

`SPRUCE_Peatland_Warming_Community` — **8 reference-validation failures → 0.**

All eight cited PMID:38515239, and all eight were paraphrases of sentences that are **already in the cached abstract**. The fix was to quote them.

## "Paywalled" was the wrong diagnosis

The residual on #347 was recorded as 8 snippets blocked on institutional access. That does not hold:

- **Unpaywall:** `is_oa: true`, `oa_status: hybrid`, best location a PDF at Wiley.
- **Europe PMC by PMID:** no PMC record (`pmcid=None, oa=False`).
- **Europe PMC by DOI:** 1 hit, `isOpenAccess: N`, no PMC record.
- **Wiley `pdfdirect`:** **HTTP 403** to a scripted request — the publisher behaviour `cache_fulltext.py`'s own docstring names for MDPI.

So the paper is open access and simply not retrievable programmatically. No amount of fetching would have fixed it, and the snippets never needed full text: every claim they make is in the abstract, just worded differently.

## Quoting also repaired a bent claim

One paraphrase read:

> Under eCO2, trees preferentially associated with ectomycorrhizal fungi using short-distance exploration strategies that **targeted labile nitrogen**

The abstract says:

> Trees mostly associated with short-distance exploration-type fungi that **preferentially use labile soil N**

The paraphrase attaches "preferentially" to the *association*; the source attaches it to the *nitrogen use*. Different claim. That is what #347 meant by calling this the worst record in the KB — not that the snippets were unverifiable, but that they were restatements, and a restatement can drift while still sounding right.

## Also worth noting

`cache_fulltext.py` cannot retry a PMID-cached reference via its DOI — the DOI is in the cache entry's own frontmatter, but the DOI path requires a DOI-keyed cache file and reports `no abstract cache; fetch the abstract first`. It made no difference here (both Europe PMC paths fail for this DOI anyway), so I have not changed it. Mentioning it because the next person to hit an OA-but-not-in-PMC reference will meet the same dead end.

## Checks

- `just validate` — no issues
- `just validate-references` — **Total checks: 0** (was 8)
- `just validate-strict` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Closes #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)