### PR TITLE
Four nodule rhizobia were recorded as carbon fixers (#497)

### DIFF
--- a/docs/communities/Lotus_LjSC3.html
+++ b/docs/communities/Lotus_LjSC3.html
@@ -450,7 +450,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_PRODUCER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -492,7 +492,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_PRODUCER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -534,7 +534,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_PRODUCER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -1800,21 +1800,21 @@
             id: "NCBITaxon:68287",
             label: "Mesorhizobium sp. LjNodule210",
             abundance: "DOMINANT",
-            roles: ["PRIMARY_PRODUCER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Mesorhizobium sp. LjNodule215"] = {
             id: "NCBITaxon:68287",
             label: "Mesorhizobium sp. LjNodule215",
             abundance: "COMMON",
-            roles: ["PRIMARY_PRODUCER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Mesorhizobium sp. LjNodule218"] = {
             id: "NCBITaxon:68287",
             label: "Mesorhizobium sp. LjNodule218",
             abundance: "COMMON",
-            roles: ["PRIMARY_PRODUCER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Phyllobacteriaceae bacterium"] = {

--- a/docs/communities/Soybean_N_Fixation_sfSynCom.html
+++ b/docs/communities/Soybean_N_Fixation_sfSynCom.html
@@ -450,7 +450,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_PRODUCER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -1430,7 +1430,7 @@
             id: "NCBITaxon:29448",
             label: "Bradyrhizobium elkanii BXYD3",
             abundance: "DOMINANT",
-            roles: ["PRIMARY_PRODUCER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Pantoea sp. helper strain 1"] = {

--- a/kb/communities/Lotus_LjSC3.yaml
+++ b/kb/communities/Lotus_LjSC3.yaml
@@ -60,7 +60,7 @@ taxonomy:
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: DOMINANT
   functional_role:
-  - PRIMARY_PRODUCER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:34312531
     supports: SUPPORT
@@ -86,7 +86,7 @@ taxonomy:
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
-  - PRIMARY_PRODUCER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:34312531
     supports: SUPPORT
@@ -112,7 +112,7 @@ taxonomy:
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 7 GTDB taxa under the NCBI taxon]
   abundance_level: COMMON
   functional_role:
-  - PRIMARY_PRODUCER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:34312531
     supports: SUPPORT

--- a/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
+++ b/kb/communities/Soybean_N_Fixation_sfSynCom.yaml
@@ -55,7 +55,7 @@ taxonomy:
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: DOMINANT
   functional_role:
-  - PRIMARY_PRODUCER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - reference: PMID:40052412
     supports: SUPPORT


### PR DESCRIPTION
## The defect

`PRIMARY_PRODUCER` is defined in the schema as **"Fixes carbon (autotroph)"**.

A rhizobium in a legume nodule fixes **nitrogen** and *consumes* plant photosynthate. So the value was not imprecise — it was the opposite of what the organism does.

This is precisely the substitution #301 named: before `NITROGEN_FIXING_SYMBIONT` existed, `PRIMARY_PRODUCER` was the nearest available thing to "fixes something".

## The four

| record | taxon |
|---|---|
| `Soybean_N_Fixation_sfSynCom` | `Bradyrhizobium elkanii BXYD3` |
| `Lotus_LjSC3` | `Mesorhizobium sp. LjNodule210` / `215` / `218` |

**Both records state the symbiosis in their own descriptions**, so this is the #301 standard applied rather than a genus inference:

- `Soybean_N_Fixation_sfSynCom` calls BXYD3 *"the core nitrogen-fixing symbiont"*.
- `Lotus_LjSC3` says the community includes *"nitrogen-fixing symbionts from Rhizobiaceae and Phyllobacteriaceae"*, and its three *Mesorhizobium* isolates are named **LjNodule**210/215/218 — nodule-derived, and *Mesorhizobium* is Phyllobacteriaceae.

## Different from the previous pass

#558 **added** roles to taxa that had none, where the issue notes an addition cannot contradict an existing claim. These four **replace** an existing value, which is a stronger action — so each was verified by re-parsing the record and printing the role from the `taxonomy` list rather than trusting the edit.

That is the same check that caught the `engineering_design` mis-insertion in #558, where an anchor matched prose above the taxonomy block.

## Checks

- `just validate` on both records — no issues
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Advances #497 — the four clearest `PRIMARY_PRODUCER` substitutions. The remaining 13 carry `PRIMARY_DEGRADER`, `CROSS_FEEDER` or `SYNTROPHIC_PARTNER`, where the issue is explicit that degradation or cross-feeding may genuinely be what was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)