### PR TITLE
Cheese rind: the in vitro arm only, and OMM12 refused (#183, #543)

### DIFF
--- a/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
+++ b/kb/communities/Cheese_Rind_InSitu_InVitro_Model_Community.yaml
@@ -181,6 +181,43 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: succession in vitro was highly reproducible amongst replicates
     explanation: Supports reproducible temporal assembly in the reconstructed natural-rind community.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: >-
+    The in vitro arm. Communities reconstructed on cheese curd agar, inoculated with roughly
+    equal numbers of each member and followed over time; growth monitored by removing agar
+    plugs from 96-well plates, homogenising in PBS and counting CFUs. Plates at room
+    temperature.
+  notes: >-
+    `system_type` is OTHER because an agar-plug community in a 96-well plate has no enum
+    value, and FLASK or any reactor type would assert a liquid culture this is not. The
+    format is in instrument_detail instead.
+
+    No operating_temperature: the source says "room temperature" rather than a figure, and
+    turning that into 20 or 25 °C would invent precision the paper declined to give.
+
+    This record covers an in situ survey as well as this in vitro reconstruction, and only
+    the reconstruction is a cultivation. The in situ side is sampled cheese rind - the same
+    distinction that made Avena_Rhizosphere unenrichable (#543), except that here the paper
+    supplies both and only one of them belongs in this slot.
+
+    The medium is the point rather than a detail: cheese curd agar is what makes the in vitro
+    system recapitulate the in situ succession, which is the paper's central claim.
+  evidence:
+  - reference: PMID:25036636
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We inoculated approximately equal numbers of each together onto cheese curd agar and
+      followed membership of the in vitro rind communities over time
+    explanation: The medium and the equal-inoculum design of the reconstructed community.
+  - reference: PMID:25036636
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Plates were incubated at room temperature, and after colony and foci formation, CFUs
+      of each strain were counted
+    explanation: Incubation temperature as stated, and how the community was followed.
+
 environmental_factors:
 - name: rind moisture
   value: natural-rind treatment drier than undried plates


### PR DESCRIPTION
## The record curated

`Cheese_Rind_InSitu_InVitro_Model_Community` — communities reconstructed on **cheese curd agar** from roughly equal inocula, followed over time by pulling agar plugs from 96-well plates and counting CFUs, plates at room temperature.

**Only the in vitro arm.** The record also covers an in situ survey, and sampled cheese rind is not a cultivation — the same distinction that made `Avena_Rhizosphere` unenrichable, except that here one paper supplies both and only one belongs in this slot.

The medium is treated as the point rather than a detail: cheese curd agar is what makes the in vitro system recapitulate in situ succession, which is the paper's central claim.

Two fields left empty with reasons: `system_type` is `OTHER` because an agar-plug community in a 96-well plate has no enum value, and `FLASK` or a reactor type would assert a liquid culture this is not. No `operating_temperature`, because the source says "room temperature" and turning that into 20 or 25 °C would invent precision the paper declined to give.

## OMM12 checked and refused

`OMM12_Gnotobiotic_Mouse_Gut_Community` has a **"Bacterial Cultivation"** section with everything you could want: anaerobic chamber at 3% H₂/rest N₂, 100 mL Wheaton glass serum bottles with butyl rubber stoppers, 10 mL of Anaerobic Akkermansia Medium.

All of it is **per-strain revival from glycerol cryostocks**, before the mixture is inoculated into germ-free mice. The community lives in the animal. Those bottles are precultures, and a gnotobiotic mouse is not a `CultivationSetup`.

## The list in #543 is not a work queue

Two of thirteen candidates now refused, one partially curatable. I've added a predicted classification of the remaining ten to #543 — five likely refusals (plant SynComs and a second gut community, all with OMM12's shape), three likely curatable, one possibly in silico. **If that holds, the tractable remainder is three or four records, not thirteen.**

The pattern underneath is worth stating: in every refusal, the paper *does* contain real cultivation numbers — for the strains **individually**. That is exactly why these records rank highly on any automated filter, and why the refusal always takes reading. A SynCom paper almost always describes growing its members; describing growing the *community* is a different sentence, and sometimes it does not exist.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Advances #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)