### PR TITLE
First of #183's abstract-only tier (#183)

### DIFF
--- a/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
+++ b/kb/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.yaml
@@ -243,6 +243,46 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: most Geobacter cells were attached to the electrode
     explanation: Supports G. sulfurreducens localization on the electrode.
+cultivation_setup:
+- cultivation_mode: FED_BATCH
+  system_type: MICROBIAL_FUEL_CELL
+  instrument_detail: >-
+    Two-chamber microbial fuel cells run fed-batch, with ferricyanide as the catholyte and
+    cellulose as the sole substrate. The coculture reached 143 mW/m2 of anode area on
+    carboxymethyl cellulose and 59.2 mW/m2 on MN301 cellulose.
+  electrode_detail: >-
+    Ferricyanide catholyte in the second chamber. No applied potential is recorded: the cell
+    is operated as a fuel cell producing power, not poised at a setpoint, so the electrode is
+    described by its chemistry rather than a voltage.
+  notes: >-
+    The two-chamber format is part of the claim rather than incidental. Neither organism
+    alone produces current from cellulose - C. cellulolyticum ferments it but is not
+    electroactive, G. sulfurreducens is electroactive but cannot use cellulose - so the anode
+    chamber is where the division of labour is made visible.
+
+    No temperature, working volume or medium composition. This is abstract-only: the cached
+    entry is 2.6 KB and the methods are not in it. Recorded as far as the evidence goes, as
+    with the infant HMO record, rather than left empty because it is incomplete.
+
+    From #183's abstract-only tier, which is what remains after the 13 full-text candidates
+    in #543 were read. The yield is thinner per record and the fields left empty are the
+    normal case, not the exception.
+  evidence:
+  - reference: PMID:17695929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: In fed-batch tests using two-chamber MFCs with ferricyanide as the catholyte, the
+      coculture achieved maximum power densities of 143 mW/ m2 (anode area) and 59.2 mW/m2 from
+      1 g/L carboxymethyl cellulose (CMC) and MN301 cellulose, respectively
+    explanation: Feeding regime, vessel, catholyte and the substrate the coculture ran on.
+  - reference: PMID:17695929
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Electricity was generated from cellulose in an MFC using a defined coculture of the
+      cellulolytic fermenter Clostridium cellulolyticum and the electrochemically active Geobacter
+      sulfurreducens
+    explanation: The conditions are the coculture's, and names both members (#529).
+
 environmental_factors:
 - name: Cellulose substrate
   value: carboxymethyl cellulose or MN301 cellulose


### PR DESCRIPTION
## What

`Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture` — two-chamber microbial fuel cells run **fed-batch**, ferricyanide catholyte, cellulose as the sole substrate. 143 mW/m² of anode area on carboxymethyl cellulose, 59.2 mW/m² on MN301.

## The two-chamber format is part of the claim

Neither organism alone produces current from cellulose — *C. cellulolyticum* ferments it but is not electroactive; *G. sulfurreducens* is electroactive but cannot use cellulose. The anode chamber is where the division of labour becomes visible, which is why it is in `instrument_detail` rather than left as background.

**No `applied_potential`:** the cell *produces* power rather than being poised at a setpoint, so the electrode is described by its chemistry. Same call as the Rifle aquifer record (#547), opposite reason — there the poise was a range, here there is no poise at all.

## This is the abstract-only tier, and it looks different

No temperature, working volume, or medium composition, because the cached entry is **2.6 KB** and the methods are not in it.

That is the shape of what remains. After the 13 full-text candidates in #543 were read, #183's remainder is **173 `ENGINEERED` records whose sources are abstract-only**. Empty fields are the *normal case* here, not the exception — so each record's `notes` say which fields are absent and why, rather than leaving a reader to wonder whether the curator simply stopped early.

The #529 check still passes on the wording: the supporting snippet names both members and calls it *"a defined coculture"*.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)