### PR TITLE
Light and dark are the cycle, not a setting (#183)

### DIFF
--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -226,6 +226,49 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: temporal/spatial separation design conquered the physiological incompatibility
     explanation: Supports the spatial-temporal device organization as the compatibility mechanism.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: BIOELECTROCHEMICAL_SYSTEM
+  instrument_detail: >-
+    Dual-chamber electrochemical devices on M9 medium, used to compare current production
+    from monocultures against the consortium. The cyanobacterium charges the system in the
+    light by making d-lactate; Shewanella discharges it in the dark by oxidising that
+    d-lactate to the anode. The consortium sustained electricity production for over 40 days.
+  electrode_detail: >-
+    Anode-respiring: the engineered S. oneidensis releases electrons from d-lactate and
+    transfers them to the anode. No applied potential is recorded because the paper reports
+    power output rather than poised-potential operation.
+  notes: >-
+    Light and dark are the operating cycle, not a condition. Charging and discharging are run
+    sequentially under light and dark, and the paper's own attempt to run the consortium under
+    continuous light failed - it produced no current, because photosynthetic oxygen raised
+    dissolved oxygen and Shewanella is itself light-sensitive. Recording an illumination
+    setting as a single value would flatten the finding into a parameter.
+
+    `cultivation_mode` is BATCH because the devices are charged and discharged rather than
+    fed and drained; no dilution or feed rate is reported.
+
+    The LB at 30 °C elsewhere in the paper is the S. oneidensis preculture, not the
+    consortium, and is deliberately not recorded here (#529).
+  evidence:
+  - reference: PMID:31537786
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Dual-chamber electrochemical devices (Supplementary Fig. 14a, b) were used to evaluate
+      the efficiency of current production in mono-cultures and microbial consortia in this study
+    explanation: The vessel, stated for the consortium as well as the monocultures.
+  - reference: PMID:31537786
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The charging process (photosynthetic production of d-lactate) and discharging process
+      are implemented sequentially under light and dark conditions, respectively
+    explanation: The light/dark cycle is the operating regime, which is why it is not a field.
+  - reference: PMID:31537786
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: can produce relatively high-power electricity from light for over 40 days
+    explanation: Duration the consortium was operated for.
+
 environmental_factors:
 - name: Light-driven charging phase
   value: Continuous illumination with 3 percent carbon dioxide for cyanobacterial D-lactate production


### PR DESCRIPTION
## What

`Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium` — dual-chamber electrochemical devices on M9 medium, operated for **over 40 days**.

The cyanobacterium *charges* the system in the light by making d-lactate; the engineered *S. oneidensis* *discharges* it in the dark by oxidising that d-lactate to the anode.

## Illumination is deliberately not a field

Charging and discharging run **sequentially** under light and dark. And the paper's own attempt to run the consortium under continuous light **produced no current at all** — photosynthetic oxygen raised dissolved oxygen, and *S. oneidensis* is itself light-sensitive, with cell death after 24 h of illumination.

Recording a single illumination value would turn that result into a parameter. The light/dark alternation is the operating cycle, so it lives in `instrument_detail` and `notes` with the snippet that states it.

## Two other fields left empty

- **`applied_potential`** — the paper reports power output (>150 mW·m⁻²), not poised-potential operation. The electrode is described rather than given a voltage the source never states.
- **`cultivation_mode` is `BATCH`** because the devices are charged and discharged rather than fed and drained; no dilution or feed rate is reported.

## Preculture excluded again

The LB at 30 °C elsewhere in the paper is the *S. oneidensis* preculture, not the consortium. That is the **third** record in this batch where a member's conditions sit beside the community's in the same source (#529) — and, as before, the member-coverage guard was green and the discrimination came from reading which sentence the number attaches to.

Here the supporting snippet resolves it directly: the dual-chamber sentence says the devices were used for "mono-cultures **and microbial consortia** in this study."

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; all three snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)