### PR TITLE
Stop calling two quote artefacts fabrication suspects (#596)

### DIFF
--- a/scripts/evidence_snippet_audit.py
+++ b/scripts/evidence_snippet_audit.py
@@ -11,11 +11,19 @@ abstract text), normalize whitespace, and classify:
                (e.g. record "10% CO 2" vs cached "10% CO2"): a faithful quote of
                the paper whose cache carries a PDF/XML extraction artefact. This
                is the class `just validate-references` reports as an error
+  ASSEMBLED  - every comma/semicolon-separated part is in the source but the
+               whole is not: cells joined from a table, or a quote welded from
+               two places. Supported content, but not a verbatim quote (#596)
   MISMATCH   - real abstract content exists but the snippet is absent (suspect)
   NOCONTENT  - cache missing or stub-only (no abstract body to verify against)
 
+Nearly all MISMATCH hits are a *retrieval* gap, not a curation one: 290 of 296
+in the #596 survey sat on an abstract-only cache while quoting Methods. Run
+`scripts/cache_fulltext.py` for the reference before reading a MISMATCH as a
+bad snippet.
+
 Usage: uv run python scripts/evidence_snippet_audit.py [--list-mismatch]
-       [--list-nocontent] [--list-rendering]
+       [--list-nocontent] [--list-rendering] [--list-assembled]
 """
 
 import difflib
@@ -33,6 +41,7 @@ CACHE = Path(__file__).resolve().parent.parent / "references_cache"
 LIST_MM = "--list-mismatch" in sys.argv
 LIST_NC = "--list-nocontent" in sys.argv
 LIST_RD = "--list-rendering" in sys.argv
+LIST_AS = "--list-assembled" in sys.argv
 
 # Sections that contain curated/paraphrased snippets, not the real abstract.
 # Stripping them prevents circular self-matching.
@@ -93,15 +102,63 @@ GREEK = {
 }
 
 
+# Typographic symbols a curator spells out when reading a rendered page, and
+# the letters they spell them with. Needed because `alnum` strips punctuation
+# but NOT letters: the cache's "(ATCC® 47054)" reduces to "atcc47054" while a
+# record's "(ATCC(R) 47054)" keeps the R and reduces to "atccr47054", so a
+# faithful quote lands in MISMATCH instead of RENDERING (#596). Mapping the
+# symbol to the same letters makes the two agree.
+SYMBOLS = {
+    "®": "r",
+    "™": "tm",
+    "©": "c",
+}
+
+
 def alnum(s: str) -> str:
-    """Lowercase, transliterate Greek, keep only [a-z0-9].
+    """Lowercase, transliterate Greek and typographic symbols, keep only [a-z0-9].
 
     Robust to punctuation/whitespace spacing and Greek-letter vs spelled-out
     differences (e.g. abstract "β-5" vs snippet "beta-5")."""
     s = s.lower()
     for g, name in GREEK.items():
         s = s.replace(g, name)
+    for symbol, spelled in SYMBOLS.items():
+        s = s.replace(symbol, spelled)
     return re.sub(r"[^a-z0-9]", "", s)
+
+
+# A snippet is "assembled" when every comma/semicolon-separated part of it is in
+# the source but the whole is not. Two real shapes produce this:
+#
+#   * cells joined from a table — OMM12 quotes "Lactobacillus reuteri I49,
+#     Enterococcus faecalis KB1, Blautia coccoides YL58", three non-adjacent rows
+#     of a strain table, each present verbatim;
+#   * a quote welded from two places — PET's "R. jostii was added to reduce the
+#     inhibition caused by terephthalic acid" takes the opening of one sentence
+#     and the tail of another 35KB away.
+#
+# Reported as its own bucket rather than folded into MATCH. The content is
+# supported and it is not a fabrication, but it is *not a verbatim quote*, and
+# a matcher loose enough to call it one would be loose enough to hide a real
+# mismatch — which is the failure this whole audit exists to prevent.
+_ASSEMBLED_MIN_PART = 12
+
+
+def assembled_parts(snippet: str, content: str) -> list[str] | None:
+    """The parts a non-matching snippet was assembled from, or None.
+
+    None when the snippet has no multi-part structure, or when any substantial
+    part is absent from the source — the latter stays a MISMATCH, since a
+    snippet with an unsupported clause is not merely reformatted.
+    """
+    parts = [p.strip() for p in re.split(r"[;,]", snippet) if len(p.strip()) >= _ASSEMBLED_MIN_PART]
+    if len(parts) < 2:
+        return None
+    haystack = alnum(content)
+    if not all(alnum(p) in haystack for p in parts):
+        return None
+    return parts
 
 
 def cache_text(reference: str) -> tuple[str, bool]:
@@ -182,6 +239,7 @@ def main() -> None:
     file_mismatch = defaultdict(list)
     file_nocontent = defaultdict(int)
     file_rendering = defaultdict(int)
+    file_assembled = defaultdict(list)
     cache_cache = {}
 
     for f in sorted(COMM.glob("*.yaml")):
@@ -222,6 +280,12 @@ def main() -> None:
                 else:
                     stats["RENDERING"] += 1
                     file_rendering[f.name] += 1
+            elif assembled_parts(snip, content) is not None:
+                # Every part is in the source; the join is not. Supported content,
+                # but not a verbatim quote — kept out of both MATCH and MISMATCH
+                # so it is neither blessed nor called a fabrication (#596).
+                stats["ASSEMBLED"] += 1
+                file_assembled[f.name].append((path, ref, snip[:70]))
             elif cov >= 0.6:
                 stats["WEAK"] += 1
                 file_mismatch[f.name].append((path, ref, round(cov, 2), snip[:70], "WEAK"))
@@ -231,7 +295,7 @@ def main() -> None:
 
     total = sum(stats.values())
     print(f"# {total} evidence snippets scanned across {len(list(COMM.glob('*.yaml')))} files")
-    for k in ("MATCH", "RENDERING", "WEAK", "MISMATCH", "NOCONTENT"):
+    for k in ("MATCH", "RENDERING", "ASSEMBLED", "WEAK", "MISMATCH", "NOCONTENT"):
         print(f"  {k:<10} {stats[k]}")
 
     print(
@@ -259,6 +323,13 @@ def main() -> None:
         print("\n# Top files by NOCONTENT (unverifiable; cache stub/missing)")
         for fn, n in sorted(file_nocontent.items(), key=lambda x: -x[1])[:30]:
             print(f"  {n:>2}  {fn}")
+
+    if LIST_AS:
+        print("\n# ASSEMBLED (every part is in the source; the join is not —")
+        print("# a table flattened into prose, or a quote welded from two places)")
+        for fn, rows in sorted(file_assembled.items(), key=lambda x: -len(x[1])):
+            for _path, ref, snip in rows:
+                print(f"  {fn} {ref}\n      {snip}...")
 
 
 if __name__ == "__main__":

--- a/tests/test_snippet_audit_artefact_classes.py
+++ b/tests/test_snippet_audit_artefact_classes.py
@@ -1,0 +1,168 @@
+"""Two artefact classes the audit used to call fabrication suspects (#596).
+
+The #596 survey of 296 MISMATCH snippets found that 290 were a *retrieval* gap —
+a Methods quote checked against an abstract-only cache — and only 6 were
+mismatches against a fully cached paper. Of those 6, only one was a genuine
+curation defect. The other five were the two shapes gated here.
+
+**1. A typographic symbol spelled out.** `alnum()` strips punctuation but not
+letters, so the cache's `(ATCC® 47054)` reduces to `atcc47054` while a record's
+`(ATCC(R) 47054)` keeps the R and reduces to `atccr47054`. A faithful quote of
+a registered trademark therefore looked like a fabrication.
+
+**2. A snippet assembled from parts.** OMM12 quotes
+
+    "Lactobacillus reuteri I49, Enterococcus faecalis KB1, Blautia coccoides YL58"
+
+which is three non-adjacent rows of a strain table, each present verbatim,
+joined with commas.
+
+**What is deliberately NOT rescued.** PET's
+
+    "R. jostii was added to reduce the inhibition caused by terephthalic acid"
+
+welds the opening of one sentence to the tail of another 35 KB away, and no
+single part of it appears in the paper. That is a paraphrase presented as a
+quote and it must stay a MISMATCH. A matcher loose enough to bless it would be
+loose enough to hide the defect this audit exists to find, so
+`test_a_stitched_paraphrase_is_still_a_mismatch` pins it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+REPO = pathlib.Path(__file__).parent.parent
+SCRIPT = REPO / "scripts/evidence_snippet_audit.py"
+
+
+@pytest.fixture(scope="module")
+def audit():
+    spec = importlib.util.spec_from_file_location("evidence_snippet_audit_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- 1. typographic symbols ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cached", "written"),
+    [
+        ("P. putida KT2440 (ATCC® 47054)", "P. putida KT2440 (ATCC(R) 47054)"),
+        ("BioBrick™ assembly", "BioBrick(TM) assembly"),
+        ("Somebody© 2019", "Somebody(C) 2019"),
+    ],
+)
+def test_a_spelled_out_symbol_matches_the_symbol(audit, cached, written):
+    """The real PET case and its siblings."""
+    assert audit.alnum(written) == audit.alnum(cached)
+
+
+def test_symbols_do_not_collapse_unrelated_text(audit):
+    """Guard: the mapping must not make different strings equal.
+
+    `®`→`r` is a character-level equivalence, but a mapping that over-reached
+    would silently turn mismatches into matches — the exact direction of error
+    this audit must never make.
+    """
+    assert audit.alnum("ATCC 47054") != audit.alnum("ATCC(R) 47054")
+    assert audit.alnum("strain R6") != audit.alnum("strain 6")
+
+
+def test_greek_transliteration_still_works(audit):
+    """The pre-existing behaviour the symbol change sits next to."""
+    assert audit.alnum("β-5") == audit.alnum("beta-5")
+
+
+# --- 2. assembled snippets -------------------------------------------------
+
+_STRAIN_TABLE = (
+    "Clostridium innocuum I46 DSM 26113 1 Bacteroides caecimuris I48 DSM 26085 1 "
+    "Lactobacillus reuteri I49 DSM 32035 1 Bifidobacterium longum subsp. animalis "
+    "YL2 DSM 26074 1 Muribaculum intestinale YL27 DSM 28989 2 Blautia coccoides "
+    "YL58 DSM 26115 1 Acutalibacter muris KB18 DSM 26090 2 Enterococcus faecalis "
+    "KB1 DSM 32036 1 Subsequently, 100 ul of each subculture was transferred"
+)
+
+
+def test_a_table_flattened_into_prose_is_assembled(audit):
+    """The real OMM12 case: three non-adjacent rows joined with commas."""
+    snippet = "Lactobacillus reuteri I49, Enterococcus faecalis KB1, Blautia coccoides YL58"
+
+    parts = audit.assembled_parts(snippet, _STRAIN_TABLE)
+
+    assert parts is not None, "the OMM12 table join was not recognised"
+    assert len(parts) == 3
+    assert audit.norm(snippet) not in audit.norm(_STRAIN_TABLE), (
+        "this fixture no longer exercises the case — the snippet matches "
+        "literally, so it would never reach the assembled check"
+    )
+
+
+def test_a_stitched_paraphrase_is_still_a_mismatch(audit):
+    """The one genuine defect among the six, which must NOT be rescued.
+
+    Both halves exist in the paper, far apart, but neither comma-part of the
+    snippet does — so it stays unclassified here and falls through to MISMATCH.
+    """
+    source = (
+        "Besides, the PET monomer TPA inhibited the degradation process. Therefore, "
+        "R. jostii was added to the existing consortium to break down TPA, leading to "
+        "a three-species microbial consortium with improved degradation efficiency. "
+        + "filler " * 200
+        + "a three-species microbial consortium was further obtained by adding R. "
+        "jostii to reduce the inhibition caused by terephthalic acid (TPA)."
+    )
+    snippet = "R. jostii was added to reduce the inhibition caused by terephthalic acid"
+
+    assert audit.assembled_parts(snippet, source) is None, (
+        "a paraphrase welded from two sentences was classified as merely "
+        "reformatted; that is the failure mode this audit exists to catch"
+    )
+
+
+def test_one_unsupported_part_keeps_the_whole_a_mismatch(audit):
+    """A snippet is only 'assembled' if EVERY part is real.
+
+    Otherwise a fabricated clause could ride along beside two genuine ones.
+    """
+    source = "Lactobacillus reuteri I49 DSM 32035 and Enterococcus faecalis KB1 DSM 32036"
+    snippet = "Lactobacillus reuteri I49, Enterococcus faecalis KB1, Nonexistent bacterium Q99"
+
+    assert audit.assembled_parts(snippet, source) is None
+
+
+def test_a_single_part_snippet_is_never_assembled(audit):
+    """No comma structure means nothing was assembled; it is just absent."""
+    assert audit.assembled_parts("a phrase that is simply not present", "unrelated text") is None
+    assert audit.assembled_parts("present text", "some present text here") is None
+
+
+def test_short_fragments_do_not_qualify_as_parts(audit):
+    """Parts under the floor are too short to be evidence of anything.
+
+    Without a floor, "E. coli, pH 7, 37 C" would be 'assembled' against almost
+    any microbiology paper.
+    """
+    source = "we grew E. coli at pH 7 and 37 C in rich medium"
+    assert audit.assembled_parts("E. coli, pH 7, 37 C", source) is None
+
+
+def test_the_corpus_classification_is_stable(audit):
+    """The buckets exist and the tool still runs over the real corpus."""
+    import subprocess
+
+    result = subprocess.run(
+        ["uv", "run", "python", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    assert result.returncode == 0, result.stderr
+    for bucket in ("MATCH", "RENDERING", "ASSEMBLED", "MISMATCH", "NOCONTENT"):
+        assert bucket in result.stdout, f"{bucket} missing from the summary"


### PR DESCRIPTION
Part of #596.

## Why

The #596 survey found that of 296 MISMATCH snippets, **290 were a retrieval gap** — a Methods quote checked against an abstract-only cache — and only **6** were mismatches against a fully cached paper. On inspection, five of those six were not curation defects either. This PR teaches the audit the two shapes they take, so the suspect count means something.

## 1. A typographic symbol spelled out

`alnum()` strips punctuation but **not letters**:

| | reduces to |
|---|---|
| cache `P. putida KT2440 (ATCC® 47054)` | `atcc47054` |
| record `P. putida KT2440 (ATCC(R) 47054)` | `atcc**r**47054` |

So a faithful quote of a registered trademark read as a fabrication. `®`/`™`/`©` now transliterate the way Greek letters already did. That snippet's coverage goes 0.03 → 1.0.

## 2. A snippet assembled from parts

OMM12 quotes:

> "Lactobacillus reuteri I49, Enterococcus faecalis KB1, Blautia coccoides YL58"

Those are three **non-adjacent rows of a strain table**, each present verbatim, joined with commas. New `ASSEMBLED` bucket: every comma/semicolon-separated part is in the source, the whole is not.

**Deliberately its own bucket, not folded into MATCH.** The content is supported and it is not a fabrication, but it is not a verbatim quote either — and a matcher loose enough to bless it would be loose enough to hide a real mismatch, which is the failure this audit exists to prevent.

## What is deliberately NOT rescued

PET's

> "R. jostii was added to reduce the inhibition caused by terephthalic acid"

welds the opening of one sentence to the tail of another 35 KB away, and no part of it appears in the paper. It stays a MISMATCH. `test_a_stitched_paraphrase_is_still_a_mismatch` pins that, so a future loosening of this code has to break a test that says why.

That snippet is the **one genuine curation defect** among the six — a paraphrase presented as a quote, the #347 class.

## Corpus effect

| bucket | before | after |
|---|---|---|
| MATCH | 4633 | 4633 |
| RENDERING | 68 | 69 |
| ASSEMBLED | — | 1 |
| MISMATCH | 190 | **188** |

Small, and that is the point: the two rescued snippets are the only ones in the corpus that were being misfiled this way. The value is that the classes now exist, so the next one lands in the right bucket instead of inflating a fabrication count.

## Also

The module docstring now records that a MISMATCH usually means the **cache** is abstract-only, and to run `cache_fulltext.py` before reading one as a bad snippet — the #577/#578 lesson, written where someone triaging will hit it.

## Mutation checks

| reverted | result |
|---|---|
| the `SYMBOLS` map | 3 failed (the symbol tests) |
| the every-part-present check | 1 failed (unsupported-part test) |
| `_ASSEMBLED_MIN_PART` 12 → 1 | 1 failed (short-fragment test) |
| nothing | 11 passed |

Also asserts the mapping does **not** over-reach: `alnum("ATCC 47054") != alnum("ATCC(R) 47054")`.

## Gates

`lint` 0, **2433 passed**. Branched from `main`; no overlap with #587 or #593.