### PR TITLE
Two more cultivation setups, and two refusals worth their reasons (#183)

### DIFF
--- a/kb/communities/DVM_Triculture.yaml
+++ b/kb/communities/DVM_Triculture.yaml
@@ -486,3 +486,34 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: "chemically defined media with lactate (30 mM), as the sole organic carbon source"
     explanation: "Documents lactate (30 mM) as the sole organic carbon source."
+cultivation_setup:
+- cultivation_mode: SEMI_CONTINUOUS
+  system_type: SERUM_BOTTLE
+  working_volume: 30.0
+  working_volume_unit: mL
+  controls_notes: Anaerobic serum flasks, 30 mL medium in a 50 mL flask; chemically
+    defined medium with 30 mM Na-lactate as sole organic carbon source and Na2SO4
+    added at varying levels; sub-cultured twice over three-week periods.
+  notes: 'Recorded as semi-continuous because the community was serially sub-cultured
+    rather than run as a single closed batch — the authors describe the regime as
+    mimicking "a low-flow, chemostat-like system", but no dilution rate is given, so
+    CHEMOSTAT would overstate it. The 30 mL in 50 mL flask figure comes from the
+    media-preparation sentence, which is where the paper states the vessel and fill
+    volume; the lactate and sulfate additions are stated for the co- and tri-cultures
+    specifically.'
+  evidence:
+  - reference: doi:10.1098/rsif.2019.0129
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Each constructed community was incubated, and sub-cultured twice, over
+      three-week periods. These conditions mimicked a low-flow, chemostat-like system
+  - reference: doi:10.1098/rsif.2019.0129
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: This solution was filter sterilized into a sterile anaerobic serum flask
+      (30 ml in 50 ml flask)
+  - reference: doi:10.1098/rsif.2019.0129
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: For the co- and tri-cultures, 30 mM Na-lactate was added as the carbon
+      source

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -259,4 +259,30 @@ related_ingredients:
     snippet: sucrose-secreting cyanobacterium Synechococcus elongatus
     explanation: Names sucrose as the metabolite secreted by the engineered cyanobacterial partner.
 metal_relevance: NOT_APPLICABLE
-
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: FLASK
+  notes: 'The paper ran the same consortium two ways and reports both; this is the
+    batch arm. Temperature, light and CO2 are given only for each partner''s seed
+    preparation (S. elongatus in 250 mL flasks, the yeasts in 150 mL flasks, both at
+    28 C), never for the co-culture itself, so they are deliberately not recorded
+    here (#529).'
+  evidence:
+  - reference: doi:10.1186/s13068-017-0736-x
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Co-cultures of <i>S. elongatus</i> and <i>R. glutinis</i> were sustained
+      over 1 month in both batch and in semi-continuous culture
+- cultivation_mode: SEMI_CONTINUOUS
+  system_type: FLASK
+  controls_notes: 50 mL of culture withdrawn and replaced with 50 mL fresh BG-11[co]
+    medium at days 10 and 21.
+  notes: The semi-continuous arm of the same experiment. The exchange volume is
+    stated but the total working volume is not, so it is left unset rather than
+    inferred from it.
+  evidence:
+  - reference: doi:10.1186/s13068-017-0736-x
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Arrows indicate the time when 50 mL of original culture was withdrawn and
+      50 mL of fresh BG-11[co] medium was added


### PR DESCRIPTION
Part of #183. Second pass over the 11 vocabulary-scored candidates.

## Curated (2)

**`Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture`** gets **two arms**, because the paper ran the same consortium two ways — a batch culture, and a semi-continuous one where **50 mL was withdrawn and replaced with fresh BG-11[co] at days 10 and 21**, sustained over a month.

Two deliberate omissions, both noted in the record: temperature/light/CO₂ appear only in each partner's *seed preparation* (S. elongatus in 250 mL flasks, the yeasts in 150 mL, both at 28 °C) and never for the co-culture (#529); and `working_volume` is left unset because the *exchange* volume is stated while the total is not — inferring one from the other would be invention.

**`DVM_Triculture`** — anaerobic serum flasks, 30 mL in a 50 mL flask, chemically defined medium with 30 mM Na-lactate as the sole carbon source and Na₂SO₄ varied.

Recorded `SEMI_CONTINUOUS`, not `CHEMOSTAT`: the community was serially sub-cultured twice over three-week periods and the authors describe it as mimicking *"a low-flow, chemostat-like system"* — but no dilution rate is given, so `CHEMOSTAT` would claim more than the paper does.

## Refused (2), both for reasons worth keeping

**`Tobacco_Chemotactic_Biocontrol_SynCom`** — 30 °C / 150 rpm is for individual strains in TSB, 30 °C / 100 rpm for a 96-well chemotaxis assay. The SynCom itself is applied as a solid formulation at 5% (v/w). Nothing community-level exists to record.

**`PMI_Variovorax_Thermotolerance_Collection`** is the interesting one, and the first case where **the conditions were good and the modelling was the obstacle**. It has clean community-level conditions — 48-well plates, 3 mL 1× liquid MS, growth chamber at 22 °C, 12 h cycle, 100 µmol. But:

> "**Individual strains** of Variovorax were added to MS liquid medium to inoculate 7-day-old seedlings and co-cultured for an additional 7 days"

It is Arabidopsis + **one** strain at a time, across 25 strains. They were never grown together, so a `cultivation_setup` would assert a consortium that does not exist. That is the panel-vs-community distinction in #573, and I have added the case there.

## Running total for this thread

Across both passes of the 11 candidates: **5 records curated** (2 Synechococcus SPC, baijiu solid-state, synthetic lichen ×2 arms, DVM triculture), **3 refused with stated reasons**, **1 integrity finding filed** (#605).

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.