### PR TITLE
The inoculation ratio is a designed parameter (#183)

### DIFF
--- a/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
+++ b/kb/communities/PET_Artificial_FourSpecies_Degradation_Consortium.yaml
@@ -298,6 +298,45 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: obtaining a four-species microbial consortium
     explanation: Supports medium choice as a way to stabilize the four-member consortium.
+cultivation_setup:
+- cultivation_mode: BATCH
+  working_volume: 20.0
+  working_volume_unit: mL
+  instrument_detail: >-
+    20 mL of Wn medium with 2 μg/mL erythromycin, at ambient temperature, with a PET film as
+    the substrate. The four members go in at a fixed ratio - Bs_PETase : Bs_MHETase :
+    R. jostii : P. putida of 3 : 1 : 10 : 1e-5 - which the source reports as the optimum. The
+    four-species consortium reached 23.2% weight loss of the PET film.
+  notes: >-
+    The inoculation ratio is recorded because it is a designed parameter, not a starting
+    condition that happened to be used: it was optimised, and the P. putida share is 1e-5,
+    six orders of magnitude below R. jostii. A consortium assembled at equal ratios would be
+    a different system.
+
+    Erythromycin is in the setup rather than among environmental factors because it maintains
+    the engineered B. subtilis modules; it is part of what keeps the consortium the
+    consortium.
+
+    No `operating_temperature`: the source says "ambient temperature" and gives no figure, and
+    turning that into a number would invent precision - the same call as "room temperature" in
+    the cheese-rind record. The 37 °C and 30 °C the source does give belong to the strains
+    grown separately beforehand, at two different temperatures, so neither is the community's
+    (#529).
+
+    No `system_type`: the vessel is never named.
+  evidence:
+  - reference: PMID:35003008
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The consortium was inoculated into 20 mL W n medium with 2 μg/mL erythromycin
+    explanation: Working volume, medium and the selection antibiotic, stated for the consortium.
+  - reference: PMID:35003008
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: With the four-species consortium, the weight loss of PET film reached 23.2% under
+      ambient temperature.
+    explanation: The temperature regime as the source states it, and the substrate.
+
 environmental_factors:
 - name: PET film substrate
   value: amorphous PET film, 0.25 mm thickness, cut and UV-treated before degradation assays


### PR DESCRIPTION
## What

`PET_Artificial_FourSpecies_Degradation_Consortium` — 20 mL Wn medium with 2 μg/mL erythromycin, ambient temperature, PET film as substrate. Members inoculated at **Bs_PETase : Bs_MHETase : *R. jostii* : *P. putida* = 3 : 1 : 10 : 1×10⁻⁵**. The four-species consortium reached 23.2% weight loss of the film.

## Why the ratio is in the setup

It was **optimised**, not merely used — and the *P. putida* share is **1×10⁻⁵**, six orders of magnitude below *R. jostii*. A consortium assembled at equal ratios would be a different system, so omitting the ratio would describe one.

**Erythromycin** sits here rather than among environmental factors because it maintains the engineered *B. subtilis* modules. It is part of what keeps the consortium the consortium.

## No `operating_temperature`

The source says **"ambient temperature"** and gives no figure. Turning that into a number would invent precision — the same call as "room temperature" in the cheese-rind record (#545).

The 37 °C and 30 °C it *does* give belong to the strains grown separately beforehand, **at two different temperatures**. So there isn't even a single preculture value to be tempted by — which is a cleaner instance of #529 than usual, since the mistake would have required picking one of two wrong numbers.

Also no `system_type`: the vessel is never named.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)