### PR TITLE
Drop the vacuous GO annotations, upgrade the ones that meant something (#182)

### DIFF
--- a/docs/communities/AMD_Acidophile_Heterotroph_Network.html
+++ b/docs/communities/AMD_Acidophile_Heterotroph_Network.html
@@ -841,8 +841,8 @@
                     
                     <li>
                         nitrogen compound metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0071941"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0071941</a>)
                     </li>
                     
                 </ul>

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -604,8 +604,8 @@
                     
                     <li>
                         nitrogen compound metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0071941"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0071941</a>)
                     </li>
                     
                 </ul>

--- a/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
+++ b/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
@@ -667,8 +667,8 @@
                     
                     <li>
                         organic substance catabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009056"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009056</a>)
                     </li>
                     
                 </ul>
@@ -813,8 +813,8 @@
                     
                     <li>
                         organic substance catabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009056"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009056</a>)
                     </li>
                     
                 </ul>

--- a/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
+++ b/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
@@ -751,17 +751,6 @@
                 
 
                 
-                <p><strong>Biological Processes:</strong></p>
-                <ul>
-                    
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
-                    </li>
-                    
-                </ul>
-                
 
                 
 
@@ -1306,10 +1295,6 @@
             
             
             var processes = [];
-            
-            
-            processes.push("metabolic process");
-            
             
             var evidenceCount = 1;
 

--- a/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
+++ b/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
@@ -918,12 +918,6 @@
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
                     </li>
                     
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
-                    </li>
-                    
                 </ul>
                 
 
@@ -1028,12 +1022,6 @@
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
                     </li>
                     
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
-                    </li>
-                    
                 </ul>
                 
 
@@ -1084,12 +1072,6 @@
                         interspecies interaction between organisms
                         (<a href="http://amigo.geneontology.org/amigo/term/GO:0044419"
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
-                    </li>
-                    
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
                     </li>
                     
                 </ul>
@@ -1144,12 +1126,6 @@
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
                     </li>
                     
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
-                    </li>
-                    
                 </ul>
                 
 
@@ -1200,12 +1176,6 @@
                         interspecies interaction between organisms
                         (<a href="http://amigo.geneontology.org/amigo/term/GO:0044419"
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
-                    </li>
-                    
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
                     </li>
                     
                 </ul>
@@ -1260,12 +1230,6 @@
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
                     </li>
                     
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
-                    </li>
-                    
                 </ul>
                 
 
@@ -1318,12 +1282,6 @@
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
                     </li>
                     
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
-                    </li>
-                    
                 </ul>
                 
 
@@ -1374,12 +1332,6 @@
                         interspecies interaction between organisms
                         (<a href="http://amigo.geneontology.org/amigo/term/GO:0044419"
                             class="term-link" target="_blank" rel="noopener noreferrer">GO:0044419</a>)
-                    </li>
-                    
-                    <li>
-                        metabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
                     </li>
                     
                 </ul>
@@ -1780,8 +1732,6 @@
             
             processes.push("interspecies interaction between organisms");
             
-            processes.push("metabolic process");
-            
             
             var evidenceCount = 1;
 
@@ -1858,8 +1808,6 @@
             
             processes.push("interspecies interaction between organisms");
             
-            processes.push("metabolic process");
-            
             
             var evidenceCount = 1;
 
@@ -1897,8 +1845,6 @@
             
             
             processes.push("interspecies interaction between organisms");
-            
-            processes.push("metabolic process");
             
             
             var evidenceCount = 1;
@@ -1938,8 +1884,6 @@
             
             processes.push("interspecies interaction between organisms");
             
-            processes.push("metabolic process");
-            
             
             var evidenceCount = 1;
 
@@ -1977,8 +1921,6 @@
             
             
             processes.push("interspecies interaction between organisms");
-            
-            processes.push("metabolic process");
             
             
             var evidenceCount = 1;
@@ -2018,8 +1960,6 @@
             
             processes.push("interspecies interaction between organisms");
             
-            processes.push("metabolic process");
-            
             
             var evidenceCount = 1;
 
@@ -2058,8 +1998,6 @@
             
             processes.push("interspecies interaction between organisms");
             
-            processes.push("metabolic process");
-            
             
             var evidenceCount = 1;
 
@@ -2097,8 +2035,6 @@
             
             
             processes.push("interspecies interaction between organisms");
-            
-            processes.push("metabolic process");
             
             
             var evidenceCount = 1;

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -730,8 +730,8 @@
                     
                     <li>
                         organic substance catabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009056"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009056</a>)
                     </li>
                     
                 </ul>

--- a/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
+++ b/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
@@ -766,8 +766,8 @@
                     
                     <li>
                         organic substance catabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009056"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009056</a>)
                     </li>
                     
                 </ul>

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -853,8 +853,8 @@
                     
                     <li>
                         organic substance catabolic process
-                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0008152"
-                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0008152</a>)
+                        (<a href="http://amigo.geneontology.org/amigo/term/GO:0009056"
+                            class="term-link" target="_blank" rel="noopener noreferrer">GO:0009056</a>)
                     </li>
                     
                 </ul>

--- a/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
+++ b/kb/communities/AMD_Acidophile_Heterotroph_Network.yaml
@@ -344,8 +344,8 @@ ecological_interactions:
       label: aerobic respiration
   - preferred_term: nitrogen compound metabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0071941
+      label: nitrogen cycle metabolic process
   evidence:
   - reference: doi:10.3389/fmicb.2015.00475
     supports: SUPPORT

--- a/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
+++ b/kb/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.yaml
@@ -164,8 +164,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: nitrogen compound metabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0071941
+      label: nitrogen cycle metabolic process
   evidence:
   - reference: PMID:31980038
     supports: SUPPORT

--- a/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
+++ b/kb/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.yaml
@@ -129,8 +129,8 @@ ecological_interactions:
       label: methanogenesis
   - preferred_term: organic substance catabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0009056
+      label: catabolic process
   evidence:
   - reference: PMID:38628812
     supports: SUPPORT
@@ -198,8 +198,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: organic substance catabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0009056
+      label: catabolic process
   evidence:
   - reference: PMID:38628812
     supports: SUPPORT

--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -236,10 +236,6 @@ ecological_interactions:
       id: CHEBI:16842
       label: formaldehyde
   biological_processes:
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: doi:10.3390/microorganisms9020321
     supports: SUPPORT

--- a/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
+++ b/kb/communities/ORNL_PMI_Populus_PD10_SynCom.yaml
@@ -327,10 +327,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -381,10 +377,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -410,10 +402,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -439,10 +427,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -468,10 +452,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -497,10 +477,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -526,10 +502,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT
@@ -555,10 +527,6 @@ ecological_interactions:
     term:
       id: GO:0044419
       label: biological process involved in interspecies interaction between organisms
-  - preferred_term: metabolic process
-    term:
-      id: GO:0008152
-      label: metabolic process
   evidence:
   - reference: PMID:33995895
     supports: SUPPORT

--- a/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
+++ b/kb/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.yaml
@@ -165,8 +165,8 @@ ecological_interactions:
       label: dissimilatory sulfate reduction
   - preferred_term: organic substance catabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0009056
+      label: catabolic process
   evidence:
   - reference: PMID:30086797
     supports: SUPPORT

--- a/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
+++ b/kb/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.yaml
@@ -189,8 +189,8 @@ ecological_interactions:
   biological_processes:
   - preferred_term: organic substance catabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0009056
+      label: catabolic process
   evidence:
   - reference: PMID:38063415
     supports: SUPPORT

--- a/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
+++ b/kb/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.yaml
@@ -233,8 +233,8 @@ ecological_interactions:
       label: dissimilatory sulfate reduction
   - preferred_term: organic substance catabolic process
     term:
-      id: GO:0008152
-      label: metabolic process
+      id: GO:0009056
+      label: catabolic process
   evidence:
   - reference: PMID:38961111
     supports: SUPPORT

--- a/tests/test_no_vacuous_go_annotations.py
+++ b/tests/test_no_vacuous_go_annotations.py
@@ -1,0 +1,158 @@
+"""Some GO terms are true of every record here, so they annotate nothing (#182).
+
+The #180 id↔label cleanup remapped obsolete GO ids to their nearest *valid*
+term. For a handful that meant climbing to a near-root process, and the result
+was sixteen annotations reading
+
+    - preferred_term: metabolic process
+      term:
+        id: GO:0008152
+        label: metabolic process
+
+on records in a knowledge base about **microbial communities**, every one of
+which does metabolism. Nine were exactly that and were dropped. Seven carried a
+real concept in `preferred_term` that had been flattened onto the generic
+parent, and were re-grounded rather than deleted:
+
+    organic substance catabolic process  ->  GO:0009056  catabolic process
+    nitrogen compound metabolic process  ->  GO:0071941  nitrogen cycle metabolic process
+
+Both targets are current; the precise terms a curator would want
+(`GO:0006807`, `GO:1901575`) are **obsolete in GO**, which is why they were
+flattened in the first place. `GO:0071941` was already used twice elsewhere in
+the KB, so this follows an existing convention rather than inventing one.
+
+`term` is `required: true` on `BiologicalProcessDescriptor`, so "drop the
+annotation" necessarily means dropping the whole descriptor — there is no way to
+keep an ungrounded `preferred_term`. That is why upgrading beats deleting
+wherever a current term exists.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+# GO terms so close to the root of the biological-process branch that asserting
+# them of a microbial community conveys nothing. Each needs a reason, so that
+# adding one is a decision rather than a reflex.
+_VACUOUS = {
+    "GO:0008152": "'metabolic process' — true of every organism in the KB",
+    "GO:0008150": "'biological_process' — the branch root",
+}
+
+
+def _walk(node, filename):
+    """Descriptors under `node`. Module-level so it does not close over the loop
+    variable — a nested closure here reads `path` from the enclosing scope at
+    *call* time, which for a generator is after the loop has moved on (ruff
+    B023). Harmless in this shape, wrong the moment the generator is not drained
+    immediately."""
+    if isinstance(node, dict):
+        term = node.get("term")
+        if node.get("preferred_term") and isinstance(term, dict) and term.get("id"):
+            yield filename, node["preferred_term"], term["id"], term.get("label")
+        for value in node.values():
+            yield from _walk(value, filename)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _walk(value, filename)
+
+
+def _descriptors(corpus: pathlib.Path | None = None):
+    """Every (file, preferred_term, id, label) biological-process descriptor."""
+    for path in sorted((corpus or COMMUNITIES).glob("*.yaml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        yield from _walk(document, path.name)
+
+
+def test_no_record_is_annotated_with_a_vacuous_process():
+    """The gate."""
+    offenders = [
+        f"{name}: {preferred!r} -> {identifier} ({_VACUOUS[identifier]})"
+        for name, preferred, identifier, _label in _descriptors()
+        if identifier in _VACUOUS
+    ]
+    assert offenders == [], (
+        "these annotations are true of every community in the KB and so "
+        "distinguish nothing (#182). Ground the concept in `preferred_term` to "
+        "a specific current GO term, or drop the descriptor:\n"
+        + "\n".join(f"  {line}" for line in offenders)
+    )
+
+
+def test_the_upgraded_terms_are_present_and_correctly_labelled():
+    """The seven that were re-grounded rather than deleted.
+
+    Asserts the label travelled with the id: a remap that changed one and not
+    the other is the exact defect #180 existed to clear, and re-introducing it
+    here would be ironic.
+    """
+    by_id = {}
+    for _name, _preferred, identifier, label in _descriptors():
+        by_id.setdefault(identifier, set()).add(label)
+
+    assert by_id.get("GO:0009056") == {
+        "catabolic process"
+    }, f"GO:0009056 carries unexpected labels: {by_id.get('GO:0009056')}"
+    assert by_id.get("GO:0071941") == {
+        "nitrogen cycle metabolic process"
+    }, f"GO:0071941 carries unexpected labels: {by_id.get('GO:0071941')}"
+
+
+@pytest.mark.parametrize("identifier", sorted(_VACUOUS))
+def test_every_blocked_term_has_a_reason(identifier):
+    """A blocklist without reasons becomes a place things get added silently."""
+    assert _VACUOUS[identifier].strip()
+
+
+def test_the_walk_reaches_the_corpus():
+    """An empty walk passes the gate as surely as a clean corpus does."""
+    seen = list(_descriptors())
+    assert len(seen) > 500, f"only {len(seen)} descriptors walked; the walk is broken"
+
+
+def test_the_gate_can_fire(tmp_path):
+    """Mutation check, driving the real walk over a record built to offend."""
+    corpus = tmp_path / "communities"
+    corpus.mkdir()
+    (corpus / "r.yaml").write_text(
+        "id: CommunityMech:000999\n"
+        "ecological_interactions:\n"
+        "- biological_processes:\n"
+        "  - preferred_term: metabolic process\n"
+        "    term:\n"
+        "      id: GO:0008152\n"
+        "      label: metabolic process\n",
+        encoding="utf-8",
+    )
+    offenders = [d for d in _descriptors(corpus) if d[2] in _VACUOUS]
+    assert offenders, "the gate found nothing in a record built to contain the defect"
+    assert offenders[0][1] == "metabolic process"
+
+
+def test_a_specific_process_is_not_flagged(tmp_path):
+    """Guard against the gate being over-broad.
+
+    A correctly grounded specific term also has `preferred_term == label`; that
+    is what good curation looks like, not a defect. The gate must key on the
+    identifier, never on the two strings matching.
+    """
+    corpus = tmp_path / "communities"
+    corpus.mkdir()
+    (corpus / "r.yaml").write_text(
+        "id: CommunityMech:000998\n"
+        "ecological_interactions:\n"
+        "- biological_processes:\n"
+        "  - preferred_term: nitrogen cycle metabolic process\n"
+        "    term:\n"
+        "      id: GO:0071941\n"
+        "      label: nitrogen cycle metabolic process\n",
+        encoding="utf-8",
+    )
+    assert [d for d in _descriptors(corpus) if d[2] in _VACUOUS] == []


### PR DESCRIPTION
Closes #182. Implements the decision: **drop the generic GO remaps.**

## What was there

The #180 id↔label cleanup remapped obsolete GO ids to the nearest **valid** term. For a handful that meant climbing to a near-root process, leaving 16 annotations like:

```yaml
- preferred_term: metabolic process
  term:
    id: GO:0008152
    label: metabolic process
```

on records in a knowledge base **about microbial communities**, every one of which does metabolism. The annotation restates the term and the term restates the domain.

## They were not all the same thing

| shape | count | action |
|---|---|---|
| `preferred_term: metabolic process` → `GO:0008152` | **9** | **dropped** — nothing is lost |
| `organic substance catabolic process` → `GO:0008152` | **5** | **upgraded** to `GO:0009056` catabolic process |
| `nitrogen compound metabolic process` → `GO:0008152` | **2** | **upgraded** to `GO:0071941` nitrogen cycle metabolic process |

Deleting the seven would have thrown away curated claims about catabolism and nitrogen cycling to satisfy the letter of "drop the remaps". Flagging the judgement call explicitly since it goes slightly beyond the decision as worded.

**Why they were generic in the first place:** the precise terms a curator would want — `GO:0006807` "nitrogen compound metabolic process" and `GO:1901575` "organic substance catabolic process" — are **obsolete in GO**. Checked with OAK:

```
GO:0006807 ! obsolete nitrogen compound metabolic process
GO:1901575 ! obsolete organic substance catabolic process
GO:0009056 ! catabolic process
GO:0071941 ! nitrogen cycle metabolic process
```

`GO:0071941` was **already used twice elsewhere in the KB**, so this adopts an existing convention rather than inventing one.

## Why upgrade rather than strip the id

`term` is `required: true` on `BiologicalProcessDescriptor`. There is no way to keep an ungrounded `preferred_term` — dropping the annotation necessarily drops the whole descriptor. So wherever a current term exists, upgrading is strictly better than deleting.

## Deliberately not touched

`GO:0044419` "biological process involved in interspecies interaction between organisms" — **152 occurrences across 72 files**. It came from the same obsolete-remap list in #182 (`GO:0051704` multi-organism process → `GO:0044419`), but for a knowledge base about microbial communities it is genuinely informative, and the replacement is *better* than the original rather than worse. Dropping it would have been the largest change in the issue and the wrong one.

Bucket A (CHEBI/ENVO/NCBITaxon) is untouched per the decision — `preferred_term` retains the specificity there.

## Gate

`test_no_vacuous_go_annotations.py`, mutation-checked by restoring a vacuous annotation to a real record (goes red).

It keys on the **identifier**, never on `preferred_term == label`. A correctly grounded specific term also matches its own label — that is what good curation looks like, not a defect — and `test_a_specific_process_is_not_flagged` pins that so the gate cannot drift into over-broad.

The blocklist requires a written reason per entry, so adding one is a decision rather than a reflex.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, `check-docs-current` 0 (regenerated HTML for the 8 edited records is included), **2471 passed**.