### PR TITLE
A deliberately partial setup, labelled as one (#183)

### DIFF
--- a/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
+++ b/kb/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.yaml
@@ -147,6 +147,43 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: HMO utilization can vary with an individual's microbiome
     explanation: Supports the inter-individual variability of HMO utilization.
+cultivation_setup:
+- instrument_detail: >-
+    All cultivation was done inside a Coy Labs anaerobic chamber under 70% N2 / 25% CO2 /
+    5% H2. Media were sparged with N2 and reduced with l-cysteine hydrochloride, and sugar
+    solutions were equilibrated in the chamber for at least 48 h before use, so the carbon
+    source itself was anoxic at the point of mixing.
+  controls_notes: >-
+    Atmosphere controlled by the chamber rather than by a headspace in each vessel, which is
+    why gas composition is recorded here and not as a per-culture setting.
+  notes: >-
+    Deliberately partial, and worth saying so rather than padding. The source states the
+    chamber and its gas mix for "all cultivation work", which covers the B. breve /
+    R. gnavus cocultures - so that much is theirs. It then defers the coculture's vessel,
+    volume and temperature to "(Methods)", which the cached text does not carry.
+
+    So no `system_type`, no `working_volume`, no `operating_temperature`. The 37 °C with
+    shaking elsewhere in the paper belongs to a 48 h inoculum recovery step, not to the
+    cocultures (#529), and the gas mix is a genuine fact about how this community was grown
+    rather than a placeholder for the ones that are missing.
+
+    The cocultures were run with 2'-fucosyllactose, or its constituents l-fucose and
+    d-lactose, as the sole carbohydrate source; that design is the cross-feeding this record
+    documents and is described in the interactions rather than repeated here.
+  evidence:
+  - reference: PMID:37973815
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: All cultivation work was performed in the same anaerobic chamber (Coy Labs; 70% N2,
+      25% CO2, 5% H2)
+    explanation: The atmosphere, stated for all cultivation and so covering the cocultures.
+  - reference: PMID:37973815
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Sugar solutions were loosely capped and stored in the anaerobic chamber for at least
+      48 h before mixing with BHI-based media for cultivation
+    explanation: The carbon source was anoxic before it reached the culture.
+
 environmental_factors:
 - name: 2'-fucosyllactose supplementation
   value: 2'FL HMO substrate


### PR DESCRIPTION
## What

`Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding` gets a `cultivation_setup` with **no `system_type`, no `working_volume`, and no `operating_temperature`.**

That is the point of this one.

## What the source does state

The atmosphere, for **"all cultivation work"**: a Coy Labs anaerobic chamber under 70% N₂ / 25% CO₂ / 5% H₂, with media sparged with N₂ and reduced with l-cysteine hydrochloride, and sugar solutions equilibrated in the chamber for at least 48 h before mixing — so the carbon source itself was anoxic when it reached the culture.

That phrasing covers the *B. breve* / *R. gnavus* cocultures, so it is theirs. And for a strict-anaerobe gut community the chamber composition is a real, citable fact about how it was grown — not a placeholder for the fields that are missing.

Atmosphere is in `controls_notes` rather than as a per-culture setting, because it is controlled by the chamber, not by a headspace in each vessel.

## What it doesn't state

The paper defers the coculture's vessel, volume and temperature to **"(Methods)"**, which the cached text does not carry. The 37 °C with shaking that *does* appear belongs to a 48 h inoculum recovery step — recording it would be #529 for the sixth time in this batch.

## Why record anything at all

Padding the block out would have been easy and wrong. Leaving the record untouched would have thrown away a fact that is unambiguous and useful.

So the empty fields and the reason for each are written into `notes`. A later curator with the full methods knows exactly what to add, and does not have to re-derive which numbers in that paper were already checked and rejected.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)