### PR TITLE
The grain is the inoculum and the structure at once (#183, #543)

### DIFF
--- a/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
+++ b/kb/communities/BioModels_MODEL2204300001_Kefir_Community_Model.yaml
@@ -498,6 +498,48 @@ external_resources:
       reproducibility/verification of the underlying BioModels record. Partial
       because the paper addresses the BioModels collection as a whole rather than
       this specific kefir entry.
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 25.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Pasteurised cow milk at 3.5% fat, inoculated with 60 g of kefir grains per litre, held at
+    25 °C without shaking for 48 h - the paper's stated aim being to match traditional home
+    fermentation rather than to optimise it. Grains are strained out at the end, washed, and
+    used to inoculate the next culture, so the community is propagated by serial transfer of
+    the grain itself. A 90 h fermentation was used for the community-dynamics and -omics runs.
+  notes: >-
+    The grain is the inoculum and the structure at once. Passaging the community *without*
+    the grain changes its composition within a few transfers, so "60 g of grains per litre"
+    is not a dosing detail - it is what makes the community reproducible, and the reason this
+    record exists as a stability model.
+
+    Static, and stated as such. As with the thermophilic cellulose and bioleaching records, a
+    matrix-attached community is grown undisturbed on purpose.
+
+    No `system_type` or `working_volume`: the source gives a ratio and scales it ("or scaled
+    accordingly for lower volumes"), so no single vessel or fill is the experiment's.
+
+    Predicted "possibly in silico" in #543, on the strength of the BioModels identifier in the
+    record name. Wrong: the cited paper is experimental, and the model is downstream of the
+    fermentations described here. That is the fourth of five #543 predictions to fail, all of
+    them made from record names rather than sources.
+  evidence:
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Fermentation was initiated by adding 60 g of kefir grains for one liter milk (or
+      scaled accordingly for lower volumes). The process was carried at the 25 ˚C and without
+      shaking for 48 h
+    explanation: Inoculum ratio, temperature, static operation and duration for the community.
+  - reference: PMID:33398099
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Kefir grains were collected at the end by straining through a heat sterilized
+      household mesh strainer, washed using double distilled water and subsequently used to
+      inoculate new cultures
+    explanation: The community is propagated by serial transfer of the grain.
+
 growth_media:
 - name: UHT-pasteurized cow milk (3.5% fat)
   temperature: '25'


### PR DESCRIPTION
## What

`BioModels_MODEL2204300001_Kefir_Community_Model` — pasteurised cow milk at 3.5% fat, **60 g of kefir grains per litre**, 25 °C **without shaking** for 48 h, grains strained out at the end and reused to inoculate the next culture. 90 h was used for the community-dynamics and -omics runs.

## Why the grain ratio is a setting, not a dosing detail

Passaging the community **without** the grain changes its composition within a few transfers. The grain is the inoculum and the physical structure at once — it is what makes the community reproducible, and the reason this record exists as a *stability* model.

No `system_type` or `working_volume`: the source gives a ratio and explicitly scales it ("or scaled accordingly for lower volumes"), so no single vessel or fill is the experiment's.

## Fourth of five #543 predictions to fail

I guessed **"possibly in silico"** from the BioModels identifier in the record name. The cited paper is experimental; the model is downstream of these fermentations.

Every wrong call in #543 has now come from reading a **record name** instead of a **source** — 4 of 5. The one prediction that held (`Lotus_LjSC3`) held for a reason I only confirmed by reading too.

## `Lotus_LjSC3` read and refused

Its strains are grown separately in liquid culture, combined to OD₆₀₀ 1, diluted to 0.02, and flushed into **FlowPots with plants**. That is inoculum preparation, not community cultivation — the community exists *in planta*, as with OMM12.

## #543 now fully read

All 13 candidates: **3 refused** (`Avena_Rhizosphere`, `OMM12`, `Lotus_LjSC3`), **1 partial** (`Cheese_Rind`, in vitro arm only), **9 curated**. One remains unexamined (`PSY_Transgenic_Rice`) — its cache is 140 KB and the visible text is author affiliations, so it needs a proper read rather than a keyword pass.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183. Advances #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)