### PR TITLE
THOR: nutrient level is the setting, and one record refused (#183, #543)

### DIFF
--- a/kb/communities/THOR_Rhizosphere_Model_Community.yaml
+++ b/kb/communities/THOR_Rhizosphere_Model_Community.yaml
@@ -221,6 +221,44 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: production of more robust biofilms by the three members together than individually
     explanation: Supports biofilm formation as an emergent three-member community phenotype.
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Liquid culture in half-strength tryptic soy broth at 28 °C with vigorous shaking, with
+    strains propagated on 1/10-strength tryptic soy agar. Interactions were also assayed on
+    plates and across three media - LB, half-strength TSB, and soybean root exudate - because
+    which interactions appear depends on the medium: the inhibition among these strains shows
+    up predominantly under the lower-nutrient condition.
+  notes: >-
+    No `system_type` or `working_volume`. The source says "liquid culture" and names the
+    broth, never the vessel or the fill, and the interaction assays run on both plates and in
+    liquid - so a single vessel value would misdescribe half the experiments rather than
+    approximate them.
+
+    Nutrient level is recorded as part of the setup rather than as an environmental factor
+    because it is a manipulated variable here: dilute TSA and TSB are chosen, and the paper's
+    point is that antagonism among the three members is medium-dependent. A record showing
+    only "TSB" would lose the half-strength, which is where the interactions are.
+
+    Media and temperature are stated for the strains generally, which for a three-member
+    model community assembled from those strains is also the coculture's condition; the
+    coculture sentences name the same media (#529).
+  evidence:
+  - reference: PMID:30837345
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Bacterial strains were propagated on 1/10-strength tryptic soy agar (TSA) and grown
+      in liquid culture in 1/2-strength tryptic soy broth (TSB) at 28°C with vigorous shaking
+    explanation: Temperature, agitation, and the two dilute media the community is grown on.
+  - reference: PMID:30837345
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Rhizosphere isolates were grown alone or in coculture with P. koreensis CI12 in soybean
+      root exudate
+    explanation: Cocultures were run in root exudate as well as defined broth.
+
 environmental_factors:
 - name: Rhizosphere Origin
   value: Field-grown soybean root/rhizosphere-associated isolates


### PR DESCRIPTION
## The record curated

`THOR_Rhizosphere_Model_Community` — liquid culture in **half-strength** tryptic soy broth at 28 °C with vigorous shaking, strains propagated on **1/10-strength** TSA, interactions assayed across LB, half-strength TSB, and soybean root exudate.

**The dilutions are the point.** They are chosen, not incidental: the paper's finding is that antagonism among the three members is medium-dependent and appears predominantly under the lower-nutrient condition. A setup recording "TSB" would drop the half-strength — which is exactly where the interactions are.

No `system_type` or `working_volume`: the source says "liquid culture" and names the broth, never the vessel or the fill, and the assays run on plates as well as in liquid, so a single vessel value would misdescribe half the experiments rather than approximate them.

## The record refused, and why it matters more (#543)

`Avena_Rhizosphere_CrossKingdom_SIP_Community` ranked **top** of the candidate list — 95k of cached full text, 100% member coverage, methods keywords throughout.

It must not be curated at all. It is stable-isotope probing of **native rhizosphere soil**: *Avena fatua* was grown under ¹³CO₂ and soil was sampled at 6 and 9 weeks. The plant had a growth setup; the microbial community was never grown in a vessel by anyone.

**No field in the record distinguishes that case.** I checked all three before assuming any worked:

| candidate discriminator | why it fails |
|---|---|
| `community_origin` | three `NATURAL` records legitimately carry a setup — `GLBRC_UFMP` (in-house CSTR), `Phormidium_Alkaline` (photobioreactors), `Thiocyanate_Afipia` (five CSTRs) — all verified as genuinely cultivated |
| `ecological_state` | two of those are `STABLE`, not `ENGINEERED`; filtering on `ENGINEERED` drops legitimate records |
| `community_category` | a `RHIZOSPHERE` record already carries one (`Lunar_Martian_Simulant_PGPB_Lettuce_SynCom`, a stirred-tank bioreactor) |

So "was grown in a vessel" versus "was sampled from the world" is not derivable from the KB. The check has to be a human reading the source — worth knowing before anyone batches the **13 remaining full-text ENGINEERED candidates**.

I deliberately did **not** add a test. A guard would need an allow-list naming each legitimate case individually, which is a list of decisions rather than a rule, and would give false confidence to exactly the batch run it is meant to protect.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Filed #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)