### PR TITLE
An enrichment is by definition grown (#183, #543)

### DIFF
--- a/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
+++ b/kb/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.yaml
@@ -163,6 +163,45 @@ ecological_interactions:
     snippet: amended with C2H2 as the sole electron donor and organic carbon
       source
     explanation: Supports C2H2 as the sole substrate.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  working_volume: 20.0
+  working_volume_unit: mL
+  instrument_detail: >-
+    Gastight 60 mL serum bottles under a 100% nitrogen headspace holding 20 mL of a 1:1
+    groundwater/medium mixture, dosed with 0.05 or 0.1 mL of 100% acetylene. Enrichment
+    cultures were established from NAWC well groundwater with mineral medium for nutrients
+    and acetylene as the sole electron donor and organic carbon source; bottles were
+    re-amended once acetylene fell below detection.
+  notes: >-
+    Acetylene is in the setup rather than only in the environmental factors because it is the
+    selective pressure that makes this an enrichment: it is the sole electron donor and the
+    sole organic carbon source, so the community is defined by what grows on it. Same
+    reasoning as the TCE/acetylene coculture record.
+
+    A second bottle format appears in the paper - 160 mL bottles with 100 mL liquid - but
+    only in table captions giving concentrations per bottle, not in the setup narrative, so
+    the 60 mL microcosm is what is recorded here.
+
+    This one was predicted curatable in #543 and is: an enrichment is by definition grown,
+    and the source describes establishing and feeding the culture rather than sampling it.
+    That is the contrast with the two records refused in that issue.
+  evidence:
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Anaerobic, acetylenotrophic enrichment cultures were established from groundwater
+      collected from NAWC wells 36BR-A and 73BR-D2 with the addition of mineral medium to provide
+      nutrients and C2H2 as the sole electron donor and organic carbon source
+    explanation: The community was enriched in the laboratory, and on what.
+  - reference: PMID:33531396
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Twenty milliliters of the 1:1 groundwater-SeFr1 mixture was then transferred to gastight
+      60-ml serum bottles with 100% nitrogen headspace
+    explanation: Vessel, working volume and headspace.
+
 environmental_factors:
 - name: Acetylene source
   value: C2H2 supplied as sole electron donor and carbon source


### PR DESCRIPTION
## What

`Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment` — gastight 60 mL serum bottles under a 100% N₂ headspace holding 20 mL of a 1:1 groundwater/medium mixture, dosed with 0.05 or 0.1 mL of acetylene and re-amended once it fell below detection.

## Acetylene is in the setup, not just the environment

It is the **selective pressure that makes this an enrichment** — sole electron donor *and* sole organic carbon source. The community is defined by what grows on it. Recording it only as an environmental factor would describe a community that happened to encounter acetylene, rather than one that exists because of it.

Same reasoning as the TCE/acetylene coculture in #541.

## One ambiguity resolved rather than averaged

A second bottle format appears in the paper — 160 mL bottles with 100 mL liquid — but only in **table captions giving concentrations per bottle**, not in the setup narrative. The 60 mL microcosm is what the methods describe establishing, so that is what is recorded, with the discrepancy noted rather than silently picked.

## Confirms the first #543 prediction

#543 predicted three of the remaining ten full-text candidates as "likely curatable", starting with this one, on the grounds that **an enrichment is grown by definition**. That holds: the source describes *establishing and feeding* the culture, not sampling it.

Which is exactly the contrast with the two records refused there — `Avena_Rhizosphere` and `OMM12` — where the paper described growing the *members* and never the *community*.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Advances #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)