### PR TITLE
A nematode antagonist was filed as a degrader (#497)

### DIFF
--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -450,7 +450,7 @@
                             
                             <div class="roles-list">
                                 
-                                <span class="role-badge">PRIMARY_DEGRADER</span>
+                                <span class="role-badge">PATHOGEN_ANTAGONIST</span>
                                 
                             </div>
                             
@@ -1145,7 +1145,7 @@
             id: "NCBITaxon:648995",
             label: "Rhizobium pusense TYQ1",
             abundance: "DOMINANT",
-            roles: ["PRIMARY_DEGRADER"]
+            roles: ["PATHOGEN_ANTAGONIST"]
         };
         
         taxonData["Sphingomonas panni SP"] = {

--- a/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
+++ b/kb/communities/TYQ1_Nematode_Biocontrol_SynCom.yaml
@@ -65,7 +65,7 @@ taxonomy:
     strain_name: TYQ1
     isolation_source: Cucumber rhizosphere under RKN stress
   functional_role:
-  - PRIMARY_DEGRADER
+  - PATHOGEN_ANTAGONIST
   abundance_level: DOMINANT
   evidence:
   - reference: PMID:41660888


### PR DESCRIPTION
## The fix

`Rhizobium pusense TYQ1` carried `PRIMARY_DEGRADER` — *"Degrades complex substrates"*. Its own notes say it **"directly inhibits root-knot nematodes and coordinates biofilm formation"**, and its evidence: **"This strain not only directly inhibited RKNs"**.

That is biocontrol, and `PATHOGEN_ANTAGONIST` exists for it.

**The enum's own description names this exact substitution:**

> `PATHOGEN_ANTAGONIST`: … the role that was missing when #298 reached for `PRIMARY_DEGRADER` instead

So this is the documented pattern, found again — and in a record #497's survey had grouped with the `PRIMARY_DEGRADER` cases where degradation *"may genuinely be what was measured"*. Reading it was the only way to tell.

## One confirmed correct, and left alone

`mCAFEs_Brachypodium_RCC`'s `Bradyrhizobium` is `CROSS_FEEDER` and its notes say it is enriched under asparagine — consistent, so it stays. #497 guessed this one right.

## One filed rather than fixed (#561)

`Rhizobium radiobacter F2` carries `PRIMARY_DEGRADER` while the record describes it **twice** as a bioflocculant **producer** secreting EPS to aggregate algal cells. Nothing there degrades anything.

But no `FunctionalRoleEnum` value covers EPS or matrix production either, so correcting it means **minting a term, removing the role, or defending the current one** — #301's shape again, needing a survey rather than a guess. #561 lays out the three options and recommends one.

That is the honest boundary of this pass: I fixed what the record told me, and filed what the schema could not express.

## Checks

- `just validate` — no issues
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped
- Verified by re-parsing and printing the role from `taxonomy`

Advances #497: 3 of the 12 read — 1 fixed, 1 confirmed, 1 escalated to #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)