### PR TITLE
The last candidate on the list, and three refusals that close it out (#183)

### DIFF
--- a/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
+++ b/kb/communities/Crucian_Carp_Gut_Disease_Resistance_SynCom.yaml
@@ -134,3 +134,22 @@ growth_media:
     evidence_source: IN_VITRO
     snippet: "inoculated into 5 mL of BHI and LB broth for expansion"
     explanation: "Documents broth expansion of the SynCom member strains."
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  controls_notes: Pairwise and triple-strain co-cultures incubated 78 h at inoculation
+    ratios of 1:1 and 1:1:1, as an in vitro antagonism check before the feeding trials.
+  notes: 'Deliberately thin, and thin because the paper is: the retrievable text gives
+    the duration and the inoculation ratio for the co-cultures but puts the medium and
+    temperature in Supplementary Fig. S10, which is not part of the cached full text.
+    The 28 C anaerobic incubation that does appear belongs to the isolation plates
+    that produced the strains, not to the co-culture (#529). Recorded rather than
+    omitted because "these three were grown together in vitro, at a defined ratio,
+    for 78 h" is itself a fact about the community that the record otherwise lacks.'
+  evidence:
+  - reference: PMID:41280275
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Pairwise and triple-strain co-cultures were incubated for 78 h at
+      inoculation ratios of 1:1 or 1:1:1, respectively, and no antagonistic or
+      inhibitory effects were observed


### PR DESCRIPTION
Part of #183. This finishes the 9-record list built by requiring the community to be the **grammatical subject** of a cultivation verb.

## Curated (1), thinly and on purpose

**`Crucian_Carp_Gut_Disease_Resistance_SynCom`** — the paper states that pairwise and triple-strain co-cultures were incubated **78 h at 1:1 and 1:1:1 ratios**, and puts the medium and temperature in Supplementary Fig. S10, which is not part of the cached full text. The 28 °C anaerobic incubation that *is* in the text belongs to the isolation plates that produced the strains (#529).

Recorded rather than skipped because *"these three were grown together in vitro at a defined ratio for 78 h"* is a fact about the community the record otherwise lacks — and the note says exactly why nothing more is there, so the thinness reads as the paper's limit rather than as unfinished curation.

## Refused (3)

**`Maize_Drought_Response_SynCom`** — the SynCom is prepared by growing 17 isolates **individually** to late exponential phase, pooling by OD, and resuspending in 0.1× Hoagland before application to maize. That is inoculum preparation; the community then lives on the plant and the subsequent conditions are the plant's. Same shape as CeMbio and `Lotus_LjSC3`.

**`KBase_Synthetic_Bacterial_Community_R2A`** — no community-subject cultivation sentence survives the strict pattern. The paper's contribution is flux-balance *modelling* of community growth rather than a described cultivation. (It appeared on the inflated 28-record list purely on a bare `co-culture` substring, which is what that list was wrong about.)

**`Chlorochromatium_Aggregatum_Phototrophic_Consortium`** — *"Consortia were grown under conditions that produced a biofilm on a glass surface"* is the whole statement. The K4 medium named nearby is what harvested consortia were **resuspended in for disaggregation**, not what they were grown in. Too little to record without inventing the rest.

## Final total for this thread

**13 records curated · 7 refused with stated reasons · 1 integrity finding (#605) · 1 panel case added to #573.**

The phrase-selected list is now genuinely exhausted — not "flattened", exhausted. Further progress on #183 needs a new retrieval round (more references reaching full text) rather than better selection over what is already cached.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.