### PR TITLE
hCom2 is built in vitro before it ever sees a mouse (#183, #543)

### DIFF
--- a/docs/communities/hCom2_Complex_Gut_Microbiome.html
+++ b/docs/communities/hCom2_Complex_Gut_Microbiome.html
@@ -655,7 +655,7 @@
                         
 
                         
-                        <p class="snippet">"All culturing was done in an anaerobic chamber (Coy Laboratories) at 10% CO 2 , 5% H 2 , and 85% N 2 atmosphere."</p>
+                        <p class="snippet">"All culturing was done in an anaerobic chamber (Coy Laboratories) at 10% CO2, 5% H2, and 85% N2 atmosphere."</p>
                         
                     </div>
                     

--- a/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
+++ b/kb/communities/hCom2_Complex_Gut_Microbiome.yaml
@@ -60,6 +60,55 @@ ecological_interactions:
   scope: COMMUNITY_LEVEL
   evidence:
   - *id001
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  working_volume: 4.0
+  working_volume_unit: mL
+  instrument_detail: >-
+    Built up through deep-well plates: strains revived from frozen 96-well stocks into 1 mL in
+    2.2 mL 96-well plates, diluted 1:10 every 24 h for two days, then 1:10 into 4 mL in 5 mL
+    48-well plates. All culturing inside a Coy anaerobic chamber at 10% CO2 / 5% H2 / 85% N2.
+    Communities were then propagated for 48 h per passage with DNA taken at 0, 12, 24 and 48 h.
+    Member strains are maintained in Mega Medium, Chopped Meat Medium, or both; community
+    experiments also ran in a complete defined medium and in versions with single amino acids
+    removed.
+  notes: >-
+    `system_type` is OTHER because the format is a deep-well plate, which the enum has no
+    value for; FLASK or a reactor type would assert a containment this does not have. The
+    plate sizes are in instrument_detail instead.
+
+    No `operating_temperature`: the source gives the chamber's gas mix but not its
+    temperature, and a gut-community chamber is not necessarily at 37 °C by assumption.
+
+    The amino-acid dropout media are named because they are the experiment: strains change
+    relative abundance by orders of magnitude when a single amino acid is removed, so
+    "defined medium" alone would describe a condition the study exists to vary.
+
+    Third failure of the "likely refuse" group in #543, predicted on the assumption that a
+    gut community lives in a mouse. hCom2 is used in gnotobiotic mice, but this paper builds
+    and propagates it in vitro first - which is what OMM12 does not do, and why that one was
+    correctly refused. Three of five in that group have now failed; the reasoning behind it
+    should be treated as discarded rather than partly true.
+  evidence:
+  - reference: PMID:36070752
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: constructing and propagating the 104-member community multiple times in vitro
+    explanation: The community itself was built and grown in vitro, not only in a host.
+  - reference: PMID:36070752
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We propagated the communities for 48 h and extracted DNA for sequencing at 0, 12, 24,
+      and 48 h
+    explanation: The passage length and sampling schedule.
+  - reference: PMID:36070752
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We found that each of our 104 strains can be propagated in Mega Medium (MM), Chopped
+      Meat Medium (CMM), or both
+    explanation: The media the members are maintained in.
+
 environmental_factors:
 - name: gnotobiotic fecal challenge
   value: Germ-free mice colonized with hCom1 were challenged with a human fecal sample to identify additional
@@ -211,8 +260,8 @@ growth_media:
   - reference: PMID:36070752
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: All culturing was done in an anaerobic chamber (Coy Laboratories) at 10%
-      CO 2 , 5% H 2 , and 85% N 2 atmosphere.
+    snippet: All culturing was done in an anaerobic chamber (Coy Laboratories) at 10% CO2,
+      5% H2, and 85% N2 atmosphere.
     explanation: Supports the anaerobic atmosphere and headspace gas composition used
       for cultivation.
   - reference: PMID:36070752


### PR DESCRIPTION
## What

`hCom2_Complex_Gut_Microbiome` — strains revived from frozen 96-well stocks into 1 mL in 2.2 mL deep-well plates, diluted 1:10 every 24 h for two days, then 1:10 into 4 mL in 5 mL 48-well plates, all inside a Coy anaerobic chamber at 10% CO₂ / 5% H₂ / 85% N₂, with communities then propagated 48 h per passage and DNA taken at 0, 12, 24, 48 h.

## Third failure of the #543 "likely refuse" group

I predicted this a refusal on the assumption that a gut community lives in a mouse. hCom2 **is** used in gnotobiotic mice — but this paper builds and propagates the 104-member community **in vitro first**, which is exactly what OMM12 does *not* do and why that one was correctly refused.

Three of five in that group have now failed on reading. The reasoning behind it should be treated as **discarded, not partly true**.

## Curation calls

- **The amino-acid dropout media are named**, because they are the experiment: strains move by orders of magnitude in relative abundance when a single amino acid is removed, so "defined medium" alone would describe a condition the study exists to vary.
- **`system_type` is `OTHER`** — a deep-well plate has no enum value, and `FLASK` or a reactor type would assert a containment it does not have.
- **No `operating_temperature`** — the source gives the chamber's gas mix but not its setpoint, and a gut-community chamber is not 37 °C by assumption.

## Also clears a failure already on `main`

This record had a reference-validation error before this PR. Its existing snippet wrote the chamber gas mix with subscript spacing — `CO 2`, `H2 ,` — where the cached text renders it closed up.

Same artefact class as the `MPOB T` fix in #539. The corpus sweep run then did **not** catch it, because that scan matched a strain-designation pattern, not chemical formulae — worth noting, since it means the earlier "isolated, no sweep needed" conclusion was true only for the pattern it tested.

## Checks

- `just validate` — no issues
- `just validate-references` — **0 issues** (was 1)
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2375 passed, 16 skipped

Part of #183. Corrects #543 a third time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)