### PR TITLE
The poise is a range, so it stays in electrode_detail (#183, #543)

### DIFF
--- a/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
+++ b/kb/communities/Rifle_Aquifer_Bioanode_EET_Community.yaml
@@ -280,6 +280,41 @@ ecological_interactions:
       in the Rifle aquifer that may have the potential to mediate mineral redox
       transformations
     explanation: Supports the selective enrichment of EET-capable organisms.
+cultivation_setup:
+- system_type: BIOELECTROCHEMICAL_SYSTEM
+  instrument_detail: >-
+    Electroactive biofilms grown on poised anodes and maintained for almost four years, with
+    acetate as the sole carbon source. Both the anode biofilm and the planktonic fraction
+    were sampled, so the electrode is not merely a probe - it is the growth surface that
+    selects the community this record describes.
+  electrode_detail: >-
+    Anodes poised mostly at -0.2 to -0.25 V versus the standard hydrogen electrode, a range
+    chosen to mimic the redox potential of iron-oxide minerals.
+  notes: >-
+    `applied_potential` is left unset and the value kept in `electrode_detail`. The source
+    gives a range rather than a setpoint, and qualifies it with "mostly", so a single number
+    would assert a poise the four-year run did not hold.
+
+    This is also the case #517 anticipated: the potential is only meaningful against its
+    reference electrode, and "vs SHE" is not a unit. Keeping the reference in
+    `electrode_detail` is what lets the range be stated in full rather than compressed into
+    a value-plus-suffix.
+
+    No temperature or working volume - the source characterises the communities and does not
+    restate the reactor's dimensions.
+
+    Predicted curatable in #543 on the grounds that a bioanode implies an electrochemical
+    cell, and it is: the biofilms were established and maintained rather than sampled from
+    the aquifer directly.
+  evidence:
+  - reference: PMID:32849356
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Electroactive biofilms were established and maintained for almost 4 years on anodes
+      poised mostly at -0.2 to -0.25 V vs. SHE, a range that mimics the redox potential of
+      iron-oxide minerals, using acetate as the sole carbon source
+    explanation: The electrode poise and its reference, the duration, and the sole carbon source.
+
 environmental_factors:
 - name: Anode redox potential
   value: -0.2 to -0.25 V vs SHE


### PR DESCRIPTION
## What

`Rifle_Aquifer_Bioanode_EET_Community` — electroactive biofilms on anodes poised mostly at **−0.2 to −0.25 V vs SHE**, maintained for almost four years, with acetate as the sole carbon source.

The electrode is recorded as the growth surface that *selects* this community, not as a probe applied to it: both the anode biofilm and the planktonic fraction were sampled off the same system.

## `applied_potential` is deliberately unset

The source gives a **range**, and qualifies it with **"mostly"**. A single number would assert a poise the four-year run did not hold. The range lives in `electrode_detail` in full.

## This is the case #517 anticipated

When `applied_potential_unit` was narrowed to `{V, mV}` in #517, the argument was that a potential is only meaningful against its reference electrode, that "vs SHE" is not a unit, and that the reference belongs in `electrode_detail`.

This is the first record where that decision pays for itself. Because the reference sits in prose rather than being smuggled into a unit string, the field can carry *"poised mostly at −0.2 to −0.25 V versus the standard hydrogen electrode, a range chosen to mimic the redox potential of iron-oxide minerals"* — the qualifier, the range, and the reason. Compressed into a value-plus-suffix, all three would have been lost.

## Confirms the second #543 prediction

Predicted curatable on the grounds that a bioanode implies an electrochemical cell. It holds: the biofilms were **established and maintained**, not sampled from the aquifer. Two of three "likely curatable" predictions now verified, after two verified refusals.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; snippet verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Advances #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)