### PR TITLE
Three more from the widened list, each with a detail worth keeping (#183)

### DIFF
--- a/kb/communities/Jala_Maize_PGPB_SynCom.yaml
+++ b/kb/communities/Jala_Maize_PGPB_SynCom.yaml
@@ -193,3 +193,29 @@ growth_media:
       phase.
     explanation: LB liquid medium was used to grow each strain to exponential phase
       before SynCom assembly.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  working_volume: 5.0
+  working_volume_unit: mL
+  operating_temperature: 28.0
+  operating_temperature_unit: °C
+  controls_notes: 5 mL semisolid BMGM medium in sealed bottles, inoculated with 50 uL
+    of suspension at 1 x 10^8 CFU/mL, incubated 48 h; the acetylene-reduction assay
+    for nitrogenase activity.
+  notes: The sentence names the SynCom alongside the axenic strains, so these are the
+    community's conditions and not only a per-strain control. Semisolid medium and a
+    sealed bottle are both load-bearing for a nitrogen-fixation assay — the gradient
+    lets the diazotrophs find their preferred oxygen tension, and the seal is what
+    makes the headspace measurable.
+  evidence:
+  - reference: PMID:37275168
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The axenic bacterial strains and SynCom were grown in sealed bottles
+      containing 5 mL of a semisolid BMGM medium with 50 μL of bacterial suspension
+      adjusted to a final 1x108 CFU/mL concentration
+  - reference: PMID:37275168
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The bottles were sealed and incubated for 48 h at 28°C

--- a/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
+++ b/kb/communities/LBNL_Human_Gut_Interaction_SynCom.yaml
@@ -108,3 +108,31 @@ growth_media:
     snippet: Cells were cultured in an anaerobic chamber (Coy Lab Products) using mixed
       gas tanks containing 85% N2 , 5% H2 , and 10% CO2 .
     explanation: Gives the anaerobic chamber gas mix (85% N2, 5% H2, 10% CO2).
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: 96-well deep-well plates under a gas-permeable seal (Breathe
+    Easy), arrayed by a Biomek liquid-handling robot.
+  operating_temperature: 37.0
+  operating_temperature_unit: °C
+  controls_notes: Each strain inoculated at 0.01 OD600, so a multi-species assemblage
+    starts at 0.01 x n; incubated without shaking. A parallel aliquot was read in a
+    384-well plate with shaking for OD600 every 30 min.
+  notes: 'The inoculation rule is the interesting part and is why it is recorded
+    verbatim: the community''s starting density scales with its size rather than being
+    held constant, so a larger assemblage begins denser. Two of the pairwise designs
+    depart from it deliberately (PW2 at 0.0158 and 0.0008 OD600 for major and minor
+    strains). The deep-well plate is the culture; the shaken plate-reader aliquot is
+    measurement, and its shaking is not the community''s condition.'
+  evidence:
+  - reference: PMID:29930200
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The microbial communities were arrayed using a liquid‐handling robot
+      (Biomek) into 96‐well deep‐well plates covered with a gas‐permeable seal
+      (Breathe Easy) and incubated at 37°C without shaking
+  - reference: PMID:29930200
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: In multi‐species assemblages, the total initial OD600 was 0.01 OD600 × n,
+      where n represents the number of strains in the community

--- a/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
+++ b/kb/communities/Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture.yaml
@@ -447,3 +447,24 @@ rare_earth_elements_present: []
 metal_relevance: NOT_APPLICABLE
 metal_notes: No metal or rare earth element processing role is curated for this methane-fed
   thermoacidophilic coculture.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  instrument_detail: 1 L Duran Pressure Plus bottles sealed with bromobutyl rubber
+    stoppers.
+  working_volume: 250.0
+  working_volume_unit: mL
+  controls_notes: 250 mL sterile V4 medium per bottle, inoculated to defined initial
+    concentrations; initial gas concentrations varied across the series to separate
+    O2 limitation from the effects of the methanotroph partner.
+  notes: The gas composition is the experimental variable here rather than a fixed
+    condition, so no single atmosphere is recorded — the series exists precisely to
+    vary it. Pressure-rated bottles with bromobutyl stoppers because the headspace is
+    both pressurised and the thing under study.
+  evidence:
+  - reference: PMID:41888821
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: For all cocultures, 250 mL of sterile V4 medium was added to 1-L Duran®
+      Pressure Plus bottles sealed with bromobutyl rubber stoppers and inoculated to
+      the desired initial concentrations with the appropriate microbial stocks


### PR DESCRIPTION
Part of #183. From the 22-record list the second retrieval round produced.

## Curated (3)

**`Methylacidiphilum_Galdieria_Thermoacidophilic_Coculture`** — 250 mL of V4 medium in **1 L Duran Pressure Plus bottles** under bromobutyl stoppers.

**No atmosphere is recorded, deliberately.** The initial gas concentration is the experimental variable across the series, so naming one would misrepresent the design. The pressure-rated bottle and the stopper choice both follow from the headspace being simultaneously pressurised and the object of study.

**`Jala_Maize_PGPB_SynCom`** — 5 mL of **semisolid** BMGM in sealed bottles, 50 µL of suspension at 1 × 10⁸ CFU/mL, 48 h at 28 °C, for an acetylene-reduction assay. The sentence names the SynCom alongside the axenic strains, so these are the community's conditions rather than a per-strain control.

Both the semisolid medium and the seal are load-bearing here: the gradient lets the diazotrophs sit at their preferred oxygen tension, and the seal is what makes the headspace measurable. Recorded as such rather than as incidental medium details.

**`LBNL_Human_Gut_Interaction_SynCom`** — 96-well deep-well plates under a gas-permeable seal, arrayed by a Biomek robot, 37 °C, **without shaking**.

The inoculation rule is recorded verbatim because it is unusual and consequential: each strain enters at 0.01 OD₆₀₀, so the total is **0.01 × n** — a larger assemblage *starts denser* rather than being normalised to a common total. Two pairwise designs depart from it on purpose (PW2 at 0.0158 / 0.0008). The shaken plate-reader aliquot is measurement, not the culture, so its shaking is not recorded as a condition.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.