### PR TITLE
Static 60 °C anaerobic culture, and why static is a setting (#183)

### DIFF
--- a/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.yaml
@@ -337,6 +337,37 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: relieves the carbon catabolite repression of C. thermocellum JN4
     explanation: Supports the narrower mechanism that GD17 can also relieve carbon catabolite repression.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  operating_temperature: 60.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Anaerobic tubes or serum bottles of CTFUD medium in a 60 °C incubator, static. The same
+    conditions were used for each strain alone and for the reconstructed coculture, which is
+    what makes the monoculture and coculture results in this paper comparable.
+  notes: >-
+    "Without agitation" is recorded because it is a choice rather than an omission: these are
+    thermophilic cellulose degraders and C. thermocellum works through a surface-attached
+    cellulosome, so leaving the substrate settled is part of the design, not a detail that
+    went unmentioned.
+
+    No working volume. The source names the vessel type - tubes or serum bottles, either -
+    but never a fill volume, and the two would not imply the same one.
+
+    Unlike several neighbouring #183 records, the cited conditions are explicitly the
+    coculture's as well as the monocultures': the sentence names "the reconstructed coculture
+    of the two bacteria" among what was grown this way. That is the check #529 asks for, and
+    here it passes on the sentence itself rather than on a member-name count.
+  evidence:
+  - reference: PMID:31551972
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Clostridium thermocellum JN4, T. thermosaccharolyticum GD17 and the reconstructed
+      coculture of the two bacteria were grown using CTFUD media in anaerobic tubes/serum bottles
+      in an incubator at 60°C without agitation
+    explanation: Vessel, medium, temperature and static operation, stated for the coculture itself.
+
 environmental_factors:
 - name: Cellulose-rich lignocellulosic substrate
   value: cellulose


### PR DESCRIPTION
## What

`Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture` — CTFUD medium in anaerobic tubes or serum bottles, 60 °C incubator, **no agitation**.

## "Without agitation" is recorded, not dropped

It is a choice, not an omission. These are thermophilic cellulose degraders and *C. thermocellum* works through a surface-attached cellulosome, so leaving the substrate settled is part of the design. A reader who saw no agitation field would reasonably assume it simply went unmentioned — which is the wrong inference here.

## No working volume

The source offers "tubes/serum bottles", *either*, and never a fill volume. The two would not imply the same one, so the field stays empty and `notes` says why.

## The #529 question answers itself here

The cited sentence names **"the reconstructed coculture of the two bacteria"** among what was grown this way, alongside each strain alone. So the conditions are explicitly the community's, stated in the sentence, rather than inferred from a member-name count.

That is a stronger form of the check than the guard added in #530 can perform — and it is also *why* the paper's monoculture and coculture results are comparable at all: same medium, same vessel, same temperature, same static regime.

Worth contrasting with the last three records, where the same paper carried preculture conditions beside the community's (#534, #535) or ran two distinct arms on one consortium (#536). Four records, four different answers to "what is this number about."

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; snippet verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)