### PR TITLE
Two temperatures, one for each organism (#183)

### DIFF
--- a/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.yaml
@@ -224,6 +224,41 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: high butanol production correlates with low hydrogen production
     explanation: Supports the proposed hydrogen-butanol relationship in the same species-pair coculture.
+cultivation_setup:
+- cultivation_mode: BATCH
+  instrument_detail: >-
+    Sequential, two-temperature batch. C. thermocellum is incubated with 4% Avicel crystalline
+    cellulose for at least 24 h at 60 °C; strain N1-4 is then added and the coculture held at
+    30 °C, with butanol peaking at 7.9 g/L after 9 days. Acetone was undetectable.
+  notes: >-
+    `operating_temperature` is deliberately unset. There is no single one: 60 °C is where the
+    thermophile hydrolyses the cellulose, 30 °C is where the mesophile ferments the sugars,
+    and recording either would describe a system in which one of the two members cannot work.
+    The pair of temperatures is the design, not a range to be averaged - the same reasoning
+    as the ramped retention time and the swept dilution rate elsewhere in this sweep, but
+    sharper, because here the two values belong to different organisms.
+
+    The 24 h head start is part of it too: the partners are not co-inoculated. Cellulose must
+    already be hydrolysed before the butanol producer arrives, which is why this is a
+    sequential coculture rather than a simultaneous one.
+
+    No vessel, working volume, agitation or medium composition - abstract-only, and the
+    cached entry is 2.1 KB. What is here is unusually specific for that tier because the
+    abstract reports the schedule as a result.
+  evidence:
+  - reference: PMID:21764954
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Butanol was produced from Avicel cellulose after it was incubated with C. thermocellum
+      for at least 24 h at 60°C before the addition of strain N1-4
+    explanation: The thermophilic hydrolysis stage, its temperature, and the sequential inoculation.
+  - reference: PMID:21764954
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Butanol produced by strain N1-4 on 4% Avicel cellulose peaked (7.9 g/liter) after 9
+      days of incubation at 30°C
+    explanation: The mesophilic fermentation stage, its temperature, duration and substrate loading.
+
 environmental_factors:
 - name: Crystalline cellulose substrate
   value: 4% Avicel cellulose


### PR DESCRIPTION
## What

`Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture` runs **sequentially at two temperatures**:

1. *C. thermocellum* hydrolyses 4% Avicel crystalline cellulose for ≥ 24 h at **60 °C**
2. Strain N1-4 is then added and the coculture held at **30 °C**, butanol peaking at 7.9 g/L after 9 days

## `operating_temperature` is unset, and this is the sharpest case for it yet

There is no single temperature. **60 °C is where the thermophile works; 30 °C is where the mesophile does.** Recording either would describe a system in which one of the two members cannot function.

Earlier records in this sweep left a temperature or rate unset because it was *ramped* (the thiocyanate retention time) or *swept* (the Caldicellulosiruptor dilution rate) — different phases of one run. Here the two values belong to **different organisms**, so the pair isn't a range to average; it's the design.

## The head start is part of the setup

The partners are **not co-inoculated**. Cellulose must already be hydrolysed before the butanol producer arrives — that 24 h is what makes this a *sequential* coculture rather than a simultaneous one, and it is in `instrument_detail` for that reason.

## Tier note

No vessel, working volume, agitation or medium composition — abstract-only, 2.1 KB cached. What *is* here is unusually specific because the abstract reports the schedule **as a result** rather than in a methods section.

That is now twice in three records from this tier where the useful detail came from RESULTS. Worth noting as a search heuristic for whoever continues: in abstract-only sources, the conditions worth having tend to be the ones the authors considered findings.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)