### PR TITLE
Two of the five role-less rhizobial taxa, where the record already says (#497)

### DIFF
--- a/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
+++ b/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
@@ -505,6 +505,12 @@
                         </td>
                         <td>
                             
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">CROSS_FEEDER</span>
+                                
+                            </div>
+                            
                         </td>
                         <td>N/A</td>
                     </tr>
@@ -1016,7 +1022,7 @@
             id: "NCBITaxon:68287",
             label: "Mesorhizobium sp. TaiHu (MesTH)",
             abundance: "UNKNOWN",
-            roles: []
+            roles: ["CROSS_FEEDER"]
         };
         
         taxonData["Pseudomonas sp. TaiHu (PseTH)"] = {

--- a/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
+++ b/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
@@ -520,6 +520,12 @@
                         </td>
                         <td>
                             
+                            <div class="roles-list">
+                                
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
+                                
+                            </div>
+                            
                         </td>
                         <td>N/A</td>
                     </tr>
@@ -845,7 +851,7 @@
             id: "NCBITaxon:374",
             label: "Bradyrhizobium PHNZY-24-6",
             abundance: "UNKNOWN",
-            roles: []
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Aspergillus flavus"] = {

--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -94,6 +94,8 @@ taxonomy:
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
     notes: The persistent partner and the proposed vitamin B12 source. Grounded at genus level —
       the isolate is designated only "sp. TaiHu", with no species assignment.
+  functional_role:
+  - CROSS_FEEDER
   evidence:
   - reference: PMID:41790499
     supports: SUPPORT

--- a/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
+++ b/kb/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.yaml
@@ -153,6 +153,8 @@ taxonomy:
       the community must not antagonise. The counter-selection that excluded Bradyrhizobium-
       antagonising candidates is recorded under engineering_design, not as an interaction — see the
       note there.
+  functional_role:
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:42099455
     supports: SUPPORT


### PR DESCRIPTION
## What

#497 suggests starting with the five rhizobial taxa carrying **no** `functional_role`, since adding one cannot contradict an existing claim. **Two of the five have a role stated in the record. Three do not, and stay empty.**

## Assigned

**`Bradyrhizobium PHNZY-24-6`** (`SynCom_ARC_Peanut_Aflatoxin_Nodulation`) → `NITROGEN_FIXING_SYMBIONT`. Its own notes call it *"the nitrogen-fixing symbiont whose compatibility constrained community assembly, and whose nodulation ARC is designed to induce."* Nodulation **and** N fixation both stated — the #301 standard applied, not inferred from the genus.

**`Mesorhizobium sp. TaiHu (MesTH)`** → `CROSS_FEEDER`, **not** the N-fixing role. It is the vitamin B12 source for a B12-auxotrophic *Synechococcus*, with B12 synthesis and transport genes upregulated.

That second one is the point of #497 in miniature: being a *Mesorhizobium* is exactly the inference the issue warns against. What this organism does *in this consortium* is feed a partner a vitamin.

## Left empty on purpose

- **`Rhizobium sp. OAE497`** and **`Bradyrhizobium sp. OAE829`** (`EcoFAB_Ring_Trial_SynCom17`) — a reproducibility ring trial whose claims are about inter-laboratory consistency, not about what any member does.
- **`Mesorhizobium sp. (putative nodulator)`** — "putative" is the record declining to assert it.

Assigning a role to any of these would be reading the genus, not the source.

## An insertion bug worth recording

The first attempt anchored on the first `evidence:` key following the strain name. For MesTH that key is inside **`engineering_design`** — the name appears in that prose *before* it appears in `taxonomy`. `linkml-validate` caught it immediately as an unexpected property on the wrong class:

```
Additional properties are not allowed ('functional_role' was unexpected) in /engineering_design
```

Anchored on the taxonomy entry's own line instead, and verified by re-parsing both records and printing the roles from the `taxonomy` list rather than trusting the edit.

## Checks

- `just validate` on both records — no issues
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Advances #497 (5 role-less → 3, and those 3 documented as deliberate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)