### PR TITLE
Hard agar is the whole result (#183)

### DIFF
--- a/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
+++ b/kb/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.yaml
@@ -205,6 +205,60 @@ ecological_interactions:
     evidence_source: IN_VITRO
     snippet: initiation of social spreading requires close association between the two species of bacteria
     explanation: Supports the contact/proximity dependence of the canonical pair.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  operating_temperature: 20.0
+  operating_temperature_unit: °C
+  instrument_detail: >-
+    Spots of each species placed on TSB-NK agar and incubated at 20 °C, monitored daily for
+    the point at which the two colonies touch and spreading begins. TSB-NK is 10%-strength
+    tryptic soy (3 g/L) with NaCl (5 g/L) and KH2PO4 (1 g/L), solidified with 2% agar.
+    Inocula were grown in 2 mL TSB-NK at 20 °C for 24 h with shaking at 160 rpm; assays ran
+    4 days.
+  notes: >-
+    The agar is hard on purpose and that is the entire result. At 2% agar neither species is
+    motile alone; the mixed colony spreads across the surface anyway, which is the emergent
+    phenotype the paper names "interspecies social spreading". A softer agar would permit
+    motility in monoculture and there would be nothing to observe.
+
+    Contact matters as much as composition: spreading initiates only once the two colonies
+    grow into each other, so the plates were monitored daily for that moment rather than run
+    to a fixed endpoint. Recorded because "4 days" alone would suggest a duration was chosen
+    rather than observed.
+
+    The salt amendments are part of the setup, not the recipe. The paper varies them - assays
+    with no salts, and with NaCl and KH2PO4 individually - to ask which affect spreading, so
+    "TSB" without them would describe a different assay.
+
+    `system_type` is OTHER: an agar-plate coculture has no enum value, as with the cheese-rind
+    and MSC1 records.
+
+    The 30 °C given for P. fluorescens is its routine growth temperature; both species and the
+    assays run at 20 °C (#529).
+  evidence:
+  - reference: PMID:30700513
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Our standard assay condition, TSB-NK, consists of 10% strength tryptic soy (3 g/liter)
+      supplemented with NaCl (5 g/liter) and KH2PO4 (1 g/liter)
+    explanation: The medium composition, including the salts the study varies.
+  - reference: PMID:30700513
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Once the inoculation liquid had dried, plates were incubated at 20°C and monitored daily
+      to determine the time at which colony growth led to contact between the isolates, and when
+      spreading phenotypes developed.
+    explanation: Temperature, and that contact between colonies is the observed trigger. From the
+      adjacent-plating assay, where the drops are placed near each other but not touching.
+  - reference: PMID:30700513
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: fluorescens Pf0-1 and Pedobacter on TSB-NK medium solidified with 2% agar, a mixed colony
+      of the two bacteria expanded across the surface of the agar, an environment in which neither
+      monoculture exhibited motility
+    explanation: The 2% agar, and that it is non-permissive for either species alone.
+
 environmental_factors:
 - name: low-nutrient high-salt hard agar
   value: TSB-NK medium with 2% agar, requiring low nutrient and high NaCl conditions for Pf0-1 plus V48 social spreading


### PR DESCRIPTION
## What

`Pseudomonas_Pedobacter_Social_Spreading_Coculture` — spots of each species on **TSB-NK agar at 20 °C**, monitored daily for the moment the two colonies touch and spreading begins. TSB-NK is 10%-strength tryptic soy (3 g/L) with NaCl (5 g/L) and KH₂PO₄ (1 g/L), solidified with **2% agar**. Inocula grown in 2 mL TSB-NK at 20 °C, 24 h, 160 rpm.

## The agar is hard on purpose

At 2% agar **neither species is motile alone** — and the mixed colony spreads across the surface anyway. That is the emergent phenotype the paper names *"interspecies social spreading"*. A softer agar would permit monoculture motility and there would be nothing to observe.

**Contact matters as much as composition:** spreading initiates only once the colonies grow into each other, so plates were monitored daily for that moment rather than run to a fixed endpoint. Recording "4 days" alone would imply a chosen duration rather than an observed one.

**The salts are setup, not recipe** — the paper runs assays without them, and with NaCl and KH₂PO₄ individually, to ask which affect spreading.

## An existing gate caught a real defect in my draft

`test_no_snippet_stops_mid_word` flagged a snippet ending `"spreading phenotypes develop"` where the source reads `"developed"`. I had copied a string truncated by my own 140-character search window.

**It passed `validate-references`**, because "develop" is a substring of "developed". Substring validation cannot see a truncation — which is precisely why #295 added that gate. Completed from the source, and the explanation now also names which of the paper's three assays the sentence belongs to.

Worth noting: this is the second time this session a gate written for an earlier issue caught something in new work. The first was the #529 member-coverage check firing on `main` after #530 and #547 merged.

## Checks

- `just validate` — no issues
- `just validate-references` — 0 issues; all three snippets verbatim
- `just validate-strict`, `just lint`, `just check-docs-current` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Part of #183. Second of the three records whose full text was fetched in #579's sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)