### PR TITLE
The amendments are the coculture, not a treatment on it (#183)

### DIFF
--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -227,6 +227,42 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: inhibition was removed by adding Pelobacter SFB93
     explanation: Supports SFB93 as a functional partner that can relieve acetylene inhibition.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  working_volume: 25.0
+  working_volume_unit: mL
+  operating_temperature: 34.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    60 mL serum bottles holding 25 mL of artificial bay water medium under an N2 headspace,
+    static, each strain inoculated at 10% v/v. TCE and acetylene were both supplied at
+    0.1 mM - the acetylene is the electron donor and carbon source for Pelobacter, which is
+    what feeds the dechlorinating partner, so the two amendments together are the coculture
+    rather than a treatment applied to it.
+  notes: >-
+    Static on purpose, as with the thermophilic cellulose coculture: these are strict
+    anaerobes on volatile substrates in a sealed bottle, and agitation would work against
+    both the gas balance and the syntrophic exchange.
+
+    Cocultures were carried forward by 5% v/v transfer once 20 μmol TCE had gone to vinyl
+    chloride and 36 μmol acetylene was depleted, so the batch is serial rather than
+    single-shot; that is in the description rather than compressed into cultivation_mode,
+    which has no value for it.
+
+    The monoculture conditions in the same paper - strain 195 and BAV1 on defined medium
+    under H2/CO2 (80:20), SFB93 alone on ABW - are not recorded here (#529).
+  evidence:
+  - reference: PMID:28075122
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Bacterial cocultures of strains 195 and SFB93 (10% vol/vol inoculation of each bacterium)
+      were initially established in 60 mL serum bottles containing 25 mL ABW medium with TCE supplied
+      at a liquid concentration of 0.1 mM (corresponding to 3 μmol TCE per bottle), 0.1 mM acetylene
+      (corresponding to 0.15 mL gas), and N2 headspace incubated at 34 °C without agitation
+    explanation: Vessel, working volume, medium, amendments, headspace, temperature and static
+      operation - stated for the coculture itself.
+
 environmental_factors:
 - name: Acetylene co-contaminant
   value: acetylene generated during TCE degradation


### PR DESCRIPTION
## What

`Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture` — 60 mL serum bottles with 25 mL artificial bay water medium under an N₂ headspace, static, 34 °C, each strain inoculated at 10% v/v, with TCE and acetylene both at 0.1 mM.

## Why both amendments are in `instrument_detail`

They are the coculture's **mechanism**, not a condition applied to it. Acetylene is *Pelobacter*'s electron donor and carbon source; *Pelobacter* is what feeds the dechlorinating partner; TCE is what that partner reduces. Remove either and there is no consortium left to describe.

Recording them as `environmental_factors` alone would read as "this community was exposed to TCE", which inverts the relationship.

## Static, again on purpose

Same reasoning as the JN4/GD17 record: strict anaerobes on volatile substrates in a sealed bottle, where agitation works against both the gas balance and the syntrophic exchange. Recorded rather than dropped, because a missing agitation field otherwise reads as an omission.

## The serial transfers are described, not forced into an enum

Cocultures were carried forward at 5% v/v once 20 μmol TCE had gone to vinyl chloride and 36 μmol acetylene was depleted. `CultivationModeEnum` has no value for serial batch transfer, so it goes in `notes` rather than being approximated by `SEMI_CONTINUOUS`, which would imply continuous feeding.

## Monocultures excluded

Strains 195 and BAV1 on defined medium under H₂/CO₂ (80:20), and SFB93 alone on ABW, are all in the same paper and none are recorded here — #529 for the **fifth** time in this batch. The supporting snippet settles it directly: it names "Bacterial cocultures of strains 195 and SFB93".

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; snippet verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)