### PR TITLE
Three tailings rhizobia that nodulate, per their own notes (#497)

### DIFF
--- a/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
+++ b/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
@@ -454,6 +454,8 @@
                                 
                                 <span class="role-badge">SYNTROPHIC_PARTNER</span>
                                 
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
+                                
                             </div>
                             
                         </td>
@@ -509,6 +511,8 @@
                                 
                                 <span class="role-badge">CROSS_FEEDER</span>
                                 
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
+                                
                             </div>
                             
                         </td>
@@ -561,6 +565,8 @@
                             <div class="roles-list">
                                 
                                 <span class="role-badge">PRIMARY_DEGRADER</span>
+                                
+                                <span class="role-badge">NITROGEN_FIXING_SYMBIONT</span>
                                 
                             </div>
                             
@@ -1722,21 +1728,21 @@
             id: "NCBITaxon:280333",
             label: "Bradyrhizobium pachyrhizi",
             abundance: "ABUNDANT",
-            roles: ["PRIMARY_DEGRADER", "SYNTROPHIC_PARTNER"]
+            roles: ["PRIMARY_DEGRADER", "SYNTROPHIC_PARTNER", "NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Rhizobium selenitireducens"] = {
             id: "NCBITaxon:1336235",
             label: "Rhizobium selenitireducens",
             abundance: "COMMON",
-            roles: ["PRIMARY_DEGRADER", "CROSS_FEEDER"]
+            roles: ["PRIMARY_DEGRADER", "CROSS_FEEDER", "NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Rhizobium pisi"] = {
             id: "NCBITaxon:574561",
             label: "Rhizobium pisi",
             abundance: "RARE",
-            roles: ["PRIMARY_DEGRADER"]
+            roles: ["PRIMARY_DEGRADER", "NITROGEN_FIXING_SYMBIONT"]
         };
         
         taxonData["Bacillus species"] = {

--- a/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
+++ b/kb/communities/Panzhihua_Vanadium_Titanium_Tailings.yaml
@@ -70,6 +70,7 @@ taxonomy:
   functional_role:
   - PRIMARY_DEGRADER
   - SYNTROPHIC_PARTNER
+  - NITROGEN_FIXING_SYMBIONT
   abundance_level: ABUNDANT
   abundance_value: Dominant rhizobial genus; 12 isolates from P. pinnata nodules; strain PP1 most abundant
   evidence:
@@ -107,6 +108,7 @@ taxonomy:
   functional_role:
   - PRIMARY_DEGRADER
   - CROSS_FEEDER
+  - NITROGEN_FIXING_SYMBIONT
   abundance_level: COMMON
   abundance_value: Three isolates from P. pinnata nodules
   evidence:
@@ -140,6 +142,7 @@ taxonomy:
       '
   functional_role:
   - PRIMARY_DEGRADER
+  - NITROGEN_FIXING_SYMBIONT
   abundance_level: RARE
   abundance_value: One isolate from P. pinnata nodules
   evidence:


### PR DESCRIPTION
## What

The three rhizobia in `Panzhihua_Vanadium_Titanium_Tailings` gain `NITROGEN_FIXING_SYMBIONT` **alongside** the roles they already carry. Their own notes state both halves of the #301 standard:

- **`Bradyrhizobium pachyrhizi`** — *"Nitrogen-fixing alphaproteobacterium that forms **root nodule symbioses** with legumes"*
- **`Rhizobium selenitireducens`** — *"Nitrogen-fixing alphaproteobacterium … isolated from P. pinnata **root nodules**"*
- **`Rhizobium pisi`** — *"Fast-growing **nitrogen-fixing** rhizobium … adapted to form **nodules** with P. pinnata"*

## Added, not replaced

That is what #497 prescribes when the existing role is *also* supported — and here it plainly is. These are mine-tailings isolates, and selenium reduction and heavy-metal tolerance are exactly the degradation and cross-feeding their other roles record.

**Nodulating and degrading are not alternatives.** The result:

```
Bradyrhizobium pachyrhizi    PRIMARY_DEGRADER, SYNTROPHIC_PARTNER, NITROGEN_FIXING_SYMBIONT
Rhizobium selenitireducens   PRIMARY_DEGRADER, CROSS_FEEDER,       NITROGEN_FIXING_SYMBIONT
Rhizobium pisi               PRIMARY_DEGRADER,                     NITROGEN_FIXING_SYMBIONT
```

#497 predicted this record as one where *"degradation and cross-feeding may genuinely be what was measured"*. That was **right, and incomplete** — the roles were not wrong, they were missing one.

## Four read and left alone

All consistent with their records: `Bradyrhizobium japonicum` as `CROSS_FEEDER` in a straw-humification pair; `Sinorhizobium sp.` as `SYNTROPHIC_PARTNER` where the evidence says chitin *"requires the coordinated action of several microorganisms"*; `Sinorhizobium meliloti MSC1_014` as `PRIMARY_DEGRADER` in a chitin-decomposition consortium; and ORNL's `Rhizobium sp. CF142` as `CROSS_FEEDER`.

The last three have **empty notes**, so the support is the record's framing rather than a per-taxon statement. Thin, but not contradicted — recorded that way rather than presented as verified.

## Checks

- `just validate` — no issues
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped
- Verified by re-parsing and printing the roles from `taxonomy`

Advances #497: all 22 taxa now read. 3 added, 6 corrected, 1 escalated to #561, 12 confirmed as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)