### PR TITLE
One more setup, and the finding that a third of #183 is unreachable (#183, #615)

### DIFF
--- a/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
+++ b/kb/communities/Model_Lignocellulose_Formaldehyde_Crossfeeding_Community.yaml
@@ -362,3 +362,34 @@ metal_relevance: NOT_APPLICABLE
 metal_notes: >
   No metal or rare earth element processing role is curated for this lignocellulose formaldehyde
   cross-feeding record.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: 48-well tissue culture plates (Corning Costar) in an LPX44 Plate
+    Hotel (LiCONiC).
+  working_volume: 0.64
+  working_volume_unit: mL
+  operating_temperature: 30.0
+  operating_temperature_unit: °C
+  controls_notes: 640 uL total volume per well, shaken at 650 rpm; Model Lignocellulose
+    medium, an MP base with altered PIPES and phosphate concentrations.
+  notes: 'The paper states one temperature for every vessel it used — flasks, tubes,
+    multiwell plates and agar — so 30 C is the community''s condition regardless of
+    format; the multiwell arm is recorded here because it is the one with a stated
+    volume and agitation. Worth noting the vessel choice elsewhere in the same paper:
+    Balch tubes with serum stoppers were used specifically so that volatile compounds
+    such as formaldehyde were not lost to the gas phase, which makes the seal part of
+    the experiment rather than convenience — formaldehyde cross-feeding is what this
+    consortium is for.'
+  evidence:
+  - reference: doi:10.3390/microorganisms9020321
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: All cultures were grown at 30 °C, either in culture flasks, culture tubes,
+      multiwell culture plates, or culture plates with solid medium
+  - reference: doi:10.3390/microorganisms9020321
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: we used 48-well tissue culture plates (Corning Costar, Tewksbury, MA, USA)
+      with a total volume of 640 µL per well, and incubated in a LPX44 Plate Hotel
+      (LiCONiC, Mauren, Liechtenstein) with shaking at 650 RPM


### PR DESCRIPTION
Part of #183. Also closes out the two stale branches.

## Curated (1)

**`Model_Lignocellulose_Formaldehyde_Crossfeeding_Community`** — 48-well tissue culture plates in an LPX44 Plate Hotel, 640 µL per well, 650 rpm, 30 °C, on Model Lignocellulose medium.

The paper states one temperature for **every** vessel format it used — flasks, tubes, multiwell, agar — so 30 °C is the community's condition regardless of format. The multiwell arm is recorded because it is the one with a stated volume and agitation.

Noted in the record: elsewhere in the same paper, **Balch tubes with serum stoppers were chosen specifically so volatile compounds such as formaldehyde were not lost to the gas phase**. That makes the seal part of the experiment rather than convenience — formaldehyde cross-feeding is what the consortium is *for*. Same shape as the sealed bottle in `Jala_Maize` and the serum bottle in `Clostridium_Cellulovorans`.

## The bigger finding — #615

Four more candidates this round turned out to be the same refusal: a SynCom mixed as an **inoculum** and then applied to a plant. That made **eight** in this thread. Rather than refuse it a ninth time, I counted the class:

> **77 of the 232 records without a `cultivation_setup` are host- or plant-associated.**

A third of #183's gap is a class `cultivation_setup` has no slot for. Under the convention I have been applying, that third is not "not yet curated" — it is **permanently uncurable**, and #183 cannot close for a reason nothing in the repo states.

These communities are not under-specified. `At_RSPHERE` grows on gnotobiotic plates in 0.5× MS under a controlled photoperiod; `EcoFAB_Ring_Trial` is a **ring trial**, whose entire point was that conditions were reproducible across laboratories. The information exists and is good; the schema has nowhere to put it.

#615 sets out three options — write the convention down and narrow #183; let `cultivation_setup` describe the host system; or add a separate `host_system` structure — and deliberately does not pick one. It is a modelling decision with 77 records downstream.

## Stale branches removed

`pr308` and `pr308b` were identical to each other, 155 commits behind `main`, from PR #308 which was squash-merged long ago.

Verified before deleting rather than trusting the merge status, since a squash merge makes `git cherry` report all four commits as absent:

- all four records present on `main`
- the Microcystis regrounding to `NCBITaxon:1125` (genus, not species) landed
- both retracted edges — "Biotic Interaction Dominance over Carbon Source", "Inoculant Restructuring of the Root Endophytic Community" — are absent from `main`
- `interaction_type` counts match per record

Nothing lost.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.