### PR TITLE
Encapsulation is part of the setup, not the strain (#183)

### DIFF
--- a/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
+++ b/kb/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.yaml
@@ -288,6 +288,39 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: exchange of further molecules beyond the unidirectional feeding with sucrose
     explanation: Supports additional interaction mechanisms beyond the engineered sucrose cross-feeding link.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: FLASK
+  working_volume: 10.0
+  working_volume_unit: mL
+  instrument_detail: >-
+    125 mL baffled Erlenmeyer flasks holding roughly 10 mL of alginate-bead suspension in M3
+    minimal medium, on a Multitron Pro rotary shaker. The cyanobacterium is encapsulated in
+    barium-alginate hydrogel rather than free in suspension; that encapsulation is what
+    shields it from 2,4-DNT toxicity, so it is a property of the setup and not of the strain.
+    Cells were stepped from 25 to 50 mM NaCl over two days before the final medium.
+  notes: >-
+    No operating temperature or light intensity. The paper gives 32 °C and 150 rpm for
+    Lysogeny broth cultures, and LB is the P. putida preculture medium - the coculture runs
+    on M3 with light and CO2 as inputs, so those numbers are not the community's (#529). The
+    incubator model is recorded instead of a temperature invented for it.
+
+    `cultivation_mode` is BATCH: the medium is exchanged between acclimation steps rather
+    than fed continuously, and no dilution rate is reported.
+  evidence:
+  - reference: PMID:32064751
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: the alginate bead suspension were portioned in ~ 10‐ml aliquots into 125‐ml baffled
+      Erlenmeyer flasks
+    explanation: The vessel and the working volume the coculture was run in.
+  - reference: PMID:32064751
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: By encapsulating S. elongatus within a barium-alginate hydrogel, cyanobacterial cells
+      were protected from the toxic effects of 2,4-DNT, enhancing the performance of the co-culture
+    explanation: Why the encapsulation belongs in the setup rather than being incidental.
+
 environmental_factors:
 - name: Light and CO2
   value: Illumination with CO2 as primary carbon input


### PR DESCRIPTION
## What

`Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture` — 125 mL baffled Erlenmeyer flasks holding ~10 mL of alginate-bead suspension in M3 minimal medium on a Multitron Pro rotary shaker, with cells stepped from 25 → 50 mM NaCl before the final medium.

## Why the encapsulation is in `instrument_detail`

The cyanobacterium is encapsulated in **barium-alginate hydrogel** rather than free in suspension, and that is what makes the coculture work: it shields *S. elongatus* from 2,4-DNT toxicity.

Read as a property of the *strain* it would be wrong — the organism has no such resistance. Read as a property of the *setup* it explains the result. That is why it is recorded here rather than left to the description, with the snippet that states the causal link.

## No temperature, no light intensity

The paper gives 32 °C and 150 rpm — for **Lysogeny broth** cultures. LB is the *P. putida* preculture medium; the coculture runs on M3 with light and CO₂ as its inputs.

Recording those numbers would be the #529 error for the fourth time in this batch. The incubator model goes in instead of a temperature invented for it.

## Also checked and found clean

Before curating this record I swept the whole corpus for the superscript-type-strain rendering artefact fixed in #539 (`MPOB T` → `MPOBT`). **It is isolated** — only that one record, already fixed. Worth stating as a proven negative rather than leaving as an open worry: no batch fix is needed.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)