### PR TITLE
Three cultivation setups the #591 sweep made curatable (#183)

### DIFF
--- a/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
+++ b/kb/communities/SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus.yaml
@@ -350,3 +350,33 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: Each strain in the SynComs was mixed at an equal concentration of 1 × 10 5 CFU/mL.
     explanation: Inoculum composition for the assembled SynCom.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: Solid-state fermentation bags embedded 0.5 m deep in the upper
+    layer of a baijiu fermentation pit, at a sesame-flavour baijiu distillery in
+    Suqian City, Jiangsu, China.
+  controls_notes: 500 g of mixed grains per bag, blended 4.5:1 last-batch to fresh,
+    steamed and cooled before the SynCom was inoculated; each member mixed in at an
+    equal 1 x 10^5 CFU/mL; fermented 30 d.
+  notes: 'Solid-state, so there is no working volume to record: the charge is a mass
+    of grain, not a liquid, and `working_volume` takes volume units only. Duration is
+    kept here rather than in `retention_time` because `retention_time_type` offers
+    only HRT and SRT, both of which describe continuous systems; this is a 30-day
+    batch. The per-strain incubations the paper also gives (yeast 30 C/24 h, most
+    bacteria 37 C/14 h, L. acetotolerans anaerobic 37 C/3 d, A. oryzae 30 C/5 d) are
+    seed-culture preparation and are deliberately NOT recorded as the community''s
+    conditions (#529).'
+  evidence:
+  - reference: PMID:42121419
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A total of 500 g of mixed materials was placed into fermentation bags.
+      After steaming and cooling, the SynCom was inoculated into the materials. The
+      fermentation bags were then embedded in the upper layer of the pit (0.5 m deep)
+      to simulate actual baijiu fermentation for 30 d
+  - reference: PMID:42121419
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Each strain in the SynComs was mixed at an equal concentration of 1 × 105
+      CFU/mL

--- a/kb/communities/Synechococcus_Bacillus_SPC.yaml
+++ b/kb/communities/Synechococcus_Bacillus_SPC.yaml
@@ -186,3 +186,30 @@ growth_media:
     snippet: CoB BG-11 consists of BG-11 supplemented with 106 mM NaCl, 4 mM NH4Cl and 25 mM HEPPSO,
       pH 8.3-KOH
     explanation: Defined prokaryote co-culture medium for the Synechococcus/Bacillus consortium.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: FLASK
+  instrument_detail: Multitron Infors HT incubator; 15 W Gro-Lux Sylvania fluorescent bulbs
+  working_volume: 25.0
+  working_volume_unit: mL
+  operating_temperature: 35.0
+  operating_temperature_unit: °C
+  temperature_controlled: true
+  controls_notes: 150 rpm shaking, 2% CO2, constant light at PAR ~80 umol photons
+    m-2 s-1.
+  notes: Stated for the co-cultures themselves, not inferred from either member.
+    The heterotrophs were prepared separately in rich media at 37 C (B. subtilis,
+    E. coli) or 30 C (S. cerevisiae) and then acclimated into co-culture medium
+    before mixing, so those temperatures belong to strain preparation rather than
+    to the consortium (#529).
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: All acclimating cultures and co-cultures were grown at 35 °C, 150 rpm,
+      2% CO2, in light (PAR = ~80 μmol with 15 W Gro-Lux Sylvania fluorescent bulbs)
+      within a Multitron Infors HT incubator
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Data for growth rate was collected from 25 mL flask

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -268,3 +268,30 @@ growth_media:
     snippet: CoB BG-11 consists of BG-11 supplemented with 106 mM NaCl, 4 mM NH4Cl and 25 mM HEPPSO,
       pH 8.3-KOH
     explanation: Defined prokaryote co-culture medium for the Synechococcus/E. coli consortium.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: FLASK
+  instrument_detail: Multitron Infors HT incubator; 15 W Gro-Lux Sylvania fluorescent bulbs
+  working_volume: 25.0
+  working_volume_unit: mL
+  operating_temperature: 35.0
+  operating_temperature_unit: °C
+  temperature_controlled: true
+  controls_notes: 150 rpm shaking, 2% CO2, constant light at PAR ~80 umol photons
+    m-2 s-1.
+  notes: Stated for the co-cultures themselves, not inferred from either member.
+    The heterotrophs were prepared separately in rich media at 37 C (B. subtilis,
+    E. coli) or 30 C (S. cerevisiae) and then acclimated into co-culture medium
+    before mixing, so those temperatures belong to strain preparation rather than
+    to the consortium (#529).
+  evidence:
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: All acclimating cultures and co-cultures were grown at 35 °C, 150 rpm,
+      2% CO2, in light (PAR = ~80 μmol with 15 W Gro-Lux Sylvania fluorescent bulbs)
+      within a Multitron Infors HT incubator
+  - reference: PMID:28127397
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Data for growth rate was collected from 25 mL flask


### PR DESCRIPTION
Part of #183. First curation round using the full text the #591 re-sweep retrieved.

## How the candidates were picked

The sweep left **111 records** with no `cultivation_setup` but at least one full-text reference. Scoring those by cultivation vocabulary ("were grown in", "incubated at", "rpm", "serum bottle", "chemostat", …) narrowed it to **11 strong candidates**. This PR works the top of that list.

## Curated (3)

**`Synechococcus_Bacillus_SPC`** and **`Synechococcus_Ecoli_SPC`** — one sentence in PMID:28127397 states conditions for the co-cultures themselves:

> "All acclimating cultures and **co-cultures** were grown at 35 °C, 150 rpm, 2% CO2, in light (PAR = ~80 μmol …) within a Multitron Infors HT incubator"

plus 25 mL flasks. The paper *also* gives 37 °C for *E. coli*/*B. subtilis* and 30 °C for *S. cerevisiae* — those are **seed-culture preparation before mixing**, and are deliberately not recorded as the consortium's conditions (#529). The note says so, so the omission reads as a decision rather than an oversight.

**`SynCom_Sesame_Flavor_Baijiu_Fuqu_13Genus`** — solid-state, and pleasingly unlike anything else in the KB: 500 g of grain blended 4.5:1 last-batch to fresh, steamed, inoculated with each member at 1 × 10⁵ CFU/mL, sealed into bags and **embedded 0.5 m deep in a distillery fermentation pit for 30 days**.

Two schema notes recorded in the record itself: no `working_volume`, because the charge is a *mass* and that slot takes volume units; and duration in `notes` rather than `retention_time`, because `retention_time_type` offers only HRT and SRT, both of which describe continuous systems.

## Refused (1)

**`Tobacco_Chemotactic_Biocontrol_SynCom`** (PMID:40670700) — 30 °C / 150 rpm is given for *individual strains* grown overnight in TSB, and 30 °C / 100 rpm for a 96-well chemotaxis assay. The SynCom itself is applied as a solid formulation at 5% (v/w). No community-level vessel conditions, so nothing to record (#529).

## One integrity finding, filed not fixed

Checking membership before curating turned up **#605**: `Synechococcus_Yarrowia_SPC` claims *Yarrowia lipolytica* Po1g, and its **only** reference contains **zero** mentions of Yarrowia or lipolytica — the paper's three heterotrophs are *B. subtilis*, *E. coli* and *S. cerevisiae*.

Every snippet in that record is a **verbatim quote** and validates cleanly, which is exactly why nothing caught it. The membership claim is backed by *"we observed heterotrophic growth dependent upon cyanobacterial photosynthate in each co-culture pair"* — true, quoted correctly, and incapable of identifying which heterotroph. Left for a curator with the literature rather than guessed at.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.