### PR TITLE
Put the UMAP filters above the plot they filter (#199)

### DIFF
--- a/docs/community_umap.html
+++ b/docs/community_umap.html
@@ -566,12 +566,12 @@
 
         <div class="main-container">
             <!-- Plot and legend on top -->
-            <div class="plot-container">
-                <div id="umap-plot"></div>
-                <div class="legend" id="legend"></div>
-            </div>
-
-            <!-- Facet/search panel below the plot -->
+            <!-- Filters precede the plot (#199). The dataviz rubric puts
+                 filter controls above the chart they act on; this panel sat
+                 below it, so a reader met the plot before the means of
+                 narrowing it. Reordered in the DOM rather than with
+                 flex-direction: column-reverse, so screen-reader and tab
+                 order match what is on screen. -->
             <div class="filter-panel">
                 <!-- Enhanced search -->
                 <div class="search-container">
@@ -629,6 +629,12 @@
                         <div id="origin-checkboxes" class="facet-checkboxes"></div>
                     </div>
                 </div>
+            </div>
+
+            <!-- Facet/search panel below the plot -->
+            <div class="plot-container">
+                <div id="umap-plot"></div>
+                <div class="legend" id="legend"></div>
             </div>
         </div>
 

--- a/src/communitymech/templates/community_umap.html
+++ b/src/communitymech/templates/community_umap.html
@@ -566,12 +566,12 @@
 
         <div class="main-container">
             <!-- Plot and legend on top -->
-            <div class="plot-container">
-                <div id="umap-plot"></div>
-                <div class="legend" id="legend"></div>
-            </div>
-
-            <!-- Facet/search panel below the plot -->
+            <!-- Filters precede the plot (#199). The dataviz rubric puts
+                 filter controls above the chart they act on; this panel sat
+                 below it, so a reader met the plot before the means of
+                 narrowing it. Reordered in the DOM rather than with
+                 flex-direction: column-reverse, so screen-reader and tab
+                 order match what is on screen. -->
             <div class="filter-panel">
                 <!-- Enhanced search -->
                 <div class="search-container">
@@ -629,6 +629,12 @@
                         <div id="origin-checkboxes" class="facet-checkboxes"></div>
                     </div>
                 </div>
+            </div>
+
+            <!-- Facet/search panel below the plot -->
+            <div class="plot-container">
+                <div id="umap-plot"></div>
+                <div class="legend" id="legend"></div>
             </div>
         </div>
 

--- a/tests/test_network_palette.py
+++ b/tests/test_network_palette.py
@@ -455,3 +455,28 @@ def test_published_umap_page_matches_the_template():
         f"(#602). template vs published: {drifted}. Run `just gen-umap` and "
         "commit the result."
     )
+
+
+def test_umap_filters_precede_the_plot():
+    """Filter controls come before the chart they act on (#199).
+
+    The dataviz rubric puts filters above the plot; this panel sat below it, so
+    a reader met the visualisation before the means of narrowing it. Asserted on
+    DOM order rather than on CSS because that is what screen readers and tab
+    order follow — a `flex-direction: column-reverse` would satisfy the eye and
+    not the keyboard.
+
+    Checked in the template *and* in the published page, since those can drift
+    (#602).
+    """
+    for source in (UMAP_TEMPLATE, Path(__file__).parent.parent / "docs/community_umap.html"):
+        if not source.is_file():
+            continue
+        text = source.read_text()
+        filters = text.find('class="filter-panel"')
+        plot = text.find('class="plot-container"')
+        assert filters != -1 and plot != -1, f"expected both panels in {source.name}"
+        assert filters < plot, (
+            f"in {source.name} the filter panel comes after the plot it filters. "
+            f"Reorder the DOM (not the CSS — screen readers follow source order)."
+        )


### PR DESCRIPTION
Closes #199.

## The last actionable item

The dataviz rubric puts filter controls **above** the chart they act on. `.main-container` is `flex-direction: column` with `.plot-container` first, so a reader met the visualisation before the means of narrowing it.

Reordered **in the DOM**, not with `flex-direction: column-reverse` — a CSS-only flip satisfies the eye and not the keyboard, since screen readers and tab order follow source order.

The encoding controls (`colour-by`, `size-by`) were already above the plot; it was the search/facet panel that sat below.

## The issue's other open item was already done

#199 lists "UMAP/graph header lacks the brand hero gradient" as open. It is not — `header` carries the same `135deg` pair as `community.html`, `landing.html` and `index.html`, with a comment citing this very issue. The checklist had simply not been ticked. Worth noting rather than silently ticking, because it means the issue overstated what remained.

## Verification

Reordering markup by script is easy to get wrong, so:

```
div balance:        32 open vs 32 close
plot markup intact: True
search input intact: True
controls still above: True
published order correct: True
```

`test_umap_filters_precede_the_plot` asserts the order in **both** the template and the published page, since those can drift (#602). Mutation checked by swapping the two panels back — goes red.

## Gates

`lint` 0, `validate-strict` 0, `check-docs-current` 0, **2502 passed**.

## What this leaves

With this merged, #183 is the only one of the original 31 still open, and it is open-ended by nature — enriching records as full text becomes retrievable. The measured next step there is #591, with a 66% expected yield across 53 retrievable references.