### PR TITLE
Record the three ways a condition passes every check and is wrong (#583)

### DIFF
--- a/.claude/skills/add-growth-conditions/SKILL.md
+++ b/.claude/skills/add-growth-conditions/SKILL.md
@@ -43,6 +43,37 @@ when the paper is **paywalled** (abstract-only) — make **no change** and say s
 Growth values in `growth_media` are strings (ranges allowed); `cultivation_setup`
 numerics are floats.
 
+## Three ways a condition can be wrong while every check passes
+
+These are the failure modes the #183 sweep actually hit, repeatedly. All three
+produce a block that is schema-valid, verbatim-sourced, and false. No validator
+catches any of them, so they have to be caught by reading.
+
+**1. The medium is defined by what it OMITS (#583 — five instances).** When a
+community's interactions turn on auxotrophy, vitamin exchange or a metabolic
+dependency, check whether the medium is defined by subtraction before writing
+down what it contains. Recording "P20 medium" where the source says "P20 without
+thiamine" describes a system in which the partnership is unnecessary — the
+auxotroph no longer needs its partner. Seen with thiamine-free P20, B12-free
+BG11, amino-acid-free M9, a non-permissive L1-Si, and a fumarate deliberately
+withheld from a syntrophic coculture. The inverse also occurs: a component listed
+for the *pure cultures* must not be carried into the coculture's medium.
+
+**2. The conditions belong to a MEMBER, not the community (#529).** A SynCom
+paper almost always describes growing its members; describing growing the
+*community* is a different sentence, and sometimes it does not exist because the
+community was only ever assembled in a host, on a plant, or as an inoculum. Check
+that the sentence carrying the numbers is about the community. Watch for
+precultures — a paper giving 37 °C for one strain and 30 °C for another has no
+single value to borrow.
+
+**3. A thin cache is not a thin source.** Before concluding a record cannot be
+enriched, run `uv run python scripts/cache_fulltext.py PMID:<id>`. In one sweep,
+six of thirteen attempts retrieved 60–150 KB of full text from caches of 1–3 KB,
+and two records already curated "as far as the abstract allows" turned out to
+have *wrong* values — a `BATCH` that was fed on days 2/3/4, and a `FLASK` that was
+a sealed serum bottle whose seal was the entire mechanism.
+
 ## Deep-research workflow (per record)
 
 1. Read the record; find its primary `reference` (a PMID/doi in the evidence).


### PR DESCRIPTION
## What

Adds a section to the `add-growth-conditions` skill, immediately after the cardinal rule.

That rule covers **inventing** values. It says nothing about the three ways a value can be sourced, verbatim, schema-valid and still false — which is what the #183 sweep kept hitting.

## The three

**1. The medium is defined by what it omits (#583).** Five instances: thiamine-free P20, B12-free BG11, amino-acid-free M9, a non-permissive L1-Si, and a fumarate deliberately withheld from a syntrophic coculture. Recording what the medium *contains* describes a system in which the interaction under study is unnecessary. The inverse also occurs — a component listed for the *pure cultures* must not be carried into the coculture's.

**2. The conditions belong to a member, not the community (#529).** A SynCom paper almost always describes growing its members; describing growing the *community* is a different sentence, and sometimes it does not exist. Four refusals in this sweep were exactly that.

**3. A thin cache is not a thin source.** Six of thirteen fetch attempts returned 60–150 KB from caches of 1–3 KB — and two records curated "as far as the abstract allows" turned out to have **wrong** values rather than missing ones: a `BATCH` that was fed on days 2/3/4, and a `FLASK` that was a sealed serum bottle whose seal was the entire mechanism.

## Option 2 from #583 was prototyped and dropped

The proposed heuristic — flag records with cross-feeding/syntrophy/mutualism interactions whose setup notes lack a negation — **fires on 36 of 49 records**, including every syngas and biomining consortium, whose media are unremarkable and whose interactions are real.

A check firing on three-quarters of its population would be ignored within a week, and its presence would imply coverage the problem does not admit. The five instances share a *biological* property, and biological properties are not reliably visible in the shape of a record — the same reason #529 has no mechanical test.

So the guidance goes where the mistake is made rather than into a gate that cannot see it.

## Checks

- `just lint` — exit 0
- `uv run pytest tests/` — 2422 passed, 16 skipped

Docs-only; path-filtered workflows may report no checks.

Advances #583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)