### PR TITLE
Three more, and an honest recount of how many candidates there are (#183)

### DIFF
--- a/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
+++ b/kb/communities/SMutans_VParvula_ASC_Biofilm.yaml
@@ -195,3 +195,30 @@ growth_media:
       suspensions at 37°C for 24 h under facultative anaerobic conditions
       without disturbance.
     explanation: Documents the 24-well plate / hydroxyapatite biofilm vessel, 37°C, and 24 h incubation.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: Saliva-coated hydroxyapatite slides laid horizontally in 24-well
+    plates.
+  working_volume: 2.0
+  working_volume_unit: mL
+  operating_temperature: 37.0
+  operating_temperature_unit: °C
+  controls_notes: 2.0 mL of microbial suspension per well, 24 h, facultative anaerobic,
+    left undisturbed; BHI with 0.6% sodium lactate, plus 1% sucrose for the biofilm
+    studies.
+  notes: Recorded for the dual-species biofilm, which the paper grows next to
+    mono-species controls. Sister record to SMutans_SSputigena_ECC_Pathobiont, which
+    uses the same hydroxyapatite-disc approach from a different group — the slides
+    here are horizontal in 24-well plates rather than vertical.
+  evidence:
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Mono- and dual-species biofilms were grown on saliva-coated hydroxyapatite
+      slides placed in 24-well plates horizontally with 2.0 mL of microbial suspensions
+      at 37°C for 24 h under facultative anaerobic conditions without disturbance
+  - reference: PMID:39345197
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: For the biofilm studies, 1% sucrose was added to the BHI broth

--- a/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
+++ b/kb/communities/SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture.yaml
@@ -253,3 +253,24 @@ growth_media:
     snippet: Glycerol-preserved strains were inoculated into TSB and cultured overnight at 25 °C
       with shaking at 150 rpm.
     explanation: Preculture conditions (TSB, overnight, 25 °C, 150 rpm) prior to biofilm inoculation.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: Six-well plate with a sterile 100 um pore-size nylon mesh cell
+    strainer in each well, giving the biofilm a surface to form on.
+  working_volume: 10.0
+  working_volume_unit: mL
+  operating_temperature: 30.0
+  operating_temperature_unit: °C
+  controls_notes: 10 mL TSB plus 100 uL bacterial suspension per well, incubated
+    statically for 24, 48 and 72 h.
+  notes: Stated for the mixed-species biofilms, which the paper grows alongside
+    single-species biofilms as its comparison; static, so no agitation is recorded.
+  evidence:
+  - reference: PMID:42125264
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: A six-well plate was used, with a sterile 100 μm pore-size nylon mesh cell
+      strainer (Biologix) placed in each well. Each well was supplemented with 10 mL
+      TSB medium and 100 μL bacterial suspension and incubated statically at 30 °C for
+      24, 48, and 72 h to allow biofilm formation

--- a/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
+++ b/kb/communities/Synthetic_Periphyton_Freshwater_Biofilm.yaml
@@ -120,3 +120,39 @@ growth_media:
     snippet: sterile 300-mL Erlenmeyer flasks containing 150 mL of COMBO and placed on a shaker operated
       at 30 rpm
     explanation: Stock-culture vessel and 30 rpm shaking for the phototrophic pre-cultures.
+cultivation_setup:
+- cultivation_mode: SEMI_CONTINUOUS
+  system_type: OTHER
+  instrument_detail: Static microcosms with no flow; actinic light exposure.
+  operating_temperature: 17.0
+  operating_temperature_unit: °C
+  controls_notes: 2 mL of COMBO medium exchanged every two days across 30 days of
+    periphyton establishment; full factorial design over four terbuthylazine levels
+    (0, 1, 10, 100 nM) and two temperatures.
+  notes: The 17 C arm. The paper establishes the same synthetic community at two
+    temperatures as a designed factor, so both are recorded rather than one being
+    treated as the condition and the other as a treatment. The authors note the
+    absence of flow as a limitation of the system, which is why the mode is
+    semi-continuous by medium exchange rather than continuous.
+  evidence:
+  - reference: PMID:35869094
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Synthetic periphyton communities were established, as described previously,
+      in the presence of four levels of terbuthylazine (i.e., 0, 1, 10, and 100 nM)
+      and under two temperatures (17 °C and 20 °C)
+  - reference: PMID:35869094
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: During the 30 days of periphyton establishment, 2 mL COMBO, supplemented
+      or not with terbuthylazine, were exchanged every two days
+- cultivation_mode: SEMI_CONTINUOUS
+  system_type: OTHER
+  operating_temperature: 20.0
+  operating_temperature_unit: °C
+  controls_notes: The 20 C arm of the same factorial design; medium exchange as above.
+  evidence:
+  - reference: PMID:35869094
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: under two temperatures (17 °C and 20 °C)


### PR DESCRIPTION
Part of #183.

## Correcting last round's count

Last round I replaced vocabulary scoring with "community-level phrasing" and reported **28 candidates**. That number was wrong, and wrong in exactly the way I had just criticised: it matched the bare substring `co-culture` **anywhere** in a paper, including in discussion and reference lists. Probing four of them found no cultivation sentence at all.

Requiring the community to be the **grammatical subject of a cultivation verb** — "co-cultures were grown", "biofilms were cultivated", "communities were established" — gives **9 records, not 28**. Three curated here, two already refused, one is #605, three remain.

So the real state of #183 is narrower than last round claimed, and I would rather say so than let an inflated figure stand.

## Curated (3)

**`Synthetic_Periphyton_Freshwater_Biofilm`** — two arms. The community was established at **17 °C and at 20 °C as a designed factor**, with 2 mL of COMBO medium exchanged every two days across 30 days. Semi-continuous by exchange; the authors flag the absence of flow as a limitation of the system, which is why it is not continuous.

**`SynCom_Y_Agrobacterium_Bacillus_Biofilm_Biocontrol_Coculture`** — six-well plates with a **100 µm nylon mesh strainer** per well as the biofilm surface, 10 mL TSB plus 100 µL suspension, static at 30 °C for 24–72 h.

**`SMutans_VParvula_ASC_Biofilm`** — saliva-coated hydroxyapatite slides laid **flat** in 24-well plates, 2.0 mL suspension, 37 °C, 24 h, facultative anaerobic, undisturbed; BHI with 0.6% sodium lactate and 1% sucrose for the biofilm work.

Sister record to `SMutans_SSputigena_ECC_Pathobiont` from the previous round — same hydroxyapatite approach from a different group, slides flat rather than vertical. Noted in both records so the difference reads as real rather than as inconsistent curation.

## A gate caught me

`test_no_snippet_stops_mid_word` (#295) rejected one of my own snippets, which ended *"to allow biofilm form"* — truncated mid-word from "formation" when I copied it. Completed from the cache. That gate has now caught this same class of error twice in this session, both times mine.

## Running total

**12 records curated · 4 refused with stated reasons · 1 integrity finding (#605) · 1 panel case added to #573.**

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.