### PR TITLE
Two syntrophy/coculture setups where the substrate IS the design (#183)

### DIFF
--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -473,3 +473,28 @@ metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element processing role is curated for this syntrophic acetate
   oxidation and methanogenesis coculture.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  instrument_detail: 150 mL bottles with a 70 mL headspace.
+  operating_temperature: 55.0
+  operating_temperature_unit: °C
+  controls_notes: Modified freshwater medium DSM880, anaerobic, in the dark, without
+    shaking; the syntrophic co-culture grown on acetate at 40 mM, and transferred at
+    least 10 times.
+  notes: 'The paper separates the substrates explicitly, which is what makes this
+    recordable: the axenic T. phaeum culture was grown on formate or hydrogen/CO2,
+    the CO-CULTURE on acetate. Recording the axenic substrate here would invert the
+    experiment, since acetate oxidation is the thing the syntrophy exists to do. The
+    hydrogen/CO2 headspace flushing described nearby belongs to the axenic condition
+    for the same reason.'
+  evidence:
+  - reference: PMID:31849917
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: cultures were grown anaerobically in modified freshwater medium DSM880 as
+      described before (Keller et al., 2019) at 55°C in the dark without shaking
+  - reference: PMID:31849917
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: whereas the syntrophic co-culture was grown with acetate as substrate

--- a/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
+++ b/kb/communities/Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture.yaml
@@ -302,3 +302,33 @@ metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element processing role is curated for this
   cellulose-fed filamentous coculture.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: MICROFLUIDIC_DEVICE
+  instrument_detail: 48-round-well microtiter plates (Beckman Coulter) in an in-house
+    micro-respiration online monitoring system (uRAMOS) with a BioLector; wells are
+    closed by microfluidic valves at intervals to measure oxygen transfer rate.
+  working_volume: 1.0
+  working_volume_unit: mL
+  operating_temperature: 30.0
+  operating_temperature_unit: °C
+  controls_notes: 800 rpm shaking at a 3 mm shaking diameter; the coculture set up on
+    alpha-cellulose as sole carbon source, which is what makes S. coelicolor depend on
+    hydrolysate sugars released by T. reesei cellulases.
+  notes: 'The carbon source is the experimental design rather than a medium detail:
+    alpha-cellulose is chosen because S. coelicolor cannot use it, so the dependency
+    on T. reesei cellulases is created by the substrate. Recorded as MICROFLUIDIC_DEVICE
+    because the valves that close each well are part of the measurement system, not
+    incidental plasticware.'
+  evidence:
+  - reference: PMID:36314761
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Cultivations were performed in 48‐round well plates (Beckman Coulter). For
+      the cultivation conditions, if not stated otherwise, a filling volume of 1 ml, a
+      shaking frequency of 800 rpm, a shaking diameter of 3 mm, and a temperature of
+      30°C were set
+  - reference: PMID:36314761
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The coculture was set up to use α-cellulose as a carbon source


### PR DESCRIPTION
Part of #183.

## Curated (2)

**`Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture`** — modified freshwater medium DSM880, anaerobic, **55 °C, in the dark, without shaking**, 150 mL bottles with a 70 mL headspace, transferred at least 10 times.

The paper separates the substrates explicitly, and that is what makes this recordable at all:

> "The axenic culture of T. phaeum was grown with formate or hydrogen/CO₂, **whereas the syntrophic co-culture was grown with acetate as substrate**"

Recording the axenic substrate would invert the experiment — acetate oxidation is the reaction the syntrophy exists to perform. The hydrogen/CO₂ headspace flushing described in the same paragraph belongs to the axenic condition for the same reason, and is deliberately left out.

**`Trichoderma_Streptomyces_Filamentous_Cellulose_Coculture`** — 48-round-well microtiter plates, 1 mL filling volume, **800 rpm at a 3 mm shaking diameter**, 30 °C, with wells closed by microfluidic valves at intervals to measure oxygen transfer rate (µRAMOS / BioLector).

Recorded as `MICROFLUIDIC_DEVICE` rather than `OTHER`, because those valves are part of the measurement system rather than incidental plasticware — the enum choice carries information here.

The carbon source is likewise design rather than medium detail: **α-cellulose is chosen precisely because *S. coelicolor* cannot use it**, so the dependency on *T. reesei* cellulases is created by the substrate. Noted in the record so a reader does not treat it as an arbitrary medium.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.