### PR TITLE
Two more, found by selecting on community-level phrasing (#183)

### DIFF
--- a/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
+++ b/kb/communities/SMutans_SSputigena_ECC_Pathobiont.yaml
@@ -193,3 +193,29 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: The cultures were incubated in the anaerobic chamber at 37 °C for 48 h.
     explanation: Documents 48 h anaerobic incubation at 37 °C.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: Saliva-coated hydroxyapatite disc (2.7 +/- 0.2 cm2) held
+    vertically to mimic a tooth-enamel surface.
+  controls_notes: Mixed biofilms grown in BHIS medium with 1% sucrose, inoculated at
+    10^7 CFU/mL for the partner species and 10^5 CFU/mL for S. mutans.
+  notes: 'Recorded for the MIXED biofilm, which the paper grows alongside single-species
+    biofilms as its comparison. The 37 C anaerobic chamber given earlier is where the
+    strains were taken to exponential phase before inoculation, so it is preparation
+    rather than the biofilm''s own condition (#529). Sucrose is not an incidental
+    ingredient here: it is supplied to simulate the cariogenic conditions the study
+    is about.'
+  evidence:
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Single or mixed biofilms were grown on the apatitic surfaces in BHIS
+      medium (107 CFU/mL for the new species and/or 105 CFU/mL S. mutans) supplemented
+      with 1% sucrose
+  - reference: PMID:37217495
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: a saliva-coated hydroxyapatite disc (2.7 ± 0.2 cm2; Clarkson Chromatography
+      Products) was placed in a vertical position to mimic the tooth-enamel surfaces
+      of human teeth

--- a/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
+++ b/kb/communities/SkinCom_Synthetic_Skin_Community.yaml
@@ -92,3 +92,41 @@ growth_media:
     snippet: Under anaerobic conditions, plates were incubated in a vinyl anaerobic chamber (Coy Lab Products)
       with an atmosphere of N2/CO2/H2 (85%/10%/5%).
     explanation: Anaerobic incubation atmosphere for the anaerobic SkinCom members.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: 96-well plates, arrayed by a pico-litre printing microfluidic
+    device.
+  operating_temperature: 37.0
+  operating_temperature_unit: °C
+  controls_notes: Members diluted to OD600 0.065 before arraying; plates incubated
+    oxically, in the presence of oxygen.
+  notes: The paper ran the assembled community under two atmospheres and reports
+    both; this is the oxic arm. Each type strain was raised separately in BHI first
+    (and C. acnes in cysteine-reduced medium in Hungate tubes, being an anaerobe);
+    that is seed preparation and is not recorded as the community's conditions
+    (#529).
+  evidence:
+  - reference: PMID:39111313
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: cultures were diluted to an optical density (OD600) of 0.065 and arrayed
+      into 96-well plates using a pico-liter printing microfluidic device
+  - reference: PMID:39111313
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Plates were incubated at 37°C in the presence of oxygen (oxic) or in the
+      anaerobic chamber (anoxic)
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: 96-well plates in an anaerobic chamber.
+  operating_temperature: 37.0
+  operating_temperature_unit: °C
+  controls_notes: The anoxic arm of the same experiment, incubated in the anaerobic
+    chamber rather than in air.
+  evidence:
+  - reference: PMID:39111313
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Plates were incubated at 37°C in the presence of oxygen (oxic) or in the
+      anaerobic chamber (anoxic)


### PR DESCRIPTION
Part of #183.

## The selection method was the limiting factor, not the corpus

The previous rounds scored candidates on **cultivation vocabulary** — "incubated at", "rpm", "flask". That finds papers describing growing *something*, which is why it kept surfacing records whose only conditions turned out to be seed preparation, and why I concluded the list was exhausted.

Selecting instead on phrases that name **the community as the grammatical subject** — "co-cultures were grown", "communities were incubated", "mixed biofilms were grown" — gives **28 records**, and it is a better list. It includes records the vocabulary score missed entirely, including both curated here.

Worth recording because it explains the earlier flattening yield: the well was not dry, the sieve was wrong.

## Curated (2)

**`SkinCom_Synthetic_Skin_Community`** — two arms, because the assembled community was run under both atmospheres. Members diluted to OD₆₀₀ 0.065, arrayed into 96-well plates by a **pico-litre printing microfluidic device**, plates incubated at 37 °C either in air or in an anaerobic chamber.

Each type strain was raised separately in BHI first — and *C. acnes* in cysteine-reduced Hungate tubes, being an anaerobe — which is preparation, not the community's condition (#529).

**`SMutans_SSputigena_ECC_Pathobiont`** — a biofilm system: a **saliva-coated hydroxyapatite disc held vertically** to mimic a tooth-enamel surface, mixed biofilm grown in BHIS plus **1% sucrose** at 10⁷ CFU/mL for the partner species and 10⁵ CFU/mL for *S. mutans*.

The sucrose is recorded deliberately rather than as an ingredient: it is supplied to simulate the cariogenic conditions the study exists to examine. The 37 °C anaerobic chamber mentioned earlier in the paper is where strains reached exponential phase before inoculation.

## Running total

**9 records curated · 4 refused with stated reasons · 1 integrity finding (#605) · 1 panel case added to #573.**

26 records remain on the new phrase-selected list, so this thread has further to run than the previous round suggested.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.