### PR TITLE
Sampling is the origin, sub-culturing is the cultivation (#183, #543)

### DIFF
--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -190,6 +190,51 @@ ecological_interactions:
       conjugal transfer genes found in the same genus, likely belonging to
       another plasmid, evidence of intra-plasmid competition
     explanation: Supports the CRISPR-spacer-based plasmid competition.
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    The consortium was sampled from packed bioleaching column SC3 at the Skouriotissa Mine in
+    Cyprus, then maintained in the laboratory: incubated at 28 °C without agitation and
+    sub-cultured ten times at 5% inoculum every two months in MAM with 0.25 g of unsterilised
+    research-grade chalcopyrite. It was then split and sub-cultured onto chalcocite as well as
+    chalcopyrite, since the mineral is the variable the study is about.
+  notes: >-
+    The mineral is in the setup rather than only among environmental factors because it is
+    the substrate the community is grown on and the experimental variable at once - the whole
+    question is how mineral type drives composition. It is also deliberately unsterilised,
+    which is a choice about what the community is allowed to encounter.
+
+    Static, and worth recording for the same reason as the thermophilic cellulose and TCE
+    records: a mineral-attached acidophile consortium is grown on a settled solid surface, so
+    "without agitation" is a design decision rather than an omission.
+
+    No `system_type` or `working_volume`. The source names neither the vessel nor the fill for
+    the sub-cultures; the packed column it came from is the field source, not the laboratory
+    setup, and recording it would describe where the community was found rather than how it
+    was grown.
+
+    Third of the three "likely curatable" predictions in #543, and it holds - but only just.
+    The community originates in a column at a mine, which is exactly the shape that made
+    Avena_Rhizosphere unenrichable. What separates them is that this one was then carried into
+    the laboratory and propagated for ten passages; the sampling is the origin, the
+    sub-culturing is the cultivation.
+  evidence:
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Before the experiment, the microbial enrichment was incubated at 28°C without agitation
+      and sub‐cultured 10 times with a 5% inoculum every 2 months in MAM with 0.25 g unsterilized
+      research grade chalcopyrite
+    explanation: Temperature, static operation, transfer regime, medium and mineral substrate.
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: microbial consortia from a copper bioleaching column in Cyprus were cultivated on
+      chalcopyrite (CuFeS2) and then sub‐cultured on chalcocite (Cu2S) and chalcopyrite
+    explanation: The community was cultivated in the laboratory, and the mineral was varied.
+
 environmental_factors:
 - name: Mineral substrate
   value: chalcopyrite (CuFeS2) and chalcocite (Cu2S)


### PR DESCRIPTION
## What

`Cyprus_Copper_Sulphide_Bioleaching_Consortium` — sampled from packed bioleaching column SC3 at the Skouriotissa Mine, then maintained at **28 °C without agitation** and sub-cultured **ten times at 5% inoculum every two months** in MAM with 0.25 g of unsterilised chalcopyrite, before being split onto chalcocite as well.

## The mineral is part of the setup

It is the growth **substrate** and the experimental **variable** at once — the study exists to ask how mineral type drives composition. It is also deliberately **unsterilised**, which is a choice about what the community is allowed to encounter, not an oversight.

## Static, again on purpose

Same reasoning as the thermophilic cellulose (#537) and TCE (#541) records: a mineral-attached acidophile consortium grows on a settled solid surface, so "without agitation" is a design decision. Recorded rather than dropped, because a missing agitation field reads as an omission.

## What is not recorded

No `system_type` or `working_volume` — the source names neither for the sub-cultures. The packed column is the **field source**, not the laboratory setup; recording it would describe where the community was found rather than how it was grown.

## The closest call in #543 so far

This completes the three "likely curatable" predictions. It is also the one that nearly went the other way: the community originates **in a column at a mine**, which is precisely the shape that made `Avena_Rhizosphere` unenrichable.

What separates them is a single fact — this one was carried into the laboratory and propagated for ten passages. **Sampling is the origin; sub-culturing is the cultivation.** A record whose paper only describes the first has nothing for this slot.

## #543 scorecard

Five of thirteen candidates now verified by reading: **2 refused** (`Avena_Rhizosphere`, `OMM12`), **1 partial** (`Cheese_Rind`, in vitro arm only), **3 curated** (`Acetylene_Fueled`, `Rifle_Aquifer`, this one). The predicted classification has held on every one checked.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Advances #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)