### PR TITLE
Static, because the pellicle is the community (#183)

### DIFF
--- a/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
+++ b/kb/communities/Kombucha_KMC_IMBG1_Fermentation_Community.yaml
@@ -166,6 +166,41 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: bacterial core component in nsBTS remained the same
     explanation: Supports a relatively stable bacterial core despite growth-condition changes.
+cultivation_setup:
+- cultivation_mode: BATCH
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Filter-sterilised black tea extract (Lipton, 1.2% w/v) with sucrose at 3.0% w/v, cultivated
+    14 days at 28 °C without shaking to obtain a matured KMC-IMBG1. The study then grows the
+    same community across different microenvironments to see how composition responds.
+  notes: >-
+    Static, and central rather than incidental: kombucha forms a floating cellulose pellicle at
+    the air-liquid interface, so an unshaken culture is what allows the community to structure
+    itself. Shaking it would not be the same community.
+
+    The tea is both medium and substrate. Recording only "black tea" would lose the sucrose,
+    which is the carbon the acetobacteria and yeasts actually ferment - the tea supplies the
+    matrix and the minor nutrients.
+
+    No `system_type` or `working_volume`: the source names neither, and for an open-vessel
+    fermentation defined by its air-liquid interface a vessel enum would say little anyway.
+
+    This is one of only six records in the KB whose source states that the *community* was
+    cultivated rather than its members - which for kombucha is unsurprising, since it has no
+    members to grow separately.
+  evidence:
+  - reference: PMID:26061774
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A matured KMC-IMBG1 was obtained after cultivation for 14 days at 28°C without shaking
+    explanation: Duration, temperature and static operation for the community itself.
+  - reference: PMID:26061774
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: black tea (Lipton, 1.2%, w/v) extract with sucrose (3.0%, w/v)
+    explanation: The medium, and the sucrose that is the fermentable carbon.
+
 environmental_factors:
 - name: sweetened black tea substrate
   value: black tea extract with sucrose


### PR DESCRIPTION
## What

`Kombucha_KMC_IMBG1_Fermentation_Community` — filter-sterilised black tea extract (Lipton, 1.2% w/v) with sucrose at 3.0% w/v, **14 days at 28 °C without shaking**.

## Static is central, not incidental

Kombucha forms a floating **cellulose pellicle at the air–liquid interface**. An unshaken culture is what lets the community structure itself; shaking it would not produce the same community.

This is the third record in the sweep where "without agitation" is a design choice — after the thermophilic cellulose coculture (#537) and the bioleaching consortium (#548) — but the first where the structure being preserved is one **the community builds itself** rather than one supplied to it.

## The tea is medium and matrix

Recording only "black tea" would lose the **sucrose**, which is the carbon the acetobacteria and yeasts actually ferment. The tea supplies the matrix and the minor nutrients.

No `system_type` or `working_volume`: neither is named, and for an open-vessel fermentation defined by its air–liquid interface a vessel enum would say little anyway.

## Why this one was findable

It is one of only **six** records in the KB whose source states that the *community* was cultivated rather than its members. For kombucha that is unsurprising — it has no members to grow separately.

Which is exactly why that scan returns so few: most records here describe **assembling** a community from strains each grown alone. That is the structural reason #529 keeps firing, and it bounds how much of #183 is tractable at all.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; both snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)