### PR TITLE
The last rhizobial carbon-fixer (#497)

### DIFF
--- a/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
+++ b/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
@@ -491,7 +491,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_PRODUCER</span>
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -775,7 +775,7 @@
             id: "NCBITaxon:374",
             label: "Bradyrhizobium",
             abundance: "UNKNOWN",
-            roles: ["PRIMARY_PRODUCER"]
+            roles: ["NITROGEN_FIXING_SYMBIONT"]
         };
         
 

--- a/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
+++ b/kb/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.yaml
@@ -69,7 +69,7 @@ taxonomy:
       is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25) [grounded at g__ rank; 3 GTDB taxa under the NCBI taxon]
   functional_role:
-  - PRIMARY_PRODUCER
+  - NITROGEN_FIXING_SYMBIONT
   evidence:
   - *id001
 ecological_interactions:


### PR DESCRIPTION
## What

`Soybean_Chlorophyll_Selected_Biofertilizer_SynCom`'s `Bradyrhizobium` carried `PRIMARY_PRODUCER` — *"Fixes carbon (autotroph)"* — which is wrong for a rhizosphere *Bradyrhizobium* under any reading.

## The record states the right role itself

> "Recurrent host-mediated selection favored **nodulating** Bradyrhizobium"

and the community is described as engineered *"to improve nodulation and biomass"*.

**Nodulating** is the record's own word. That matters here more than usual: for soybean it would be very easy to reach the same answer the wrong way — *Bradyrhizobium* nodulates soybean, so the genus alone "gives" the answer. That is exactly the inference #497 warns against, and it is not the one used.

## The sweep is clean

A corpus sweep now returns **zero** rhizobial taxa carrying `PRIMARY_PRODUCER`. That is the fifth and last of the substitutions this class covers.

## Why the remaining 12 are not the same

They carry `PRIMARY_DEGRADER`, `CROSS_FEEDER` or `SYNTROPHIC_PARTNER`. Unlike carbon fixation, **these are things a rhizobium can genuinely do** — and #497 says so directly, naming `Rhizobium radiobacter` (not a nodulating N fixer), the Panzhihua tailings isolates, and the mCAFEs *Bradyrhizobium* as cases where the existing role may be right.

So the remaining work is a record-by-record read against each cited source, not a sweep. No further mechanical pass is available here.

## Checks

- `just validate` — no issues
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped
- Verified by re-parsing the record and printing the role from `taxonomy`, not by trusting the edit

Advances #497: 5 role-less → 3 documented, 5 `PRIMARY_PRODUCER` substitutions fixed, 12 remaining that need reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)