### PR TITLE
The medium is B12-free on purpose (#183)

### DIFF
--- a/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
+++ b/kb/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.yaml
@@ -264,6 +264,52 @@ growth_media:
       cultured in LB medium. Both MesTH and Syn7002 were then washed with vitamin B12-free BG11
     explanation: Names the medium and the wash that sets up the B12-limited co-culture.
 
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Both partners washed into vitamin-B12-free BG11, then combined as 50 mL of algal
+    suspension with an equal volume of MesTH. Run 20 days, sampled at 0, 1, 5, 10 and 20 days,
+    with growth followed by absorbance every 2 days. The cyanobacterium's own conditions are
+    28 °C under 70 µmol m-2 s-1 with shaking at 180 rpm.
+  notes: >-
+    The medium is B12-free on purpose and that is the entire experiment. Syn7002 lacks the
+    B12 biosynthesis cluster, so a B12-free BG11 is what forces it to depend on MesTH; the
+    paper's control group is the same alga with B12 added at 4 µg/L. Recording "BG11" without
+    the omission would describe a condition in which the mutualism is unnecessary - the same
+    shape as the thiamine-free P20 in the Suillus record and the fumarate excluded from the
+    syntrophy record.
+
+    Equal volumes rather than a ratio, and 20 days rather than a single timepoint, are
+    recorded because the study is about how the interaction develops.
+
+    The 28 °C, light intensity and shaking are given for Syn7002 rather than for the
+    consortium. Carried over here because the coculture is the same alga in the same medium
+    base, and flagged rather than presented as directly stated (#529). MesTH's own LB
+    cultivation is a preculture and is not recorded.
+
+    No `system_type` or `working_volume` for the coculture: 50 mL plus 50 mL is what was
+    combined, not a stated vessel fill.
+  evidence:
+  - reference: PMID:41790499
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Both MesTH and Syn7002 were then washed with vitamin B12-free BG11
+    explanation: The B12-free medium that makes the alga dependent on its partner.
+  - reference: PMID:41790499
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The Syn7002+MesTH group involved combining 50 ml of the algal suspension with an equal
+      volume of MesTH
+    explanation: How the consortium was assembled, and in what proportion.
+  - reference: PMID:41790499
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: was cultivated in vitamin B12-supplemented BG11 medium at 28 °C under a light intensity
+      of 70 µmol m−2 s−1 with shaking at 180 r
+    explanation: Temperature, light and shaking — stated for Syn7002, carried over with that noted.
+
 environmental_factors:
 - name: Vitamin B12-positive control supplementation
   description: >


### PR DESCRIPTION
## What

`Mesorhizobium_Synechococcus_B12_Synthetic_Consortium` — both partners washed into **vitamin-B12-free BG11**, combined as 50 mL of algal suspension with an equal volume of MesTH, run 20 days with sampling at 0, 1, 5, 10, 20 days.

## The omission is the experiment

Syn7002 **lacks the B12 biosynthesis cluster**, so a B12-free medium is what forces it to depend on MesTH — and the paper's control group is the same alga with B12 added at 4 µg/L.

Recording "BG11" without the omission would describe a condition in which the mutualism is **unnecessary**. That is the third instance of this shape in the sweep, after the thiamine-free P20 in the Suillus record (#550) and the fumarate kept out of the syntrophy record (#539). It seems to be the single most common way a growth medium can be recorded wrongly: by naming what is in it.

## One honest carry-over

The 28 °C, 70 µmol m⁻² s⁻¹ and 180 rpm are stated **for Syn7002**, not for the consortium. I carried them over — the coculture is the same alga in the same medium base — but flagged them in `notes` as carried rather than stated.

That is the #529 question answered in the middle rather than either way: refusing them would discard the only conditions available, and presenting them as the consortium's would overstate the source. MesTH's own LB cultivation *is* a preculture and is not recorded.

## Also this round: one refusal

`Chlorella_Keystone_Taxa_Antifungal_SynCom` read and **refused**. Its strains are cultured individually in R2A, washed, combined into a spore stock, and applied to strawberry and tomato in a greenhouse. The community is never grown *as a community* — same shape as `Lotus_LjSC3`.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; all three snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)