### PR TITLE
The medium is solid on purpose (#183)

### DIFF
--- a/kb/communities/MSC1_Dominant_Core.yaml
+++ b/kb/communities/MSC1_Dominant_Core.yaml
@@ -589,6 +589,44 @@ ecological_interactions:
     snippet: Several soil consortia were derived that had tractable richness (30-50 OTUs) with diverse
       phyla representative of the native soil, including Actinobacteria, Bacteroidetes, Firmicutes, Proteobacteria,
       and Verrucomicrobia
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  operating_temperature: 20.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Chitin/soil extract agar plates at 20 °C, with colonies re-plated onto the same medium
+    until enough biomass was available. Chitin is the primary carbon and nitrogen substrate,
+    chosen because it is complex enough that no single species performs every step. MSC-1
+    interactions were then studied both by pairwise co-cultivation in liquid media and by
+    growth in soil.
+  notes: >-
+    The medium is solid on purpose, and the source says why: it "helped to retain some
+    physical structure needed to allow for spatial interactions between species". That is a
+    design decision about what kind of community can form, not a convenience - a shaken
+    liquid culture would have selected differently. Recorded because a reader seeing only
+    "agar" would take it for the default.
+
+    `system_type` is OTHER: an agar-plate consortium has no enum value, and FLASK or a reactor
+    type would assert a liquid culture this is not. Same call as the cheese-rind record.
+
+    The Mason-jar step - 100 g of sieved field soil with 0 to 100 ppm powdered chitin - is the
+    enrichment the isolates came from, not the consortium's own cultivation. Same distinction
+    as the Cyprus bioleaching column: sampling is the origin, plating is the cultivation.
+  evidence:
+  - reference: PMID:32983014
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: To collect isolates for model soil consortium-1 (MSC-1), the community was plated onto
+      chitin/soil extract agar and incubated at 20°C
+    explanation: Medium and temperature for the consortium itself.
+  - reference: PMID:32983014
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The solid medium helped to retain some physical structure needed to allow for spatial
+      interactions between species
+    explanation: Why the medium is solid — a design choice about which interactions can occur.
+
 environmental_factors:
 - name: Source environment
   value: arid grassland soil


### PR DESCRIPTION
## What

`MSC1_Dominant_Core` — chitin/soil extract agar plates at 20 °C, colonies re-plated onto the same medium until enough biomass accumulated. Chitin is the primary carbon **and** nitrogen substrate, chosen because it is complex enough that no single species performs every step.

## The source says why the medium is solid

> The solid medium helped to retain some **physical structure needed to allow for spatial interactions** between species

That is a design decision about *what kind of community can form*, not a convenience — a shaken liquid culture would have selected differently. Recorded because a reader seeing only "agar" would take it for the default.

`system_type` is `OTHER`: an agar-plate consortium has no enum value, and `FLASK` or a reactor type would assert a liquid culture this is not. Same call as the cheese-rind record (#545).

## Origin vs cultivation, again

The Mason-jar step — 100 g of sieved field soil with 0–100 ppm powdered chitin — is the **enrichment the isolates came from**, not the consortium's own cultivation. Same distinction as the Cyprus bioleaching column (#548): sampling is the origin, plating is the cultivation.

## A correction to my own framing

I had been describing #183's remainder as "the abstract-only tier", having restricted my candidate scan to `ecological_state: ENGINEERED`. Widening it surfaces **50 candidates**, many with substantial full-text caches — this one is 55 KB.

So the abstract-only tier was **not** the frontier; my filter was. The last several rounds were harder than they needed to be for that reason, and the remaining work is larger and more tractable than I reported.

That said, several of the top-scoring new candidates (AMD, East River, Drought Rhizosphere, Soil Corrinoid) look like #529 refusals — field communities that were never cultured — so the 50 is not 50 records of work.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)