### PR TITLE
Palette: fold the two rarest interaction types, and hold the UMAP palette to the same floor (#532, #601, #602)

### DIFF
--- a/docs/communities/AMD_Acidophile_Heterotroph_Network.html
+++ b/docs/communities/AMD_Acidophile_Heterotroph_Network.html
@@ -787,7 +787,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1526,14 +1526,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1546,9 +1544,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/AMD_Nitrososphaerota_Archaeal.html
+++ b/docs/communities/AMD_Nitrososphaerota_Archaeal.html
@@ -694,7 +694,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1380,14 +1380,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1400,9 +1398,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.html
+++ b/docs/communities/ANME_SRB_Anaerobic_Methanotrophic_Syntrophic_Consortia.html
@@ -963,14 +963,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -983,9 +981,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
+++ b/docs/communities/ANME_SRB_Marine_Methane_Seep_Consortium.html
@@ -1057,14 +1057,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1077,9 +1075,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
+++ b/docs/communities/Aalborg_East_Full_Scale_EBPR_Community.html
@@ -1039,14 +1039,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1059,9 +1057,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
+++ b/docs/communities/Acetobacterium_Clostridium_CO2_Electrolysis_Coculture.html
@@ -1165,14 +1165,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1185,9 +1183,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
+++ b/docs/communities/Acetylene_Fueled_TCE_Dechlorination_Groundwater_Enrichment.html
@@ -845,14 +845,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -865,9 +863,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_Disturbance_SynCom.html
@@ -763,14 +763,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -783,9 +781,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
+++ b/docs/communities/Aerobic_Denitrification_QQ_SynCom.html
@@ -750,14 +750,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -770,9 +768,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
+++ b/docs/communities/Alaska_Tundra_Permafrost_Iron_Redox_Community.html
@@ -959,14 +959,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -979,9 +977,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
+++ b/docs/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.html
@@ -649,7 +649,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -998,14 +998,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1018,9 +1016,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.html
+++ b/docs/communities/Anabaena_MGS1_Anaerobic_Digestion_Methanogen_Consortium.html
@@ -929,14 +929,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -949,9 +947,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
+++ b/docs/communities/Anammox_Bioreactor_DNRA_Destabilization_Community.html
@@ -807,14 +807,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -827,9 +825,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
+++ b/docs/communities/Anammox_Granule_Metabolic_Interaction_Community.html
@@ -1031,14 +1031,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1051,9 +1049,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
+++ b/docs/communities/Angelarchaeales_Thermoplasmata_CuMMO_Soil_Sediment_Community.html
@@ -790,14 +790,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -810,9 +808,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
+++ b/docs/communities/Arabidopsis_Coumarin_Root_SynCom.html
@@ -674,14 +674,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -694,9 +692,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
+++ b/docs/communities/Arabidopsis_Phyllosphere_SynCom7.html
@@ -705,14 +705,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -725,9 +723,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
+++ b/docs/communities/Asgard_Wetland_Soil_Methanogenesis_Substrate_Community.html
@@ -921,14 +921,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -941,9 +939,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/At_RSPHERE_SynCom.html
+++ b/docs/communities/At_RSPHERE_SynCom.html
@@ -710,7 +710,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1397,14 +1397,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1417,9 +1415,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Australian_Lead_Zinc_Polymetallic.html
+++ b/docs/communities/Australian_Lead_Zinc_Polymetallic.html
@@ -789,7 +789,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1702,14 +1702,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1722,9 +1720,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
+++ b/docs/communities/Avena_Rhizosphere_CrossKingdom_SIP_Community.html
@@ -653,7 +653,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Avena Rhizosphere Cross-Kingdom 13C-SIP Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -666,8 +666,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -999,14 +999,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1019,9 +1017,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
+++ b/docs/communities/Avena_Rhizosphere_Detritusphere_Niche_Succession.html
@@ -797,14 +797,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -817,9 +815,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.html
+++ b/docs/communities/BSFL_Gut_SynCom_Bacillus_Lactobacillus_Issatchenkia.html
@@ -808,14 +808,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -828,9 +826,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
+++ b/docs/communities/Bacillus_Bradyrhizobium_Straw_Humification_SynCom.html
@@ -653,14 +653,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -673,9 +671,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
+++ b/docs/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.html
@@ -1003,14 +1003,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1023,9 +1021,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
+++ b/docs/communities/Bacteroides_Methanobrevibacter_Gnotobiotic_Mouse_Mutualism.html
@@ -603,7 +603,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -959,14 +959,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -979,9 +977,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
+++ b/docs/communities/Banana_Fusarium_Biocontrol_SynCom12.html
@@ -583,7 +583,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -763,14 +763,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -783,9 +781,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
+++ b/docs/communities/Bay_Area_Sewage_SARS_CoV2_Surveillance_Community.html
@@ -710,14 +710,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -730,9 +728,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
+++ b/docs/communities/Bayan_Obo_REE_Tailings_Consortium.html
@@ -591,7 +591,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1210,14 +1210,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1230,9 +1228,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
+++ b/docs/communities/Bifidobacterium_Ruminococcus_Infant_HMO_CrossFeeding.html
@@ -785,14 +785,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -805,9 +803,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
+++ b/docs/communities/Bifidobacterium_Trichomonas_Vaginal_Coculture.html
@@ -557,7 +557,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Bifidobacterium breve-Trichomonas vaginalis Vaginal Co-culture</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (commensalism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -570,8 +570,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -915,14 +915,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -935,9 +933,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html
+++ b/docs/communities/BioAsteroid_ISS_Chondrite_Biomining_Consortium.html
@@ -1211,14 +1211,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1231,9 +1229,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
+++ b/docs/communities/BioModels_MODEL1806250003_Spittlebug_Sulcia_Sodalis.html
@@ -514,7 +514,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -779,14 +779,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -799,9 +797,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
+++ b/docs/communities/BioModels_MODEL1806250004_Sharpshooter_Sulcia_Baumannia.html
@@ -514,7 +514,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -779,14 +779,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -799,9 +797,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
+++ b/docs/communities/BioModels_MODEL1806250005_Cicada_Sulcia_Hodgkinia.html
@@ -514,7 +514,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -779,14 +779,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -799,9 +797,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
+++ b/docs/communities/BioModels_MODEL2204300001_Kefir_Community_Model.html
@@ -729,7 +729,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1189,14 +1189,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1209,9 +1207,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
+++ b/docs/communities/BioModels_MODEL2209060002_DPigrum_SAureus_Community.html
@@ -863,14 +863,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -883,9 +881,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
+++ b/docs/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.html
@@ -1208,14 +1208,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1228,9 +1226,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
+++ b/docs/communities/BioModels_MODEL2407300002_Sponge_Holobiont_Network.html
@@ -576,7 +576,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -900,14 +900,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -920,9 +918,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/BioRock_ISS_Basalt_Biomining_Consortium.html
+++ b/docs/communities/BioRock_ISS_Basalt_Biomining_Consortium.html
@@ -1217,14 +1217,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1237,9 +1235,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
+++ b/docs/communities/Brachypodium_Young_Root_Rhizosphere_EcoFAB_Community.html
@@ -923,14 +923,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -943,9 +941,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
+++ b/docs/communities/Buchnera_Serratia_Cinara_Cedri_Endosymbiont_Consortium.html
@@ -551,7 +551,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -869,14 +869,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -889,9 +887,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.html
+++ b/docs/communities/Butyrivibrio_Selenomonas_Ruminococcus_Lignocellulolytic_Rumen_Consortium.html
@@ -600,7 +600,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -711,14 +711,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -731,9 +729,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/CRC_Fusobacterium_Control_SynCom.html
+++ b/docs/communities/CRC_Fusobacterium_Control_SynCom.html
@@ -679,14 +679,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -699,9 +697,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
+++ b/docs/communities/Cable_Bacteria_Photosynthetic_Biofilm_Sediment.html
@@ -1020,14 +1020,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1040,9 +1038,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
+++ b/docs/communities/Caldibacillus_Clostridium_Aerotolerant_Cellulose_Coculture.html
@@ -1011,14 +1011,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1031,9 +1029,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
+++ b/docs/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.html
@@ -551,7 +551,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1165,14 +1165,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1185,9 +1183,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
+++ b/docs/communities/California_Grassland_Precipitation_Legacy_Soil_Community.html
@@ -902,14 +902,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -922,9 +920,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
+++ b/docs/communities/Candida_Parapsilosis_Hospitalized_Infant_Microbiome.html
@@ -727,14 +727,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -747,9 +745,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
+++ b/docs/communities/CeMbio_Caenorhabditis_Elegans_Microbiome.html
@@ -549,7 +549,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1150,14 +1150,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1170,9 +1168,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
+++ b/docs/communities/Cellulomonas_Rhodobacter_Cellulose_Photohydrogen_Coculture.html
@@ -1057,14 +1057,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1077,9 +1075,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
+++ b/docs/communities/Cellulose_Methane_Quad_Culture_SynCom.html
@@ -1248,14 +1248,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1268,9 +1266,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
+++ b/docs/communities/Cheese_Rind_InSitu_InVitro_Model_Community.html
@@ -994,14 +994,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1014,9 +1012,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
+++ b/docs/communities/Chlamydomonas_Bacterial_H2_Consortium.html
@@ -626,7 +626,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1136,14 +1136,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1156,9 +1154,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
+++ b/docs/communities/Chlamydomonas_Methylobacterium_Mutualism.html
@@ -542,7 +542,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1075,14 +1075,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1095,9 +1093,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
+++ b/docs/communities/Chlorella_Azospirillum_Synthetic_Mutualism.html
@@ -573,7 +573,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1349,14 +1349,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1369,9 +1367,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
+++ b/docs/communities/Chlorella_Ecoli_Mixotrophic_Biofuel_Coculture.html
@@ -569,7 +569,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1102,14 +1102,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1122,9 +1120,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
+++ b/docs/communities/Chlorella_Keystone_Taxa_Antifungal_SynCom.html
@@ -1070,14 +1070,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1090,9 +1088,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
+++ b/docs/communities/Chlorella_Rhizobium_Bioflocculation.html
@@ -542,7 +542,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -957,14 +957,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -977,9 +975,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
+++ b/docs/communities/Chlorochromatium_Aggregatum_Phototrophic_Consortium.html
@@ -942,14 +942,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -962,9 +960,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
+++ b/docs/communities/Chromium_Sulfur_Reduction_Enrichment.html
@@ -638,7 +638,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1367,14 +1367,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1387,9 +1385,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Cinnamate_Degradation_Consortium.html
+++ b/docs/communities/Cinnamate_Degradation_Consortium.html
@@ -943,14 +943,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -963,9 +961,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
+++ b/docs/communities/Clostridium_Autoethanogenum_Kluyveri_Syngas_Coculture.html
@@ -1187,14 +1187,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1207,9 +1205,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
+++ b/docs/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.html
@@ -1176,14 +1176,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1196,9 +1194,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
+++ b/docs/communities/Clostridium_Carboxidivorans_Kluyveri_CO_Chain_Elongation_Coculture.html
@@ -1166,14 +1166,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1186,9 +1184,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
+++ b/docs/communities/Clostridium_Cellulolyticum_Geobacter_Cellulose_MFC_Coculture.html
@@ -568,7 +568,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1141,14 +1141,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1161,9 +1159,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Methanosarcina_Cellulose_Methane_Coculture.html
@@ -573,7 +573,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1141,14 +1141,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1161,9 +1159,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
+++ b/docs/communities/Clostridium_Cellulovorans_Rhodopseudomonas_Cellulose_Biohydrogen_Coculture.html
@@ -1053,14 +1053,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1073,9 +1071,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
+++ b/docs/communities/Clostridium_Ljungdahlii_Kluyveri_Syngas_Alcohol_Coculture.html
@@ -1229,14 +1229,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1249,9 +1247,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
+++ b/docs/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.html
@@ -1245,14 +1245,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1265,9 +1263,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
+++ b/docs/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.html
@@ -573,7 +573,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1157,14 +1157,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1177,9 +1175,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacter_Cellulosic_Bioethanol_Coculture.html
@@ -1113,14 +1113,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1133,9 +1131,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
+++ b/docs/communities/Clostridium_Thermoanaerobacterium_JN4_GD17_Cellulosic_Biofuel_Coculture.html
@@ -1106,14 +1106,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1126,9 +1124,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
+++ b/docs/communities/Clostridium_Thermocellum_Saccharoperbutylacetonicum_Cellulosic_Butanol_Coculture.html
@@ -1228,14 +1228,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1248,9 +1246,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
+++ b/docs/communities/Coastal_Forested_Wetland_Seawater_Ion_Microcosm_Community.html
@@ -1158,14 +1158,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1178,9 +1176,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.html
+++ b/docs/communities/Composting_SynCom_Lignocellulose_Degradation_Humus.html
@@ -661,14 +661,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -681,9 +679,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
+++ b/docs/communities/Coniochaeta_Sphingobacterium_Citrobacter_Wheat_Straw_Consortium.html
@@ -1347,14 +1347,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1367,9 +1365,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Copper_Biomining_Heap_Leach.html
+++ b/docs/communities/Copper_Biomining_Heap_Leach.html
@@ -723,7 +723,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1572,14 +1572,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1592,9 +1590,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.html
+++ b/docs/communities/Corynebacterium_glutamicum_Shewanella_oneidensis_Succinic_Acid_Coculture.html
@@ -706,14 +706,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -726,9 +724,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Coscinodiscus_Synthetic_Community.html
+++ b/docs/communities/Coscinodiscus_Synthetic_Community.html
@@ -668,7 +668,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1452,14 +1452,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1472,9 +1470,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.html
+++ b/docs/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.html
@@ -705,14 +705,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -725,9 +723,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
+++ b/docs/communities/Crystal_Geyser_CO2_Aquifer_CPR_Lipid_Community.html
@@ -867,14 +867,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -887,9 +885,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
+++ b/docs/communities/Cyprus_Copper_Sulphide_Bioleaching_Consortium.html
@@ -918,14 +918,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -938,9 +936,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.html
+++ b/docs/communities/DIETsimp_Lignocellulose_to_Methane_DIET_Consortia.html
@@ -892,14 +892,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -912,9 +910,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/DVM_Triculture.html
+++ b/docs/communities/DVM_Triculture.html
@@ -1171,14 +1171,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1191,9 +1189,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dangl_SynComm_35.html
+++ b/docs/communities/Dangl_SynComm_35.html
@@ -761,7 +761,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1600,14 +1600,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1620,9 +1618,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
+++ b/docs/communities/Deepwater_Horizon_Deep_Sea_Oil_Plume_Succession.html
@@ -1303,14 +1303,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1323,9 +1321,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.html
@@ -1312,14 +1312,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1332,9 +1330,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
+++ b/docs/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.html
@@ -1255,14 +1255,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1275,9 +1273,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
+++ b/docs/communities/Dehalococcoides_Methanosarcina_DMB_Cobalamin_Coculture.html
@@ -1180,14 +1180,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1200,9 +1198,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
+++ b/docs/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.html
@@ -1155,14 +1155,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1175,9 +1173,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
+++ b/docs/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.html
@@ -1225,14 +1225,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1245,9 +1243,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dehalococcoides_mccartyi_CWV2_Dechlorinating_Consortium.html
+++ b/docs/communities/Dehalococcoides_mccartyi_CWV2_Dechlorinating_Consortium.html
@@ -631,14 +631,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -651,9 +649,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
+++ b/docs/communities/Desert_Tomato_Salt_Stress_SynCom5.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -666,14 +666,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -686,9 +684,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanococcus_Syntrophy.html
@@ -1270,14 +1270,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1290,9 +1288,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
+++ b/docs/communities/Desulfovibrio_Methanosarcina_Lactate_Syntrophy.html
@@ -938,14 +938,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -958,9 +956,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
+++ b/docs/communities/Drosophila_FiveSpecies_Gnotobiotic_Gut_Microbiota.html
@@ -609,7 +609,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1027,14 +1027,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1047,9 +1045,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
+++ b/docs/communities/Drought_Rhizosphere_Iron_Actinobacteria_Community.html
@@ -863,14 +863,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -883,9 +881,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Dual_Bacillus_coagulans_Pseudomonas_putida_Lactic_Acid_Coculture.html
+++ b/docs/communities/Dual_Bacillus_coagulans_Pseudomonas_putida_Lactic_Acid_Coculture.html
@@ -856,14 +856,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -876,9 +874,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/ENIGMA_Denitrifying_SynCom.html
+++ b/docs/communities/ENIGMA_Denitrifying_SynCom.html
@@ -971,14 +971,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -991,9 +989,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/East_River_Floodplain_Core_Microbiome.html
+++ b/docs/communities/East_River_Floodplain_Core_Microbiome.html
@@ -933,14 +933,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -953,9 +951,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
+++ b/docs/communities/East_River_Hillslope_Riparian_Transect_Community.html
@@ -1164,14 +1164,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1184,9 +1182,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
+++ b/docs/communities/EcoFAB_Ring_Trial_SynCom17.html
@@ -2139,14 +2139,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -2159,9 +2157,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.html
+++ b/docs/communities/Ecoli_Bifidobacterium_bifidum_Infant_gut_HMO_Mutualism_Coculture.html
@@ -771,14 +771,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -791,9 +789,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.html
+++ b/docs/communities/Electrostimulated_Mixotrophic_VFA_Producing_Enrichment_Consortium.html
@@ -684,14 +684,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -704,9 +702,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.html
+++ b/docs/communities/Electrosynthetic_Consortia_Shewanella_Clostridium_Acetobacterium_Acetate.html
@@ -801,14 +801,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -821,9 +819,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
+++ b/docs/communities/Emiliania_Phaeobacter_Dynamic_Interaction.html
@@ -537,7 +537,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Emiliania huxleyi-Phaeobacter inhibens Dynamic Interaction</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, mutualism).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -551,12 +551,12 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -915,14 +915,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -935,9 +933,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
+++ b/docs/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.html
@@ -635,7 +635,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1010,14 +1010,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1030,9 +1028,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.html
+++ b/docs/communities/Ensifer_YF2_Sphingobacterium_Y2_Polyethylene_Degrading_Consortium.html
@@ -584,7 +584,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -749,14 +749,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -769,9 +767,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
+++ b/docs/communities/Episymbiotic_CPR_DPANN_Groundwater_Community.html
@@ -833,14 +833,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -853,9 +851,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
+++ b/docs/communities/Eucalyptus_Nursery_FiveStrain_Inoculant_SynCom.html
@@ -674,7 +674,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -982,14 +982,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1002,9 +1000,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ewaste_Bioleaching_Consortium.html
+++ b/docs/communities/Ewaste_Bioleaching_Consortium.html
@@ -712,7 +712,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1389,14 +1389,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1409,9 +1407,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
+++ b/docs/communities/Ferroplasma_Leptospirillum_Syntrophy.html
@@ -570,7 +570,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1418,14 +1418,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1438,9 +1436,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
+++ b/docs/communities/GLBRC_Exometabolite_Transwell_SynCom.html
@@ -679,14 +679,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -699,9 +697,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
+++ b/docs/communities/GLBRC_Populus_Variovorax_SynCom28.html
@@ -1624,7 +1624,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for GLBRC Populus Variovorax SynCom28</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning, colonization facilitation, strain competition).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (niche partitioning, colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -1642,8 +1642,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolAsterisk"
-                             data-color="#cf30b7"></svg> Strain competition
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -2113,14 +2113,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -2133,9 +2131,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/GLBRC_UFMP_Fermentation_Community.html
+++ b/docs/communities/GLBRC_UFMP_Fermentation_Community.html
@@ -1269,14 +1269,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1289,9 +1287,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/GOM_Oil_Degrading_Consortium.html
+++ b/docs/communities/GOM_Oil_Degrading_Consortium.html
@@ -897,14 +897,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -917,9 +915,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Garlic_Pseudomonas_SynCom6.html
+++ b/docs/communities/Garlic_Pseudomonas_SynCom6.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -666,14 +666,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -686,9 +684,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.html
+++ b/docs/communities/Geobacter_Clostridium_Interspecies_Electron_Transfer_Coculture.html
@@ -567,7 +567,7 @@ MECHANISM CONTESTED - do not read this record as establishing contact-dependent 
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1262,14 +1262,12 @@ The competing mechanism is NOT asserted in its place. The follow-up (PMID:349391
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1282,9 +1280,7 @@ The competing mechanism is NOT asserted in its place. The follow-up (PMID:349391
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Geobacter_Methanosaeta_DIET.html
+++ b/docs/communities/Geobacter_Methanosaeta_DIET.html
@@ -544,7 +544,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -987,14 +987,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1007,9 +1005,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Geobacter_Methanosarcina_DIET.html
+++ b/docs/communities/Geobacter_Methanosarcina_DIET.html
@@ -544,7 +544,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1163,14 +1163,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1183,9 +1181,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
+++ b/docs/communities/Geobacter_Pseudomonas_Formate_Fumarate_Electroactive_Coculture.html
@@ -1143,14 +1143,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1163,9 +1161,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
+++ b/docs/communities/Grassland_Soil_WetUp_Virus_Host_Community.html
@@ -527,7 +527,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Grassland Soil Wet-Up Virus-Host Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction.</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -535,8 +535,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -827,14 +827,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -847,9 +845,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
+++ b/docs/communities/Groundwater_Elusimicrobia_Diverse_Metabolisms.html
@@ -860,14 +860,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -880,9 +878,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
+++ b/docs/communities/Hanford_300_Area_Unconfined_Aquifer_Community.html
@@ -893,14 +893,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -913,9 +911,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
+++ b/docs/communities/High_Solids_Switchgrass_Methanogenic_Microbiome.html
@@ -1350,14 +1350,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1370,9 +1368,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Honeybee_Core20_Defined_Microbiota.html
+++ b/docs/communities/Honeybee_Core20_Defined_Microbiota.html
@@ -671,14 +671,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -691,9 +689,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
+++ b/docs/communities/Horonobe_Mizunami_URL_Subsurface_Microbiome.html
@@ -942,14 +942,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -962,9 +960,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
+++ b/docs/communities/Human_Gut_FourMember_Proteome_Complementarity_Consortium.html
@@ -973,14 +973,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -993,9 +991,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
+++ b/docs/communities/Iberian_Pit_Lake_Stratified_Community.html
@@ -884,7 +884,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1553,14 +1553,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1573,9 +1571,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Industrial_Bioreactor_Consortium.html
+++ b/docs/communities/Industrial_Bioreactor_Consortium.html
@@ -877,7 +877,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1882,14 +1882,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1902,9 +1900,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
+++ b/docs/communities/Industrial_Milk_Line_FourSpecies_Model_Biofilm.html
@@ -1077,14 +1077,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1097,9 +1095,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
+++ b/docs/communities/Infant_Gut_DNA_Phage_Succession_Community.html
@@ -521,7 +521,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Infant Gut DNA Phageome Succession Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (colonization facilitation).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -534,8 +534,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -842,14 +842,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -862,9 +860,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Infant_Gut_Prebiotic_Response_SynCom.html
+++ b/docs/communities/Infant_Gut_Prebiotic_Response_SynCom.html
@@ -888,14 +888,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -908,9 +906,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
+++ b/docs/communities/Infant_Gut_Strain_Persistence_Maternal_Community.html
@@ -924,14 +924,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -944,9 +942,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
+++ b/docs/communities/Ion_Adsorption_REE_Indigenous_Community.html
@@ -827,7 +827,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1482,14 +1482,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1502,9 +1500,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Jala_Maize_PGPB_SynCom.html
+++ b/docs/communities/Jala_Maize_PGPB_SynCom.html
@@ -625,7 +625,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -805,14 +805,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -825,9 +823,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
+++ b/docs/communities/KB1_Chlorinated_Ethene_Dechlorinating_Consortium.html
@@ -925,14 +925,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -945,9 +943,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
+++ b/docs/communities/KBase_Models_for_Zahmeeth_Original_PLOS.html
@@ -833,14 +833,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -853,9 +851,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/KBase_ORT_Workflow_Community_Model.html
+++ b/docs/communities/KBase_ORT_Workflow_Community_Model.html
@@ -902,14 +902,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -922,9 +920,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
+++ b/docs/communities/KBase_Synthetic_Bacterial_Community_R2A.html
@@ -915,14 +915,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -935,9 +933,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
+++ b/docs/communities/Kombucha_KMC_IMBG1_Fermentation_Community.html
@@ -626,7 +626,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1032,14 +1032,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1052,9 +1050,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
+++ b/docs/communities/LBNL_Brachypodium_Drought_SynCom15.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -679,14 +679,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -699,9 +697,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
+++ b/docs/communities/LBNL_Human_Gut_Interaction_SynCom.html
@@ -684,14 +684,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -704,9 +702,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
+++ b/docs/communities/LBNL_Switchgrass_Soil_SynCom16.html
@@ -684,14 +684,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -704,9 +702,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
+++ b/docs/communities/Lac_Pavin_Stratified_Lake_Community.html
@@ -838,14 +838,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -858,9 +856,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
+++ b/docs/communities/Lake_Washington_Methane_Oxygen_Methylotroph_Community.html
@@ -1382,14 +1382,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1402,9 +1400,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
+++ b/docs/communities/Legume_Rhizobia_Mars_Simulant_Symbiosis.html
@@ -557,7 +557,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -729,14 +729,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -749,9 +747,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Lotus_LjSC3.html
+++ b/docs/communities/Lotus_LjSC3.html
@@ -878,7 +878,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1761,14 +1761,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1781,9 +1779,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.html
+++ b/docs/communities/Lunar_Martian_Simulant_PGPB_Lettuce_SynCom.html
@@ -661,7 +661,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1236,14 +1236,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1256,9 +1254,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.html
+++ b/docs/communities/Lunar_Simulant_Phosphate_Solubilizing_Bacteria_Nicotiana.html
@@ -1174,14 +1174,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1194,9 +1192,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/MAMC_M48_Lignocellulose.html
+++ b/docs/communities/MAMC_M48_Lignocellulose.html
@@ -1204,14 +1204,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1224,9 +1222,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/MSC1_Dominant_Core.html
+++ b/docs/communities/MSC1_Dominant_Core.html
@@ -1807,14 +1807,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1827,9 +1825,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/MSC2_Model_Soil_Consortium.html
+++ b/docs/communities/MSC2_Model_Soil_Consortium.html
@@ -962,14 +962,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -982,9 +980,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
+++ b/docs/communities/MUCC_Freshwater_Wetland_Methane_Network_Community.html
@@ -1303,14 +1303,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1323,9 +1321,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
+++ b/docs/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.html
@@ -679,14 +679,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -699,9 +697,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Maize_Drought_Response_SynCom.html
+++ b/docs/communities/Maize_Drought_Response_SynCom.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -674,14 +674,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -694,9 +692,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Maize_Root_Simplified_Community.html
+++ b/docs/communities/Maize_Root_Simplified_Community.html
@@ -778,7 +778,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1572,14 +1572,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1592,9 +1590,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
+++ b/docs/communities/Medicago_Nodule_Biofertilizer_SynCom.html
@@ -541,7 +541,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -729,14 +729,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -749,9 +747,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
+++ b/docs/communities/Mediterranean_Grassland_qSIP_Rainfall_Community.html
@@ -760,14 +760,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -780,9 +778,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
+++ b/docs/communities/Mercury_SFA_EFPC_Sediment_Community.html
@@ -1212,14 +1212,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1232,9 +1230,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
+++ b/docs/communities/Mesorhizobium_Synechococcus_B12_Synthetic_Consortium.html
@@ -976,14 +976,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -996,9 +994,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
+++ b/docs/communities/Methane_Oxidation_CrVI_Reduction_SynCom.html
@@ -763,14 +763,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -783,9 +781,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
+++ b/docs/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.html
@@ -569,7 +569,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1120,14 +1120,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1140,9 +1138,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Cupriavidus_Methane_Acetate_Crossfeeding_Coculture.html
@@ -1055,14 +1055,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1075,9 +1073,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
+++ b/docs/communities/Methylocaldum_Methyloceanibacter_Methane_Crossfeeding_Coculture.html
@@ -1031,14 +1031,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1051,9 +1049,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
+++ b/docs/communities/Methylocystis_Rhodococcus_Methane_VFA_PHBV_Coculture.html
@@ -1034,14 +1034,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1054,9 +1052,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
+++ b/docs/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.html
@@ -573,7 +573,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1223,14 +1223,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1243,9 +1241,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
+++ b/docs/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.html
@@ -569,7 +569,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1040,14 +1040,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1060,9 +1058,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
+++ b/docs/communities/Microcoleus_Massilia_Cyanosphere_Urea_Mutualism.html
@@ -573,7 +573,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1100,14 +1100,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1120,9 +1118,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
+++ b/docs/communities/Miscanthus_REE_Tailings_Nitrogen_SynCom10.html
@@ -667,7 +667,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -779,14 +779,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -799,9 +797,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
+++ b/docs/communities/Mixed_Gallium_LED_Recovery_Consortium.html
@@ -617,7 +617,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1171,14 +1171,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1191,9 +1189,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
+++ b/docs/communities/Model_Cyanobacterial_Consortia_Core_Microbiome.html
@@ -549,7 +549,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -926,14 +926,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -946,9 +944,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
+++ b/docs/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.html
@@ -637,7 +637,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1168,14 +1168,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1188,9 +1186,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html
+++ b/docs/communities/Moss_Microbe_Complex_Regolith_Biofertilizer.html
@@ -581,7 +581,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -752,14 +752,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -772,9 +770,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Multi_stage_Anaerobic_Digestion_SynCom_YSJ_and_SynCom_J.html
+++ b/docs/communities/Multi_stage_Anaerobic_Digestion_SynCom_YSJ_and_SynCom_J.html
@@ -649,14 +649,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -669,9 +667,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
+++ b/docs/communities/Multiomics_Corn_Straw_Degradation_SynCom.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -661,14 +661,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -681,9 +679,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
+++ b/docs/communities/Mushroom_Spring_Hot_Spring_Phototrophic_Mat_Community.html
@@ -1109,14 +1109,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1129,9 +1127,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
+++ b/docs/communities/NCycle_Bioflocculation_Model_Consortium.html
@@ -666,14 +666,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -686,9 +684,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
+++ b/docs/communities/Naica_Deep_Subsurface_Thermophilic.html
@@ -1278,14 +1278,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1298,9 +1296,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
+++ b/docs/communities/Neocallimastix_Methanobrevibacter_Xylan_Coculture.html
@@ -970,14 +970,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -990,9 +988,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
+++ b/docs/communities/Ngawha_Geothermal_Mercury_Cycling_Community.html
@@ -854,14 +854,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -874,9 +872,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
+++ b/docs/communities/OMM12_Gnotobiotic_Mouse_Gut_Community.html
@@ -813,14 +813,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -833,9 +831,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
+++ b/docs/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.html
@@ -1285,14 +1285,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1305,9 +1303,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
+++ b/docs/communities/ORNL_PMI_Populus_PD10_SynCom.html
@@ -1642,14 +1642,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1662,9 +1660,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
+++ b/docs/communities/Oak_Ridge_FRC_Uranium_Nitrate_Groundwater_Community.html
@@ -924,14 +924,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -944,9 +942,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
+++ b/docs/communities/Okeke_Lu_Cellulolytic_Consortium.html
@@ -1228,14 +1228,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1248,9 +1246,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
+++ b/docs/communities/Ostreococcus_Dinoroseobacter_BVitamin_Mutualism.html
@@ -564,7 +564,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -965,14 +965,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -985,9 +983,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
+++ b/docs/communities/PET_Artificial_FourSpecies_Degradation_Consortium.html
@@ -1256,14 +1256,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1276,9 +1274,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
+++ b/docs/communities/PGM_Spent_Catalyst_Bioleaching.html
@@ -698,7 +698,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1555,14 +1555,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1575,9 +1573,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
+++ b/docs/communities/PMI_Variovorax_Thermotolerance_Collection.html
@@ -709,7 +709,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -971,14 +971,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -991,9 +989,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -943,14 +943,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -963,9 +961,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
+++ b/docs/communities/Panzhihua_Vanadium_Titanium_Tailings.html
@@ -775,7 +775,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1689,14 +1689,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1709,9 +1707,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.html
+++ b/docs/communities/Parachlorella_Saccharomyces_Mutualistic_Coculture.html
@@ -548,7 +548,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -779,14 +779,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -799,9 +797,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
+++ b/docs/communities/Peanut_Seed_Bacterial_CS_SynCom.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -611,14 +611,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -631,9 +629,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
+++ b/docs/communities/Pelotomaculum_Methanocella_Propionate_RNASeq_Coculture.html
@@ -573,7 +573,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1275,14 +1275,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1295,9 +1293,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
+++ b/docs/communities/Pelotomaculum_Methanothermobacter_Syntrophy.html
@@ -1307,14 +1307,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1327,9 +1325,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
+++ b/docs/communities/Pepper_Growth_Rhizosphere_SynCom.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -679,14 +679,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -699,9 +697,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pepper_Phytophthora_SynCom5.html
+++ b/docs/communities/Pepper_Phytophthora_SynCom5.html
@@ -625,7 +625,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -805,14 +805,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -825,9 +823,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Phenol_Carboxylation_Consortium.html
+++ b/docs/communities/Phenol_Carboxylation_Consortium.html
@@ -953,14 +953,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -973,9 +971,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Phormidium_Alkaline_Consortium.html
+++ b/docs/communities/Phormidium_Alkaline_Consortium.html
@@ -721,7 +721,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1451,14 +1451,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1471,9 +1469,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.html
+++ b/docs/communities/Phosphitivorax_Methanoculleus_Lithosyntrophy_Phosphite_Coculture.html
@@ -708,14 +708,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -728,9 +726,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
+++ b/docs/communities/Phylogenetically_Diverse_Denitrifying_SynCom.html
@@ -776,14 +776,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -796,9 +794,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.html
+++ b/docs/communities/Pinus_armandii_Endophytic_Biocontrol_SynCom.html
@@ -749,14 +749,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -769,9 +767,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.html
+++ b/docs/communities/Pleuromutilin_Degrading_Artificial_Consortium_5_Strain.html
@@ -758,14 +758,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -778,9 +776,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
+++ b/docs/communities/Polaromonas_Vanadium_Reduction_Community.html
@@ -703,7 +703,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1317,14 +1317,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1337,9 +1335,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Populus_Salt_Tolerant_SynComs.html
+++ b/docs/communities/Populus_Salt_Tolerant_SynComs.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -611,14 +611,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -631,9 +629,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
+++ b/docs/communities/Prairie_Pothole_Wetland_Sulfur_Carbon_Virus_Community.html
@@ -663,7 +663,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for Prairie Pothole Wetland Sulfur-Carbon Virus-Host Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (cross-feeding, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -681,8 +681,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -1264,14 +1264,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1284,9 +1282,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
+++ b/docs/communities/Premature_Infant_Gut_Escherichia_Diametric_Ratio_Community.html
@@ -766,14 +766,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -786,9 +784,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
+++ b/docs/communities/Prochlorococcus_Alteromonas_Helper_Coculture.html
@@ -909,14 +909,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -929,9 +927,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
+++ b/docs/communities/Propanotrophic_Chlorinated_Ethene_Cometabolism_Enrichment.html
@@ -1381,14 +1381,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1401,9 +1399,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
+++ b/docs/communities/Pseudomonas_Pedobacter_Social_Spreading_Coculture.html
@@ -564,7 +564,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -977,14 +977,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -997,9 +995,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
+++ b/docs/communities/Pseudomonas_Rhodococcus_Chloronitrobenzene_Coculture.html
@@ -1112,14 +1112,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1132,9 +1130,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.html
+++ b/docs/communities/Pseudomonas_putida_PpTE_Rhodococcus_RDK17_Terephthalic_Acid_Consortium.html
@@ -727,14 +727,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -747,9 +745,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.html
+++ b/docs/communities/Pseudomonas_stutzeri_Rhodococcus_Naphthalene_Biochar_Engineered_Consortium.html
@@ -676,14 +676,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -696,9 +694,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
+++ b/docs/communities/Pseudonitzschia_Sulfitobacter_Association.html
@@ -542,7 +542,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1051,14 +1051,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1071,9 +1069,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
+++ b/docs/communities/Rammelsberg_Cobalt_Nickel_Tailings.html
@@ -555,7 +555,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1111,14 +1111,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1131,9 +1129,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Ecoli_CrossFeeding_Coculture.html
@@ -739,14 +739,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -759,9 +757,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
+++ b/docs/communities/Rhodopseudomonas_Geobacter_Magnetite_Redox_Coculture.html
@@ -1191,14 +1191,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1211,9 +1209,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
+++ b/docs/communities/Rice_Acid_Soil_Bioinoculant_SynCom.html
@@ -499,7 +499,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -611,14 +611,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -631,9 +629,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
+++ b/docs/communities/Rice_Duckweed_Bacillus_SynCom.html
@@ -625,7 +625,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -857,14 +857,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -877,9 +875,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
+++ b/docs/communities/Rice_P_Uptake_Intercropping_SynCom4.html
@@ -625,7 +625,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -792,14 +792,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -812,9 +810,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Richmond_Mine_AMD_Biofilm.html
+++ b/docs/communities/Richmond_Mine_AMD_Biofilm.html
@@ -783,7 +783,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1956,14 +1956,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1976,9 +1974,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
+++ b/docs/communities/Rifle_Aquifer_Bioanode_EET_Community.html
@@ -1048,14 +1048,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1068,9 +1066,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Rifle_Uranium_Reducing_Community.html
+++ b/docs/communities/Rifle_Uranium_Reducing_Community.html
@@ -710,7 +710,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1451,14 +1451,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1471,9 +1469,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SF356_Cellulose_Degrader.html
+++ b/docs/communities/SF356_Cellulose_Degrader.html
@@ -673,7 +673,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1219,14 +1219,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1239,9 +1237,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
+++ b/docs/communities/SIHUMIx_Human_Intestinal_Model_Community.html
@@ -1176,14 +1176,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1196,9 +1194,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
+++ b/docs/communities/SMutans_CAlbicans_ECC_Biofilm.html
@@ -529,7 +529,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -776,14 +776,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -796,9 +794,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
+++ b/docs/communities/SMutans_SSputigena_ECC_Pathobiont.html
@@ -717,14 +717,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -737,9 +735,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SMutans_VParvula_ASC_Biofilm.html
+++ b/docs/communities/SMutans_VParvula_ASC_Biofilm.html
@@ -717,14 +717,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -737,9 +735,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Methane_Cycling_Community.html
@@ -898,14 +898,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -918,9 +916,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SPRUCE_Peatland_Warming_Community.html
+++ b/docs/communities/SPRUCE_Peatland_Warming_Community.html
@@ -654,7 +654,7 @@
                 <div class="network-tooltip" id="network-tooltip" role="status" aria-live="polite"></div>
                 <svg id="network-svg" role="img" aria-labelledby="network-svg-title network-svg-desc">
                     <title id="network-svg-title">Ecological interaction network for SPRUCE Peatland Warming Microbial Community</title>
-                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning, predation).</desc>
+                    <desc id="network-svg-desc">Bipartite graph where circle nodes represent taxa and each ecological interaction is drawn as a distinct non-circular symbol, with colour repeating the same distinction (mutualism, niche partitioning).</desc>
                 </svg>
                 <div class="network-legend">
                     <div class="legend-item">
@@ -663,7 +663,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -672,8 +672,8 @@
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
-                             aria-hidden="true" data-symbol="symbolStar"
-                             data-color="#913079"></svg> Predation
+                             aria-hidden="true" data-symbol="symbolTriangle2"
+                             data-color="#929caa"></svg> Other
                     </div>
                 </div>
             </div>
@@ -1235,14 +1235,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1255,9 +1253,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
+++ b/docs/communities/Saanich_Inlet_OMZ_Redox_Gradient_Community.html
@@ -967,14 +967,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -987,9 +985,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
+++ b/docs/communities/Saccharomyces_Acinetobacter_Lignocellulose_Detox_Coculture.html
@@ -824,14 +824,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -844,9 +842,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
+++ b/docs/communities/Saccharomyces_Chlamydomonas_Fungal_Algal_Mutualism.html
@@ -1022,14 +1022,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1042,9 +1040,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
+++ b/docs/communities/Salar_Atacama_Lithium_Brine_Community.html
@@ -732,7 +732,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1355,14 +1355,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1375,9 +1373,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
+++ b/docs/communities/Shewanella_Denitrifying_Richness_SynComs.html
@@ -684,14 +684,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -704,9 +702,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
+++ b/docs/communities/Shewanella_Geobacter_Exoelectrogenic_Biofilm_Community.html
@@ -612,7 +612,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -993,14 +993,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1013,9 +1011,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.html
+++ b/docs/communities/Shewanella_Pseudomonas_Fe0_Electrosyntrophic_Denitrifying_Consortium.html
@@ -776,14 +776,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -796,9 +794,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
+++ b/docs/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.html
@@ -1106,14 +1106,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1126,9 +1124,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.html
+++ b/docs/communities/Shewanella_oneidensis_Rhodopseudomonas_palustris_Electrosyntrophic_Coculture.html
@@ -623,14 +623,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -643,9 +641,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SkinCom_Synthetic_Skin_Community.html
+++ b/docs/communities/SkinCom_Synthetic_Skin_Community.html
@@ -679,14 +679,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -699,9 +697,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
+++ b/docs/communities/Soil_BGC_Phylum_Depth_Vegetation_Community.html
@@ -868,14 +868,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -888,9 +886,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
+++ b/docs/communities/Soil_CPR_Nanoarchaea_Rare_Biosphere_Community.html
@@ -758,14 +758,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -778,9 +776,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
+++ b/docs/communities/Soil_Corrinoid_B12_Reservoir_Community.html
@@ -850,14 +850,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -870,9 +868,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Sorghum_SRC1_Subset.html
+++ b/docs/communities/Sorghum_SRC1_Subset.html
@@ -752,7 +752,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1223,14 +1223,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1243,9 +1241,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -1146,14 +1146,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1166,9 +1164,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
+++ b/docs/communities/Soybean_Chlorophyll_Selected_Biofertilizer_SynCom.html
@@ -729,14 +729,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -749,9 +747,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Soybean_N_Fixation_sfSynCom.html
+++ b/docs/communities/Soybean_N_Fixation_sfSynCom.html
@@ -626,7 +626,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1391,14 +1391,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1411,9 +1409,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
+++ b/docs/communities/Sphingobium_Rhodococcus_Lignin_Dimer_Valorization_Coculture.html
@@ -1019,14 +1019,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1039,9 +1037,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
+++ b/docs/communities/Stordalen_Mire_Methylotrophic_Methanogenesis_Community.html
@@ -1159,14 +1159,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1179,9 +1177,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
+++ b/docs/communities/Subsurface_Carboxydocella_CO_Aquifer_Community.html
@@ -747,14 +747,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -767,9 +765,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.html
+++ b/docs/communities/Suillus_Bacillus_Thiamine_Ectomycorrhizal_SynCom.html
@@ -620,7 +620,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1250,14 +1250,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1270,9 +1268,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
+++ b/docs/communities/Sulfide_Spring_Autotrophic_CPR_Biofilm.html
@@ -844,14 +844,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -864,9 +862,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
+++ b/docs/communities/SynComBac10_Chicken_Intestinal_SynCom.html
@@ -684,14 +684,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -704,9 +702,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
+++ b/docs/communities/SynCom_ARC_Peanut_Aflatoxin_Nodulation.html
@@ -798,14 +798,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -818,9 +816,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.html
+++ b/docs/communities/SynCom_BsBv_Cigar_Tobacco_Leaf_Fermentation.html
@@ -541,7 +541,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -729,14 +729,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -749,9 +747,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.html
+++ b/docs/communities/SynCom_Chlorella_sorokiniana_Biogas_Slurry_Coupling_System.html
@@ -676,14 +676,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -696,9 +694,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.html
+++ b/docs/communities/SynCom_MetG2_Rhizobacteria_Sugarcane_Stress_Resilience.html
@@ -535,7 +535,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -668,14 +668,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -688,9 +686,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.html
+++ b/docs/communities/SynCom_Pseudomonas_Rahnella_Artemisia_Phytoremediation.html
@@ -615,14 +615,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -635,9 +633,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.html
+++ b/docs/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.html
@@ -1144,14 +1144,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1164,9 +1162,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.html
+++ b/docs/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.html
@@ -546,7 +546,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -828,14 +828,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -848,9 +846,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
+++ b/docs/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.html
@@ -571,7 +571,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1153,14 +1153,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1173,9 +1171,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Bacillus_SPC.html
+++ b/docs/communities/Synechococcus_Bacillus_SPC.html
@@ -784,14 +784,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -804,9 +802,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Ecoli_SPC.html
+++ b/docs/communities/Synechococcus_Ecoli_SPC.html
@@ -878,14 +878,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -898,9 +896,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
+++ b/docs/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.html
@@ -986,14 +986,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1006,9 +1004,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
+++ b/docs/communities/Synechococcus_Pseudomonas_PhotoPHA_DNT_Coculture.html
@@ -582,7 +582,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1350,14 +1350,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1370,9 +1368,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
+++ b/docs/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.html
@@ -1133,14 +1133,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1153,9 +1151,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synechococcus_Yarrowia_SPC.html
+++ b/docs/communities/Synechococcus_Yarrowia_SPC.html
@@ -789,14 +789,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -809,9 +807,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
+++ b/docs/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.html
@@ -551,7 +551,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -952,14 +952,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -972,9 +970,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
+++ b/docs/communities/Synthetic_Periphyton_Freshwater_Biofilm.html
@@ -776,14 +776,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -796,9 +794,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanobacterium_Syntrophy.html
@@ -1108,14 +1108,12 @@ Still open: carrier apportionment between H2 and formate for the M. formicicum p
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1128,9 +1126,7 @@ Still open: carrier apportionment between H2 and formate for the M. formicicum p
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophobacter_Methanospirillum_Syntrophy.html
@@ -1266,14 +1266,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1286,9 +1284,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
+++ b/docs/communities/Syntrophomonas_Methanococcus_Butyrate_Growth_Coordination_Coculture.html
@@ -568,7 +568,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1202,14 +1202,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1222,9 +1220,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
+++ b/docs/communities/Syntrophomonas_Methanospirillum_Syntrophy.html
@@ -1284,14 +1284,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1304,9 +1302,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Syntrophus_Benzoate_Degrader.html
+++ b/docs/communities/Syntrophus_Benzoate_Degrader.html
@@ -954,14 +954,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -974,9 +972,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
+++ b/docs/communities/Syntrophus_Methanospirillum_Gentianae_Benzoate_Coculture.html
@@ -1223,14 +1223,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1243,9 +1241,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/THOR_Rhizosphere_Model_Community.html
+++ b/docs/communities/THOR_Rhizosphere_Model_Community.html
@@ -959,14 +959,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -979,9 +977,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
+++ b/docs/communities/TYQ1_Nematode_Biocontrol_SynCom.html
@@ -799,7 +799,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1106,14 +1106,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1126,9 +1124,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
+++ b/docs/communities/Teosinte_Maize_Biofertilizer_SynCom7.html
@@ -625,7 +625,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -792,14 +792,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -812,9 +810,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
+++ b/docs/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.html
@@ -1108,14 +1108,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1128,9 +1126,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
+++ b/docs/communities/Thalassiosira_Ruegeria_Phycosphere_Coculture.html
@@ -1048,14 +1048,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1068,9 +1066,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
+++ b/docs/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.html
@@ -1356,14 +1356,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1376,9 +1374,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.html
+++ b/docs/communities/Thermophilic_Lignocellulose_Composting_SynCom_Biosanitization.html
@@ -857,14 +857,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -877,9 +875,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
+++ b/docs/communities/Thermophilic_Pyrite_QS_Consortium.html
@@ -681,7 +681,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1656,14 +1656,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1676,9 +1674,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
+++ b/docs/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.html
@@ -1145,14 +1145,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1165,9 +1163,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
+++ b/docs/communities/Thiocyanate_Afipia_Thiobacillus_Bioreactor_Community.html
@@ -923,14 +923,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -943,9 +941,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Tinto_River_Iron_Cycling_Community.html
+++ b/docs/communities/Tinto_River_Iron_Cycling_Community.html
@@ -728,7 +728,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1166,14 +1166,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1186,9 +1184,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
+++ b/docs/communities/Tobacco_Chemotactic_Biocontrol_SynCom.html
@@ -708,14 +708,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -728,9 +726,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Tomato_Oxylipin_SynCom3.html
+++ b/docs/communities/Tomato_Oxylipin_SynCom3.html
@@ -583,7 +583,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -695,14 +695,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -715,9 +713,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
+++ b/docs/communities/Tribromophenol_Anaerobic_Bioremediation_SynCom.html
@@ -763,14 +763,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -783,9 +781,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
+++ b/docs/communities/Trichococcus_Syntrophomonas_Methanospirillum_Butyrate_Coculture.html
@@ -1306,14 +1306,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1326,9 +1324,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
+++ b/docs/communities/Trichoderma_Ecoli_Cellulosic_Isobutanol_Coculture.html
@@ -1118,14 +1118,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1138,9 +1136,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Trichoderma_Lactate_Platform.html
+++ b/docs/communities/Trichoderma_Lactate_Platform.html
@@ -973,14 +973,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -993,9 +991,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
+++ b/docs/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.html
@@ -1087,14 +1087,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1107,9 +1105,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
+++ b/docs/communities/Trichodesmium_Alteromonas_Marine_Consortium.html
@@ -591,7 +591,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -989,14 +989,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1009,9 +1007,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Urine_Nitrification_SynCom.html
+++ b/docs/communities/Urine_Nitrification_SynCom.html
@@ -842,14 +842,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -862,9 +860,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
+++ b/docs/communities/Variovorax_Cryptococcus_Vitamin_Mutualism_Microcosm.html
@@ -562,7 +562,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -977,14 +977,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -997,9 +995,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
+++ b/docs/communities/Watermelon_Rhizosphere_Fusarium_SynCom8.html
@@ -541,7 +541,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -747,14 +747,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -767,9 +765,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
+++ b/docs/communities/Wetland_Oxygen_Sulfate_GHG_Microcosm_Community.html
@@ -1152,14 +1152,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1172,9 +1170,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Wheat_Consortium_C1.html
+++ b/docs/communities/Wheat_Consortium_C1.html
@@ -584,7 +584,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -838,14 +838,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -858,9 +856,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Wheat_Consortium_C6.html
+++ b/docs/communities/Wheat_Consortium_C6.html
@@ -584,7 +584,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -851,14 +851,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -871,9 +869,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
+++ b/docs/communities/Wheat_Straw_Biogas_Pretreatment_SynCom.html
@@ -640,7 +640,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -752,14 +752,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -772,9 +770,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
+++ b/docs/communities/Yogurt_TwoSpecies_Starter_Culture.html
@@ -588,7 +588,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
@@ -1254,14 +1254,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1274,9 +1272,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
+++ b/docs/communities/Zymomonas_Ecoli_Exometabolomics_Obligate_Mutualism.html
@@ -569,7 +569,7 @@
                     <div class="legend-item">
                         <svg class="legend-symbol" width="14" height="14" viewBox="-9 -9 18 18"
                              aria-hidden="true" data-symbol="symbolSquare"
-                             data-color="#56bbe6"></svg> Mutualism
+                             data-color="#9f2ebb"></svg> Mutualism
                     </div>
                 </div>
             </div>
@@ -1077,14 +1077,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1097,9 +1095,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/hCom2_Complex_Gut_Microbiome.html
+++ b/docs/communities/hCom2_Complex_Gut_Microbiome.html
@@ -705,14 +705,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -725,9 +723,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/communities/mCAFEs_Brachypodium_RCC.html
+++ b/docs/communities/mCAFEs_Brachypodium_RCC.html
@@ -1178,14 +1178,12 @@
     (function() {
         var interactionColors = {
             "CROSS_FEEDING": "#57c7ab",
-            "MUTUALISM": "#56bbe6",
+            "MUTUALISM": "#9f2ebb",
             "SYNTROPHY": "#7f30cf",
             "COMPETITION": "#a91919",
             "COMMENSALISM": "#cf7830",
             "NICHE_PARTITIONING": "#1212ed",
-            "COLONIZATION_FACILITATION": "#edab12",
-            "STRAIN_COMPETITION": "#cf30b7",
-            "PREDATION": "#913079"
+            "COLONIZATION_FACILITATION": "#edab12"
         };
         var unmappedColor = "#929caa";
 
@@ -1198,9 +1196,7 @@
             "COMPETITION": "symbolTimes",
             "COMMENSALISM": "symbolWye",
             "NICHE_PARTITIONING": "symbolSquare2",
-            "COLONIZATION_FACILITATION": "symbolPlus",
-            "STRAIN_COMPETITION": "symbolAsterisk",
-            "PREDATION": "symbolStar"
+            "COLONIZATION_FACILITATION": "symbolPlus"
         };
         var unmappedSymbol = "symbolTriangle2";
 

--- a/docs/community_umap.html
+++ b/docs/community_umap.html
@@ -5003,18 +5003,24 @@
         const margin = { top: 20, right: 20, bottom: 40, left: 40 };
 
         // Color schemes for different attributes with semantic, non-clashing colors
-        // Categorical 8 (CVD-safe, ordered by frequency) + Other (grey).
+        // Categorical 8 + Other (grey). Re-stepped in #601 so the set clears the
+        // same floor tests/test_network_palette.py holds the network palette to:
+        // delta-E >= 15 under normal, protan AND deutan vision. The previous set
+        // was described as CVD-safe but measured 6.9 under protanopia
+        // (LIGNOCELLULOSE/METHANOGENESIS - the classic red/green convergence).
+        // Hues keep their semantic assignment; separation comes from lightness.
+        // Do not retune by eye or one colour at a time.
         // The 8 most frequent categories get a distinct colour; the rest
         // (and OTHER) collapse to grey. Order is the colourblind-safety mechanism.
         const categoryColors = {
-            'RHIZOSPHERE': '#2a78d6',            // blue
-            'BIOTECHNOLOGY': '#1baf7a',          // aqua
-            'BIOREMEDIATION': '#eda100',         // yellow
-            'LIGNOCELLULOSE': '#008300',         // green
-            'SYNTROPHY': '#4a3aa7',              // violet
-            'METHANOGENESIS': '#e34948',         // red
-            'PHYTOPLANKTON': '#e87ba4',          // magenta
-            'CARBON_SEQUESTRATION': '#eb6834',   // orange
+            'RHIZOSPHERE': '#3169e1',            // blue
+            'BIOTECHNOLOGY': '#6bc6bf',          // aqua
+            'BIOREMEDIATION': '#f2a011',         // amber
+            'LIGNOCELLULOSE': '#49ba6f',         // green
+            'SYNTROPHY': '#5511f2',              // violet
+            'METHANOGENESIS': '#cb0d0a',         // red
+            'PHYTOPLANKTON': '#9f086f',          // magenta
+            'CARBON_SEQUESTRATION': '#e3703f',   // orange
             'OTHER': '#898781',                  // grey - collapsed
             'EXTREME_ENVIRONMENT': '#898781',    // grey - collapsed
             'BIOMINING': '#898781',              // grey - collapsed

--- a/justfile
+++ b/justfile
@@ -342,6 +342,15 @@ check-docs-current:
     # this gate reported it current, green in exactly the case where the
     # regeneration it gates on had not happened (#442 review).
     just gen-html
+    # EVERY generator whose output is committed under docs/ must run here. Not
+    # just gen-html: docs/community_umap.html comes from `gen-umap`, which this
+    # gate did not run, so that page could drift from its template forever and
+    # the gate stayed green because nothing regenerated it to produce a diff
+    # (#602 — a palette re-step reached the template and not the page). Safe to
+    # run: the embedding is seeded, so two runs are byte-identical. Adding a
+    # generator without adding it here is the omission this comment exists to
+    # make visible.
+    just gen-umap
     # An orphan: a page whose record was renamed or deleted. gen-html only ever
     # writes, so the stale page stays tracked and published while the diff stays
     # empty. f8d85b1 is a rename of exactly that shape.

--- a/justfile
+++ b/justfile
@@ -342,15 +342,13 @@ check-docs-current:
     # this gate reported it current, green in exactly the case where the
     # regeneration it gates on had not happened (#442 review).
     just gen-html
-    # EVERY generator whose output is committed under docs/ must run here. Not
-    # just gen-html: docs/community_umap.html comes from `gen-umap`, which this
-    # gate did not run, so that page could drift from its template forever and
-    # the gate stayed green because nothing regenerated it to produce a diff
-    # (#602 — a palette re-step reached the template and not the page). Safe to
-    # run: the embedding is seeded, so two runs are byte-identical. Adding a
-    # generator without adding it here is the omission this comment exists to
-    # make visible.
-    just gen-umap
+    # NOT `just gen-umap`, though docs/community_umap.html is also committed
+    # here. That recipe needs data/embeddings/*.tsv.gz, which is a large local
+    # artefact absent from CI, so running it here fails the gate outright
+    # (#602). The drift it would have caught — a template edit that never
+    # reaches the published page — is gated instead by
+    # tests/test_network_palette.py::test_published_umap_page_matches_the_template,
+    # which compares the two without regenerating anything.
     # An orphan: a page whose record was renamed or deleted. gen-html only ever
     # writes, so the stale page stays tracked and published while the diff stays
     # empty. f8d85b1 is a rename of exactly that shape.

--- a/src/communitymech/templates/community.html
+++ b/src/communitymech/templates/community.html
@@ -541,14 +541,12 @@
             and `tests/test_network_palette.py` must BOTH pass. -#}
         {%- set interaction_legend = [
             {"key": "CROSS_FEEDING", "label": "Cross-feeding", "color": "#57c7ab", "symbol": "symbolDiamond"},
-            {"key": "MUTUALISM", "label": "Mutualism", "color": "#56bbe6", "symbol": "symbolSquare"},
+            {"key": "MUTUALISM", "label": "Mutualism", "color": "#9f2ebb", "symbol": "symbolSquare"},
             {"key": "SYNTROPHY", "label": "Syntrophy", "color": "#7f30cf", "symbol": "symbolTriangle"},
             {"key": "COMPETITION", "label": "Competition", "color": "#a91919", "symbol": "symbolTimes"},
             {"key": "COMMENSALISM", "label": "Commensalism", "color": "#cf7830", "symbol": "symbolWye"},
             {"key": "NICHE_PARTITIONING", "label": "Niche partitioning", "color": "#1212ed", "symbol": "symbolSquare2"},
-            {"key": "COLONIZATION_FACILITATION", "label": "Colonization facilitation", "color": "#edab12", "symbol": "symbolPlus"},
-            {"key": "STRAIN_COMPETITION", "label": "Strain competition", "color": "#cf30b7", "symbol": "symbolAsterisk"},
-            {"key": "PREDATION", "label": "Predation", "color": "#913079", "symbol": "symbolStar"}
+            {"key": "COLONIZATION_FACILITATION", "label": "Colonization facilitation", "color": "#edab12", "symbol": "symbolPlus"}
         ] -%}
         {%- set unmapped_symbol = "symbolTriangle2" -%}
         {#- Mirror the script's `interaction_type or "UNKNOWN"` so a typeless

--- a/src/communitymech/templates/community_umap.html
+++ b/src/communitymech/templates/community_umap.html
@@ -676,18 +676,24 @@
         const margin = { top: 20, right: 20, bottom: 40, left: 40 };
 
         // Color schemes for different attributes with semantic, non-clashing colors
-        // Categorical 8 (CVD-safe, ordered by frequency) + Other (grey).
+        // Categorical 8 + Other (grey). Re-stepped in #601 so the set clears the
+        // same floor tests/test_network_palette.py holds the network palette to:
+        // delta-E >= 15 under normal, protan AND deutan vision. The previous set
+        // was described as CVD-safe but measured 6.9 under protanopia
+        // (LIGNOCELLULOSE/METHANOGENESIS - the classic red/green convergence).
+        // Hues keep their semantic assignment; separation comes from lightness.
+        // Do not retune by eye or one colour at a time.
         // The 8 most frequent categories get a distinct colour; the rest
         // (and OTHER) collapse to grey. Order is the colourblind-safety mechanism.
         const categoryColors = {
-            'RHIZOSPHERE': '#2a78d6',            // blue
-            'BIOTECHNOLOGY': '#1baf7a',          // aqua
-            'BIOREMEDIATION': '#eda100',         // yellow
-            'LIGNOCELLULOSE': '#008300',         // green
-            'SYNTROPHY': '#4a3aa7',              // violet
-            'METHANOGENESIS': '#e34948',         // red
-            'PHYTOPLANKTON': '#e87ba4',          // magenta
-            'CARBON_SEQUESTRATION': '#eb6834',   // orange
+            'RHIZOSPHERE': '#3169e1',            // blue
+            'BIOTECHNOLOGY': '#6bc6bf',          // aqua
+            'BIOREMEDIATION': '#f2a011',         // amber
+            'LIGNOCELLULOSE': '#49ba6f',         // green
+            'SYNTROPHY': '#5511f2',              // violet
+            'METHANOGENESIS': '#cb0d0a',         // red
+            'PHYTOPLANKTON': '#9f086f',          // magenta
+            'CARBON_SEQUESTRATION': '#e3703f',   // orange
             'OTHER': '#898781',                  // grey - collapsed
             'EXTREME_ENVIRONMENT': '#898781',    // grey - collapsed
             'BIOMINING': '#898781',              // grey - collapsed

--- a/tests/test_network_palette.py
+++ b/tests/test_network_palette.py
@@ -419,3 +419,39 @@ def test_umap_palette_has_the_expected_shape():
     palette = _umap_palette()
     assert len(palette) >= 8, f"only {len(palette)} UMAP categories parsed: {sorted(palette)}"
     assert "_other" in palette, "the collapsed-category grey was not identified"
+
+
+def test_published_umap_page_matches_the_template():
+    """The published UMAP page must carry the template's colours (#602).
+
+    `check-docs-current` regenerates and diffs `docs/`, but only via `gen-html`.
+    `docs/community_umap.html` comes from `gen-umap`, which needs a large
+    embeddings artefact that CI does not have — so that recipe cannot run in the
+    gate, and the page could drift from its template indefinitely with nothing
+    to notice. Caught for real while re-stepping the palette in #601: the
+    template had the new colours, `gen-html` ran clean, the gate said
+    "✅ docs/ matches the KB", and the published page still served the old ones.
+
+    Comparing the two files needs no embeddings, so it works where regeneration
+    does not. It checks the property that actually matters — what a reader is
+    served — rather than the process that produces it.
+    """
+    published = Path(__file__).parent.parent / "docs/community_umap.html"
+    if not published.is_file():
+        pytest.skip("docs/community_umap.html is not built in this checkout")
+
+    def categories(text: str) -> dict[str, str]:
+        block = re.search(r"const\s+categoryColors\s*=\s*\{(.*?)\};", text, re.DOTALL)
+        assert block, "categoryColors not found"
+        return dict(re.findall(r"'([A-Z_]+)':\s*'(#[0-9a-fA-F]{6})'", block.group(1)))
+
+    in_template = categories(UMAP_TEMPLATE.read_text())
+    on_page = categories(published.read_text())
+
+    drifted = {k: (v, on_page.get(k)) for k, v in in_template.items() if on_page.get(k) != v}
+    assert not drifted, (
+        "docs/community_umap.html does not carry the template's category "
+        "colours — a template edit that never reached the published page "
+        f"(#602). template vs published: {drifted}. Run `just gen-umap` and "
+        "commit the result."
+    )

--- a/tests/test_network_palette.py
+++ b/tests/test_network_palette.py
@@ -33,6 +33,7 @@ import colorsys
 import itertools
 import math
 import re
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -46,8 +47,28 @@ SCHEMA = Path(__file__).parent.parent / "src/communitymech/schema/communitymech.
 # replaced measured 0.0 (taxon and MUTUALISM were the same hex).
 MIN_SEPARATION = 15.0
 
-# Enum whose permissible values the palette must cover exactly.
+# Enum whose permissible values the palette must cover, apart from FOLDED.
 INTERACTION_ENUM = "InteractionTypeEnum"
+
+# Types deliberately drawn with the grey "Other" swatch rather than a hue of
+# their own (#532). Nine colours cannot be separated under protan, deutan AND
+# tritan at once — the comment on `test_tritan_collisions_are_documented` said
+# so, and the palette shipped with four tritan collisions as the price. Seven
+# can: dropping these two frees the magenta region, which is where MUTUALISM had
+# to move to stop colliding with CROSS_FEEDING under tritanopia.
+#
+# Chosen on usage, not aesthetics, and the counts are re-checked by
+# `test_folded_types_are_still_the_rare_ones` so this cannot quietly become
+# wrong as the KB grows.
+FOLDED = {
+    "STRAIN_COMPETITION": "1 occurrence in the KB",
+    "PREDATION": "11 occurrences; the next-rarest coloured type has 67",
+}
+
+# No coloured type may be rarer than a folded one by more than this factor —
+# the justification is "these two are far rarer than everything else", and that
+# claim has to keep holding.
+FOLD_HEADROOM = 2
 
 
 # --------------------------------------------------------------------------
@@ -166,11 +187,18 @@ def test_palette_covers_the_interaction_enum_exactly():
     than failing, so only this comparison catches a newly added enum value.
     """
     palette, enum = set(_palette()), _enum_values()
-    assert not (enum - palette), (
+    uncoloured = enum - palette - set(FOLDED)
+    assert not uncoloured, (
         f"{INTERACTION_ENUM} values with no colour in {TEMPLATE.name}: "
-        f"{sorted(enum - palette)}. They would render as a grey 'Other' swatch "
+        f"{sorted(uncoloured)}. They would render as a grey 'Other' swatch "
         f"on every page instead of failing. Add them to `interaction_legend` "
-        f"and rerun this module to confirm separation still holds."
+        f"and rerun this module to confirm separation still holds — or, if they "
+        f"are genuinely too rare to earn a hue, add them to FOLDED with a count."
+    )
+    stale_folds = set(FOLDED) - enum
+    assert not stale_folds, (
+        f"FOLDED names values not in {INTERACTION_ENUM}: {sorted(stale_folds)}. "
+        f"Remove them, or restore the enum value."
     )
     assert not (palette - enum), (
         f"colours in {TEMPLATE.name} for values not in {INTERACTION_ENUM}: "
@@ -256,9 +284,21 @@ def test_tritan_collisions_are_documented():
         for a, b in itertools.combinations(swatches, 2)
         if _delta_e(swatches[a], swatches[b], "tritan") < MIN_SEPARATION
     )
-    assert len(collisions) <= 4, (
+    # Ratcheted from 4 to 1 by #532. Folding the two rarest types freed the
+    # magenta region, MUTUALISM moved into it, and CROSS_FEEDING/MUTUALISM went
+    # from ΔE 1.8 to 68.4 under tritanopia. The single survivor is
+    # SYNTROPHY/_taxon, which shape already separates — taxa are circles and
+    # every interaction is a non-circular symbol (#270).
+    between_types = [c for c in collisions if not (c[1].startswith("_") or c[2].startswith("_"))]
+    assert between_types == [], (
+        f"two interaction types collide under tritanopia: {between_types}. "
+        f"Since #532 the coloured types are separable under normal, protan, "
+        f"deutan AND tritan; do not trade that away."
+    )
+    assert len(collisions) <= 1, (
         f"tritanopia collisions grew to {len(collisions)} pairs: {collisions}. "
-        f"The palette shipped with 4; a retune should not make this worse."
+        f"The palette ships with 1 (a type against the grey taxon node, which "
+        f"shape distinguishes); a retune should not make this worse."
     )
 
 
@@ -275,3 +315,33 @@ def test_hues_are_spread_around_the_wheel():
         f"two interaction hues are only {min(gaps):.1f}° apart (hues: "
         f"{[round(h) for h in hues]}); colours this close read as one family."
     )
+
+
+def test_folded_types_are_still_the_rare_ones():
+    """The fold is justified by usage, so the usage claim must keep holding (#532).
+
+    `FOLDED` drops two interaction types to the grey "Other" swatch because they
+    are far rarer than everything else — 1 and 11 occurrences against a
+    next-rarest coloured type of 67. That is a fact about today's KB, not a
+    property of the enum, and curation moves. If a folded type becomes common,
+    the reasoning has inverted and somebody should look rather than discover it
+    in a figure.
+    """
+    counts = Counter()
+    for path in sorted((Path(__file__).parent.parent / "kb/communities").glob("*.yaml")):
+        for match in re.finditer(
+            r"interaction_type:\s*([A-Z_]+)", path.read_text(encoding="utf-8")
+        ):
+            counts[match.group(1)] += 1
+
+    assert counts, "no interaction types found; the scan is broken"
+
+    rarest_coloured = min(counts.get(key, 0) for key in _palette())
+    for folded in FOLDED:
+        assert counts.get(folded, 0) * FOLD_HEADROOM <= rarest_coloured, (
+            f"{folded} is folded into the grey 'Other' swatch as too rare to "
+            f"earn a hue, but it now has {counts.get(folded, 0)} occurrences "
+            f"against a rarest-coloured-type count of {rarest_coloured}. Give it "
+            f"a colour and re-run the separation tests, or widen FOLD_HEADROOM "
+            f"deliberately."
+        )

--- a/tests/test_network_palette.py
+++ b/tests/test_network_palette.py
@@ -345,3 +345,77 @@ def test_folded_types_are_still_the_rare_ones():
             f"a colour and re-run the separation tests, or widen FOLD_HEADROOM "
             f"deliberately."
         )
+
+
+# --------------------------------------------------------------------------
+# The UMAP page's category palette (#601)
+# --------------------------------------------------------------------------
+
+UMAP_TEMPLATE = Path(__file__).parent.parent / "src/communitymech/templates/community_umap.html"
+
+
+def _umap_palette() -> dict[str, str]:
+    """The category → colour map on the UMAP page, minus the collapsed greys.
+
+    Parsed from the template rather than duplicated here, for the same reason
+    `_palette()` is: a copy in the test would keep passing after the page
+    changed. Entries sharing the grey are the deliberately collapsed
+    categories — they are one visual class, so they are folded to a single
+    `_other` swatch rather than compared against each other.
+    """
+    text = UMAP_TEMPLATE.read_text()
+    # Scoped to `categoryColors` deliberately. The page defines several
+    # independent schemes (`stateColors`, `originColors`) for other colour-by
+    # modes; they are never on screen together, so comparing across them would
+    # invent failures — a first version of this parser did exactly that.
+    block = re.search(r"const\s+categoryColors\s*=\s*\{(.*?)\};", text, re.DOTALL)
+    assert block, f"categoryColors not found in {UMAP_TEMPLATE.name} — did it move?"
+    pairs = re.findall(r"'([A-Z_]+)':\s*'(#[0-9a-fA-F]{6})'", block.group(1))
+    assert pairs, f"no category colours parsed from {UMAP_TEMPLATE.name}"
+    by_key = dict(pairs)
+    grey = Counter(by_key.values()).most_common(1)[0][0]
+    palette = {k: v for k, v in by_key.items() if v != grey}
+    palette["_other"] = grey
+    return palette
+
+
+@pytest.mark.parametrize("kind", [None, "protan", "deutan"])
+def test_umap_categories_stay_separated_under_colour_vision_deficiency(kind):
+    """One standard for both palettes (#601).
+
+    The network palette has been gated at MIN_SEPARATION since #269; the UMAP
+    page's palette was hand-picked, described as "CVD-safe 8" in #199, and read
+    by no test. Measured, it sat at ΔE 6.9 under protanopia —
+    LIGNOCELLULOSE/METHANOGENESIS, the classic red/green convergence — and
+    BIOTECHNOLOGY collided with the collapsed grey at 10.4 under deuteranopia.
+
+    Same defect shape as #588: a rule applied to one artefact and not its
+    sibling.
+    """
+    palette = _umap_palette()
+    worst = min(
+        (
+            (_delta_e(palette[a], palette[b], kind), a, b)
+            for a, b in itertools.combinations(palette, 2)
+        ),
+        key=lambda row: row[0],
+    )
+    distance, first, second = worst
+    assert distance >= MIN_SEPARATION, (
+        f"UMAP categories {first} ({palette[first]}) and {second} "
+        f"({palette[second]}) are only ΔE {distance:.1f} apart under "
+        f"{kind or 'normal'} vision, below the {MIN_SEPARATION} floor. "
+        f"Re-step them together rather than lowering the floor — hues carry "
+        f"semantic meaning here, so separate on lightness."
+    )
+
+
+def test_umap_palette_has_the_expected_shape():
+    """Guard: an empty or half-parsed palette passes the separation test.
+
+    `_umap_palette` reads a JS object literal out of an HTML template, which is
+    exactly the kind of extraction that silently returns `{}` after a refactor.
+    """
+    palette = _umap_palette()
+    assert len(palette) >= 8, f"only {len(palette)} UMAP categories parsed: {sorted(palette)}"
+    assert "_other" in palette, "the collapsed-category grey was not identified"


### PR DESCRIPTION
Closes #532. Unblocks #199. Implements the decision: **fold the two rarest interaction types into "Other".**

## The constraint this removes

`tests/test_network_palette.py` stated it in its own docstring:

> no nine-colour set survives all three deficiency types at once

The palette shipped with **four documented tritan collisions** as the price, the worst being `CROSS_FEEDING` vs `MUTUALISM` at **ΔE 1.8** — the two commonest interaction types in the KB (252 and 229 occurrences), indistinguishable to a tritanope.

**Seven colours do survive.**

## Folding is the enabler, not the fix — worth being precise

The two rarest types are `STRAIN_COMPETITION` (**1** occurrence) and `PREDATION` (**11**, against **67** for the next-rarest coloured type). The failing pair was the two *commonest*. So folding does not directly repair anything.

What it buys is **the magenta region those two occupied** — and that is exactly where `MUTUALISM` had to move, because under tritanopia every blue converges on the teal of `CROSS_FEEDING`. The fold and the re-step are one change.

`MUTUALISM` `#56bbe6` → `#9f2ebb`.

## Measured, with the module's own Viénot–Brettel–Mollon projection

| check | before | after | floor |
|---|---|---|---|
| normal / protan / deutan minimum | 15.4 / 17.0 / 15.7 | **15.4 / 17.0 / 15.7** | 15.0 |
| `CROSS_FEEDING`↔`MUTUALISM` under tritan | **1.8** | **68.4** | — |
| tritan collisions *between interaction types* | 2 | **0** | — |
| documented tritan collisions total | 4 | **1** | was ≤4 |
| contrast light / dark | — | 5.86:1 / 3.13:1 | 1.9 |

The single remaining collision is `SYNTROPHY` against the **grey taxon node** — which shape already separates, since taxa are circles and every interaction is a non-circular symbol (#270). The test now asserts **zero** collisions between interaction types and ratchets the documented total from 4 to 1.

## The enum is untouched

All nine values remain — records still use them, and folded types render with the grey "Other" swatch the template already had for unmapped keys. `FOLDED` is explicit and reasoned, so a *newly added* enum value still fails rather than silently rendering grey, which is the defect this module was written to catch.

`test_folded_types_are_still_the_rare_ones` re-derives the counts from the KB, so the justification cannot rot: if a folded type becomes common, or a coloured type becomes rarer than a folded one, it goes red.

## What I could not verify, and why the issue's proposal wasn't taken as offered

The dataviz rubric's **OKLab validator is not present in this environment** (`scripts/` in the bundled skill is empty). That is the check that reported the original ΔE 10.3 normal-vision failure, and it should be re-run when available.

The two metrics genuinely disagree on that pair: CIE76 puts `#56bbe6`↔`#57c7ab` at **41.1** while the rubric's OKLab put it at **10.3**. Separately, the issue's proposed re-step `#edab12 → #b8860b` **fails this module's deutan floor at ΔE 1.5** against `COMMENSALISM` — so it could not be adopted, and I searched for a replacement that satisfies the gate the repo actually runs.

## Mutation checks

| reverted | result |
|---|---|
| `MUTUALISM` back to `#56bbe6` | 1 failed (tritan collisions) |
| `PREDATION` removed from `FOLDED` | 1 failed (enum coverage) |
| `FOLD_HEADROOM` 2 → 200 | 1 failed (usage justification) |
| nothing | 10 passed |

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2465 passed**. Regenerated HTML for all 309 affected pages is included.