### PR TITLE
Syntrophy setup, and the fumarate that must not be in it (#183)

### DIFF
--- a/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
@@ -1058,7 +1058,7 @@ Still open: carrier apportionment between H2 and formate for the M. formicicum p
                         
 
                         
-                        <p class="snippet">"Syntrophobacter fumaroxidans MPOB T (DSM 10017) was cultivated under anoxic conditions in basal medium as described previously"</p>
+                        <p class="snippet">"Syntrophobacter fumaroxidans MPOBT (DSM 10017) was cultivated under anoxic conditions in basal medium as described previously"</p>
                         
                     </div>
                     
@@ -1084,7 +1084,7 @@ Still open: carrier apportionment between H2 and formate for the M. formicicum p
                         
 
                         
-                        <p class="snippet">"Cocultures of S. fumaroxidans with Methanospirillum hungatei strain JF1 T (DSM 864) or Methanobacterium formicicum MF T (DSM 1535) were grown with 30 mM of propionate without electron acceptor"</p>
+                        <p class="snippet">"Cocultures of S. fumaroxidans with Methanospirillum hungatei strain JF1T (DSM 864) or Methanobacterium formicicum MFT (DSM 1535) were grown with 30 mM of propionate without electron acceptor"</p>
                         
                     </div>
                     

--- a/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
+++ b/kb/communities/Syntrophobacter_Methanobacterium_Syntrophy.yaml
@@ -250,6 +250,38 @@ ecological_interactions:
       were used in its sulfidogenic metabolism
     explanation: Confirms the importance of formate as an interspecies electron carrier in addition to
       H2
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: FLASK
+  working_volume: 550.0
+  working_volume_unit: mL
+  operating_temperature: 37.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    1 L flasks holding 550 mL of medium, in triplicate, under a pressurised N2/CO2 (80:20)
+    gas phase at 172 kPa. The headspace is not just an anaerobic blanket: syntrophic
+    propionate oxidation is thermodynamically feasible only while the partner keeps H2 and
+    formate low, so the gas composition and pressure are part of the experiment.
+  notes: >-
+    The cited sentence says "all organisms", which in this paper covers the cocultures as
+    well as the axenic controls - so these are the community's conditions and not a member's.
+    That is the #529 check passing on the wording rather than on a member-name count, as it
+    did for the JN4/GD17 record.
+
+    What is NOT recorded: the 20 mM propionate and 60 mM fumarate supplement, which the
+    source attaches specifically to "the medium for the pure cultures". Fumarate is an
+    electron acceptor that lets S. fumaroxidans grow without a partner, so carrying it into
+    the coculture's setup would describe a condition that removes the syntrophy this record
+    exists to document.
+  evidence:
+  - reference: PMID:29611893
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: All organisms were batch cultured in triplicate at 37°C in 1 l flasks with 550 ml
+      medium under anaerobic conditions provided by a pressurised (172 kPa; 1.7 atm) gas phase
+      of N2/CO2 (80:20, vol/vol)
+    explanation: Mode, vessel, working volume, temperature and the pressurised anaerobic headspace.
+
 environmental_factors:
 - name: Exogenous Formate Dosage
   value: 5-10 mM promotes; 50 mM inhibits
@@ -393,7 +425,7 @@ growth_media:
   - reference: PMID:29611893
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Syntrophobacter fumaroxidans MPOB T (DSM 10017) was cultivated under anoxic conditions
+    snippet: Syntrophobacter fumaroxidans MPOBT (DSM 10017) was cultivated under anoxic conditions
       in basal medium as described previously
     explanation: Establishes anoxic basal-medium cultivation for the propionate-oxidizing partner.
   - reference: PMID:29611893
@@ -404,8 +436,8 @@ growth_media:
   - reference: PMID:29611893
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Cocultures of S. fumaroxidans with Methanospirillum hungatei strain JF1 T (DSM 864) or
-      Methanobacterium formicicum MF T (DSM 1535) were grown with 30 mM of propionate without electron
+    snippet: Cocultures of S. fumaroxidans with Methanospirillum hungatei strain JF1T (DSM 864) or
+      Methanobacterium formicicum MFT (DSM 1535) were grown with 30 mM of propionate without electron
       acceptor
     explanation: Confirms the S. fumaroxidans-M. formicicum coculture and propionate substrate concentration.
 discussions:


### PR DESCRIPTION
## What

`Syntrophobacter_Methanobacterium_Syntrophy` — 1 L flasks with 550 mL medium, in triplicate, 37 °C, under a **pressurised N₂/CO₂ (80:20) gas phase at 172 kPa**.

The headspace is recorded because it is not merely an anaerobic blanket. Syntrophic propionate oxidation is thermodynamically feasible only while the methanogenic partner keeps H₂ and formate low, so the gas composition and pressure are part of the experiment rather than background.

## The #529 check passes on the wording

The cited sentence says **"All organisms were batch cultured…"**, which in this paper covers the cocultures as well as the axenic controls. So these are the community's conditions, established from the sentence itself rather than inferred from a member-name count — as with the JN4/GD17 record.

## What is deliberately excluded, and why it matters more than usual

The source also gives 20 mM propionate and 60 mM fumarate — attached specifically to **"the medium for the pure cultures"**.

Fumarate is an electron acceptor that lets *S. fumaroxidans* grow **without a partner**. Carrying it into the coculture's `cultivation_setup` would describe a condition that abolishes the very syntrophy this record exists to document. Same shape as the precultures excluded from the last three records, with a sharper consequence: not just a wrong number, but a setup that contradicts the record's subject.

## Also fixes two failures already on `main`

This record had **2 reference-validation errors before this PR**. Its snippets wrote strain designations as `MPOB T`, `JF1 T`, `MF T`; the cached text renders the superscript type-strain marker closed up — `MPOBT`, `JF1T`, `MFT`.

A rendering artefact, not a misquotation. Corrected, so the record now validates at **0 issues rather than 2**.

## Checks

- `just validate` — no issues
- `just validate-references` — **Total checks: 0** (was 2)
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)