### PR TITLE
A panel's conditions, labelled as a panel's (#183, #573)

### DIFF
--- a/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
+++ b/kb/communities/Mars_Meteorite_EETA79001_Growth_Panel.yaml
@@ -199,6 +199,37 @@ growth_media:
       at 25 °C
     explanation: Names the medium, duration and temperature for the bacterial preculture.
 
+cultivation_setup:
+- cultivation_mode: BATCH
+  instrument_detail: >-
+    Sawdust of Mars meteorite EETA79001 wetted at regolith:water ratios from 4:1 to 1:10, held
+    up to 23 days under terrestrial conditions. The regolith is the substrate and the variable
+    at once - the question is whether real martian material supports growth at all, and at
+    what water content.
+  notes: >-
+    Recorded for the panel, and the distinction matters. This record is a four-member *panel*,
+    not a co-culture: its own description calls it that, its members were tested for growth
+    separately, and it carries zero ecological_interactions. So these are conditions under
+    which each member was grown on the same substrate, not conditions under which a community
+    was grown. Filed as #573, because a panel modelled as a community is a record-shape
+    question rather than a curation one.
+
+    No temperature: the source says "terrestrial conditions" without a figure, the same
+    situation as "ambient temperature" in the PET record and "room temperature" in the
+    cheese-rind one. No vessel or working volume either - the ratio is given by mass, and the
+    source scales it rather than fixing a volume.
+
+    The water ratio range is kept as a range for the reason ranges are kept elsewhere in this
+    sweep: 4:1 to 1:10 spans two orders of magnitude and is what the experiment varies, so a
+    single value would assert a condition that was never the point.
+  evidence:
+  - reference: PMID:38665180
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: for up to 23 days under terrestrial conditions using regolith:water ratios from 4:1
+      to 1:10
+    explanation: Duration, the stated temperature regime, and the water-content range varied.
+
 environmental_factors:
 - name: Actual martian regolith substrate (Mars meteorite EETA79001)
   value: EETA79001 meteorite sawdust


### PR DESCRIPTION
## What

`Mars_Meteorite_EETA79001_Growth_Panel` — EETA79001 meteorite sawdust wetted at **regolith:water ratios from 4:1 to 1:10**, up to 23 days under terrestrial conditions.

## The framing is the point

This record is a four-member **panel**, not a co-culture:

- its own description says *"tested for their ability to grow"*
- its members were assayed **separately**
- it carries **zero** `ecological_interactions`
- the source never uses "co-culture", "consortium" or "community" — not once in 55 KB

So these are conditions under which **each member was grown on the same substrate**, not conditions under which a community was grown. `notes` says that outright, rather than leaving the field to imply otherwise.

## Filed as #573, with the survey already run

A panel modelled as a community is a record-shape question, not one to settle inside a curation PR. #573 asks whether this is the only one; the answer is in a comment there:

| taxa | record | reading |
|---|---|---|
| 5 | `Early_Dental_Biofilm_FiveSpecies` | community, interactions uncurated |
| 4 | `Mars_Regolith_Cyanobacteria_Biofertilizer_Panel` | likely the same shape |
| 4 | `Mars_Meteorite_EETA79001_Growth_Panel` | this one |
| 4 | `Defined_Multispecies_Enamel_Caries_Model` | community, interactions uncurated |

**One confirmed, one likely, two probably just under-curated.** Small enough that keeping the framing explicit is proportionate and a schema flag is not — and the two biofilm records are a separate, cheaper opportunity: communities with no interactions recorded, which is ordinary curation rather than a modelling decision.

## Two fields left empty

- **No temperature** — "terrestrial conditions" with no figure, as with "ambient temperature" in the PET record (#567) and "room temperature" in the cheese-rind one (#545).
- **The water ratio stays a range** — 4:1 to 1:10 spans two orders of magnitude and is what the experiment varies, so a single value would assert a condition that was never the point.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; snippet verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183. Filed #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)