### PR TITLE
Two more cultivation setups; the corrinoid record is a bioassay, not a community (#183)

### DIFF
--- a/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
+++ b/kb/communities/LBNL_Brachypodium_Drought_SynCom15.yaml
@@ -121,3 +121,29 @@ growth_media:
       at 16-h light, 24°C temperature, and 50% humidity.
     explanation: Gives the in-planta growth-chamber conditions (24°C, 16-h light,
       50% humidity) for the SynCom drought assay.
+cultivation_setup:
+- cultivation_mode: SEMI_CONTINUOUS
+  system_type: OTHER
+  instrument_detail: Plant growth chamber, 16 h light, 50% relative humidity.
+  working_volume: 50.0
+  working_volume_unit: mL
+  operating_temperature: 24.0
+  operating_temperature_unit: °C
+  controls_notes: 5 mL inoculum containing equal cell numbers (4 x 10^7 cells) of each
+    of the 15 members into 45 mL of 0.2X Murashige and Skoog medium; 5 mL transferred
+    into 45 mL fresh medium weekly over three weeks.
+  notes: This is the in vitro persistence experiment, where the 15 members were grown
+    together as a community and tracked by 16S over three weeks. It is not the in
+    planta work in the same paper, where the SynCom is inoculated at the base of the
+    shoot and the conditions are the plant's.
+  evidence:
+  - reference: PMID:40862137
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: we cultured 5 mL of the inoculum, containing equal cell numbers (4×107
+      cells) of each SynCom member, in 45 mL of 0.2X MS (Murashige and Skoog) media
+  - reference: PMID:40862137
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The mixture was incubated in a plant growth chamber with conditions set
+      at 16-h light, 24°C temperature, and 50% humidity

--- a/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
+++ b/kb/communities/Maize_Benzoxazinoid_Metabolizing_SynComs.yaml
@@ -113,3 +113,24 @@ growth_media:
       180 rpm.
     explanation: Gives preculture conditions (4 days, 28°C, 180 rpm) for the SynCom
       strains.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: 96-well plates.
+  controls_notes: 50% TSB supplemented with 500 uM MBOA, 68 h; community growth
+    followed by OD600.
+  notes: Stated for the SynComs themselves, and for the strain-dropout variants of
+    them, rather than for any member alone. Pre-cultures were raised separately from
+    single colonies in 1 mL of 50% TSB in deep-well plates; that is seed preparation
+    and is not recorded here (#529). No working volume is given for the assay wells.
+  evidence:
+  - reference: PMID:40853002
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The nonSC and metSC SynComs were grown in 96-well plates containing 50%
+      TSB supplemented with 500 µM MBOA for 68 h
+  - reference: PMID:40853002
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: We incubated these ‘dropout’ SynComs in a complex 50% TSB medium
+      supplemented with 500 µM MBOA for 68 h


### PR DESCRIPTION
Part of #183. Third pass — this works through the 11 vocabulary-scored candidates.

## Curated (2)

**`LBNL_Brachypodium_Drought_SynCom15`** — the paper's *in vitro* persistence experiment grew all 15 members **together**: 5 mL of inoculum at 4 × 10⁷ cells per member into 45 mL of 0.2X MS, in a plant growth chamber at 24 °C, 16 h light, 50% humidity, with 5 mL transferred into 45 mL fresh medium **weekly for three weeks**. Semi-continuous by serial transfer.

Recorded in preference to the *in planta* work in the same paper, where the SynCom is inoculated at the base of the shoot and the conditions are the plant's — noted in the record so the choice is visible.

**`Maize_Benzoxazinoid_Metabolizing_SynComs`** — 96-well plates, 50% TSB with 500 µM MBOA, 68 h, community growth followed by OD₆₀₀. Stated for the SynComs *and* for their strain-dropout variants, which is unusually direct evidence that the conditions are the community's. Pre-cultures raised separately from single colonies are seed preparation and are not recorded (#529).

## Refused (1)

**`Soil_Corrinoid_B12_Reservoir_Community`** — its 37 °C / 210 rpm / 1200 rpm plate-shaker conditions all belong to an ***E. coli* bioassay strain** used to quantify corrinoids in soil extracts. The soil community itself is sampled, not cultivated. Its "co-culture" sentences turned out to be citations to other people's work — a reminder that keyword scoring finds the word, not the experiment.

## Thread total

Across three passes of the candidate list: **7 records curated**, **4 refused with stated reasons**, **1 integrity finding filed** (#605), **1 panel case added to #573**.

The scored list is now exhausted. What remains under #183 needs either a new retrieval round or a different selection method — most of the 111 records with full text are environmental communities that were sampled rather than cultivated, and for those the absence of a `cultivation_setup` is correct.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.