### PR TITLE
My #543 prediction was wrong, and that is the useful part (#183, #543)

### DIFF
--- a/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
+++ b/kb/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.yaml
@@ -190,6 +190,51 @@ ecological_interactions:
       conjugal transfer genes found in the same genus, likely belonging to
       another plasmid, evidence of intra-plasmid competition
     explanation: Supports the CRISPR-spacer-based plasmid competition.
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    The consortium was sampled from packed bioleaching column SC3 at the Skouriotissa Mine in
+    Cyprus, then maintained in the laboratory: incubated at 28 °C without agitation and
+    sub-cultured ten times at 5% inoculum every two months in MAM with 0.25 g of unsterilised
+    research-grade chalcopyrite. It was then split and sub-cultured onto chalcocite as well as
+    chalcopyrite, since the mineral is the variable the study is about.
+  notes: >-
+    The mineral is in the setup rather than only among environmental factors because it is
+    the substrate the community is grown on and the experimental variable at once - the whole
+    question is how mineral type drives composition. It is also deliberately unsterilised,
+    which is a choice about what the community is allowed to encounter.
+
+    Static, and worth recording for the same reason as the thermophilic cellulose and TCE
+    records: a mineral-attached acidophile consortium is grown on a settled solid surface, so
+    "without agitation" is a design decision rather than an omission.
+
+    No `system_type` or `working_volume`. The source names neither the vessel nor the fill for
+    the sub-cultures; the packed column it came from is the field source, not the laboratory
+    setup, and recording it would describe where the community was found rather than how it
+    was grown.
+
+    Third of the three "likely curatable" predictions in #543, and it holds - but only just.
+    The community originates in a column at a mine, which is exactly the shape that made
+    Avena_Rhizosphere unenrichable. What separates them is that this one was then carried into
+    the laboratory and propagated for ten passages; the sampling is the origin, the
+    sub-culturing is the cultivation.
+  evidence:
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Before the experiment, the microbial enrichment was incubated at 28°C without agitation
+      and sub‐cultured 10 times with a 5% inoculum every 2 months in MAM with 0.25 g unsterilized
+      research grade chalcopyrite
+    explanation: Temperature, static operation, transfer regime, medium and mineral substrate.
+  - reference: PMID:41381092
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: microbial consortia from a copper bioleaching column in Cyprus were cultivated on
+      chalcopyrite (CuFeS2) and then sub‐cultured on chalcocite (Cu2S) and chalcopyrite
+    explanation: The community was cultivated in the laboratory, and the mineral was varied.
+
 environmental_factors:
 - name: Mineral substrate
   value: chalcopyrite (CuFeS2) and chalcocite (Cu2S)

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -566,6 +566,45 @@ ecological_interactions:
     snippet: To unravel the underlying metabolic interactions, flux balance analysis was used to model
       microbial growth and identify potential metabolic exchanges involved in shaping the microbial communities
     explanation: Supports metabolite exchange interactions in community assembly
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 30.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Serial-dilution passaging of the ten-member community in liquid culture. Each strain was
+    grown alone for 48 h, normalised to the lowest OD600 in that medium, then equal volumes
+    were mixed so the starting inoculum held all ten at roughly equal concentration.
+    Triplicate cultures were incubated 48 h at 30 °C with shaking at 200 rpm and passaged
+    every 48 h at 1:10 into fresh medium.
+  notes: >-
+    Two media were run in parallel, R2A and MOPS, because the study's question is whether the
+    same ten strains form different stable communities in different environments. Recording
+    one would misrepresent the design, so both are named here rather than a single
+    growth_media entry standing in for them.
+
+    No `system_type` or `working_volume`. The 10 mL test tubes named in the source are for the
+    individual seed cultures; the source does not say what the community passages were run in,
+    and carrying the seed-culture vessel across would be the preculture error (#529).
+
+    Predicted a likely refusal in #543, on the assumption that a plant-associated SynCom lives
+    on the plant. That was wrong: this community was assembled and passaged in liquid medium
+    and never put on a Populus root in this study. Recorded because the prediction failing is
+    the useful part - the remaining candidates there need the same reading rather than
+    inheriting the guess.
+  evidence:
+  - reference: PMID:33995895
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Equal volumes of the normalized culture were mixed together, and the community was
+      transferred into fresh medium using a 1:10 dilution
+    explanation: The community itself was passaged, not just its members.
+  - reference: PMID:33995895
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Triplicate cultures, for both media, were incubated for 48 h at 30 °C with shaking
+      at 200 rpm
+    explanation: Temperature, agitation and the 48 h passage interval, for the community cultures.
+
 environmental_factors:
 - name: Growth medium context
   value: two media environments


### PR DESCRIPTION
## What

`ORNL_PMI_Populus_PD10_SynCom` — the ten-member community was **assembled and passaged in liquid medium**: each strain grown alone for 48 h, normalised to the lowest OD₆₀₀ in that medium, equal volumes mixed so all ten started at roughly equal concentration, then triplicate cultures incubated 48 h at 30 °C with shaking at 200 rpm and passaged every 48 h at 1:10.

## The prediction it falsifies

I classified this one **"likely refuse"** in #543, reasoning that a plant-associated SynCom lives on the plant. It does not, in this study — it never touches a *Populus* root here.

That was a guess dressed as a classification, and it took one grep to falsify.

**This matters more than the record.** #543 lists five "likely refuse" candidates resting on that same single inference — *plant-associated ⇒ grown on a plant* — and one of the five has now failed. The remaining four need reading rather than inheriting the guess, which is precisely the point that issue was filed to make about automated ranking. The correction is the same lesson applied to my own shortcut: **a plausible rule over record names is still a rule over record names.**

Running tally after six of thirteen read: 2 refused, 1 partial, 4 curated — and the only wrong call was the one made without reading.

## Two curation notes

**Both media are named**, not one. The study asks whether the same ten strains form *different* stable communities in R2A versus MOPS, so recording a single medium would misrepresent the design.

**No `system_type` or `working_volume`.** The 10 mL test tubes in the source are the individual **seed cultures**; the paper does not say what the community passages ran in. Carrying the seed vessel across would be the preculture error (#529) — the same one avoided in six other records this batch.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Corrects #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)