### PR TITLE
The medium is the experiment, and the guess fails twice (#183, #543)

### DIFF
--- a/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
+++ b/kb/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.yaml
@@ -326,6 +326,43 @@ growth_media:
       at 28°C in the dark
     explanation: Plate format, plug size, temperature and light regime for the assay.
 
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    The fungus as an 8 mm plug and B. altitudinis B4 at 50 μL of OD600 0.4, co-cultured in
+    P20 liquid medium made without thiamine, alongside single-partner treatments as controls.
+    Plate work ran at 28 °C in the dark.
+  notes: >-
+    The medium is the experiment. P20 without thiamine is what makes S. clintonianus - a
+    thiamine auxotroph - dependent on the bacterium, so recording the medium without the
+    omission would describe a system in which the interaction cannot be observed. This is the
+    same shape as the fumarate deliberately excluded from the syntrophy record: a single
+    component decides whether the partnership is necessary.
+
+    No `system_type` or `working_volume`: the source gives neither for the co-culture, and
+    both the liquid co-culture and the 60 mm plate assays appear, so one vessel value would
+    misdescribe half the work.
+
+    Predicted a likely refusal in #543 on the assumption that a plant-associated SynCom lives
+    on the plant. Wrong again, and differently: the two partners are co-cultured in liquid,
+    with the plant absent. Second of the five in that group to fail, which is why the
+    remaining three are not being classified without reading.
+  evidence:
+  - reference: PMID:41454778
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: clintonianus (8 mm) and B. altitudinis B4 (50 μL, OD600 = 0.4) were co-cultured in
+      P20 liquid medium (without thiamine)
+    explanation: The two members were grown together, in a medium lacking the vitamin at issue.
+  - reference: PMID:41454778
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Fungal plugs (8 mm) were placed in the center of the plate (60 mm) and incubated at
+      28°C in the dark
+    explanation: Temperature and light regime for the plate assays.
+
 environmental_factors:
 - name: Thiamine limitation of the fungal partner
   value: fungus cannot effectively obtain or synthesize thiamine


### PR DESCRIPTION
## What

`Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom` — the fungus as an 8 mm plug and *B. altitudinis* B4 at 50 μL of OD₆₀₀ 0.4, **co-cultured in P20 liquid medium made without thiamine**, with single-partner treatments as controls. Plate assays at 28 °C in the dark.

## The omission is the experiment

*S. clintonianus* is a **thiamine auxotroph**. A medium lacking thiamine is what makes it dependent on the bacterium. Recording "P20" without "without thiamine" would describe a system in which the interaction cannot be observed at all.

Same shape as the fumarate deliberately kept out of the syntrophy record (#539): one component decides whether the partnership is necessary, so getting it wrong doesn't just misstate a condition — it describes a different experiment.

No `system_type` or `working_volume`: the source gives neither for the co-culture, and both liquid co-culture and 60 mm plate assays appear, so one vessel value would misdescribe half the work.

## Second failure of the #543 "likely refuse" group

I predicted this a refusal on the assumption that a plant-associated SynCom lives on the plant. Wrong again — and **differently** from the first failure, which is the informative part:

- `ORNL_PMI_Populus_PD10_SynCom` was assembled and passaged in liquid and never met a plant.
- Here the two partners **are** co-cultured in liquid, with the plant simply absent from the assay.

Two readings, two falsifications. The remaining three in that group (`Lotus_LjSC3`, `PSY_Transgenic_Rice`, `hCom2`) are not being classified without reading either.

My first pass on this paper also nearly got it wrong in the other direction: the visible methods are all exudate collection and **supernatant transfer**, which reads as a design where the partners never meet. The co-culture is stated once, in a single sentence about "the combined system". A keyword sweep for "co-culture" found it; a summary of the methods would not have.

## Running tally on #543

Seven of thirteen candidates read: **2 refused, 1 partial, 5 curated.** Every wrong call so far has been a prediction made without reading, and every one has been corrected by reading a single sentence.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Corrects #543 again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)