### PR TITLE
Stop citing a normal-vision failure as an argument for shape (#199, #532)

### DIFF
--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -513,13 +513,32 @@
         {%- set taxon_stroke = "#4a4a4a" -%}
         {%- set unmapped_color = "#929caa" -%}
         {#- `symbol` is the redundant channel (#270). Nine categories is past what
-            colour alone can carry: measured all-pairs, this palette drops to
-            ΔE 1.8 under tritanopia and 10.3 under NORMAL vision for
-            Mutualism-vs-Cross-feeding, so shape is not a courtesy to CVD
-            readers, it is what makes two of the commonest types separable at
-            all. Circle is reserved for taxa, so every value below is a
-            non-circle d3 symbol; the bundled d3 v7 ships 14, which is enough
-            for a 1:1 mapping without doubling up on fill. -#}
+            colour alone can carry, so shape is not a courtesy to CVD readers.
+            Circle is reserved for taxa, so every value below is a non-circle d3
+            symbol; the bundled d3 v7 ships 14, enough for a 1:1 mapping without
+            doubling up on fill.
+
+            Shape does NOT, however, excuse the normal-vision floor, and an
+            earlier version of this comment got that wrong: it cited
+            Mutualism-vs-Cross-feeding at ΔE 10.3 under NORMAL vision as an
+            argument FOR shape. Shape rescues the CVD case; a full-colour reader
+            who cannot separate the two commonest types is a colour problem, and
+            the dataviz rubric is explicit that secondary encoding does not
+            excuse it. So that 10.3 is an open defect, tracked in #532, not a
+            justification.
+
+            It is not a one-colour fix. Re-stepping Mutualism to #2a7fd4 clears
+            the rubric's normal-vision check and then fails THIS repo's
+            all-pairs gate at ΔE 5.5 against #7f30cf under deuteranopia — the
+            two checks use different metrics (OKLab ΔE×100 adjacent-pairs vs
+            CIELAB ΔE76 all-pairs) and disagree about which pairs are close.
+            A search over ~200k saturated warm pairs found none clearing both.
+            Nine mutually separable hues is at or past what the space allows,
+            which is what the rubric means by folding a 9th series into "Other".
+
+            Do not retune by eye, and do not retune one colour at a time.
+            `node scripts/validate_palette.js "<hexes>"` from the dataviz skill
+            and `tests/test_network_palette.py` must BOTH pass. -#}
         {%- set interaction_legend = [
             {"key": "CROSS_FEEDING", "label": "Cross-feeding", "color": "#57c7ab", "symbol": "symbolDiamond"},
             {"key": "MUTUALISM", "label": "Mutualism", "color": "#56bbe6", "symbol": "symbolSquare"},


### PR DESCRIPTION
## The finding

Ran the dataviz rubric's palette validator against the shipped network palette — the one check the rubric says never to eyeball. It **fails the normal-vision floor**:

```
[FAIL] Normal-vision floor  #56bbe6 ↔ #57c7ab  ΔE 10.3 (normal) — below 15
[FAIL] Lightness band       #edab12 at L 0.783
```

Mutualism and Cross-feeding are the two commonest interaction types, and a **full-colour** reader cannot reliably separate them.

## The template already knew that number, and drew the wrong conclusion

Its comment cited ΔE 10.3 as evidence that shape "is not a courtesy to CVD readers, it is what makes two of the commonest types separable at all."

That has it backwards. Shape rescues the **CVD** case; the rubric is explicit that the **normal-vision** floor is not excusable by secondary encoding. The number is a defect, not a justification. Corrected in place — that is the whole diff.

## Why no colours changed

A half-fix would trade one failure for another, and both obvious swaps do exactly that:

| swap | clears | then fails |
|---|---|---|
| `#56bbe6 → #2a7fd4` | rubric normal-vision floor | **this repo's** all-pairs gate, ΔE 5.5 vs `#7f30cf` (deutan) |
| `#edab12 → #b8860b` | lightness band | ΔE 1.5 from Commensalism `#cf7830` (deutan) |

That second one is instructive: **the validator never compared that pair**, because it checks *adjacent* entries and those two are not neighbours in the list. The repo's own all-pairs test caught it on the first run.

## The two gates disagree, which is the real finding

- `validate_palette.js` — **OKLab ΔE×100**, **adjacent pairs**
- `tests/test_network_palette.py` — **CIELAB ΔE76**, **all pairs**, including the greys

Different metric *and* different pair set. Optimising against either alone produces a change that looks verified and isn't. Neither is wrong; only satisfying both is meaningful.

## Searched rather than guessed

- 775 single candidates clearing the repo's 15.0 all-pairs floor → every one that also passed the OKLab checks was a **cyan**, re-introducing the blue-blue adjacency the change was meant to remove.
- ~207k saturated warm pairs for the two warm slots → **none** passed both; the best failed the normal-vision floor against `#a91919`.
- Relaxing chroma finds solutions the validator rejects as reading grey.

**Nine mutually separable saturated hues is at or past what the space allows** with CVD simulation and two metrics both binding — which is precisely what the rubric means by folding a ninth series into "Other", small multiples, or composite encoding. The fix is structural, not a better hex.

## Also confirmed for #199

The brand hero gradient is now on **both** `community_umap.html` and `community.html`, so that open item is done. The remaining one — filters below the plot — is recorded there as a deliberate layout choice.

## Checks

- `uv run pytest tests/` — 2375 passed, 16 skipped (`test_network_palette.py` 9 passed)
- `just lint`, `just check-docs-current` — exit 0

Advances #199. Defect tracked in #532 with the full search recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)