### PR TITLE
Correct an earlier refusal, and characterise what is left of #183

### DIFF
--- a/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
+++ b/kb/communities/Tobacco_Chemotactic_Biocontrol_SynCom.yaml
@@ -136,3 +136,33 @@ growth_media:
       with shaking at 150 rpm
     explanation: Reports the medium (TSB), temperature (30°C), and shaking speed (150 rpm) used
       to grow the chemotactic SynCom strains.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: Two-stage solid-state fermentation of a composite organic
+    fertilizer (vermicompost, distiller's grains, cow dung and oil cake in five
+    formulations, S1-S5).
+  operating_temperature: 23.0
+  operating_temperature_unit: °C
+  controls_notes: Each SynCom strain inoculated into the composite nutrient at 5%
+    (v/w) with its screened prebiotic; moisture held at 40% throughout to keep the
+    compost aerated and loose; turned every 12 h; fermented approximately 7-10 days
+    in three replicates.
+  notes: 'This record was refused in an earlier pass of #183 on the grounds that the
+    paper gave conditions only for individual strains (30 C, 170 rpm in TSB) and for a
+    96-well chemotaxis assay. That was wrong — it gives the SynCom''s own solid-state
+    fermentation conditions further into the Methods, and I stopped reading too early.
+    The moisture figure is a control rather than a description: the paper says 40% is
+    maintained specifically to ensure aeration and looseness, so it is doing the job
+    agitation does in a liquid culture.'
+  evidence:
+  - reference: PMID:40670700
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The moisture content was adjusted to 40%, and fermentation was carried out
+      at 23 °C
+  - reference: PMID:40670700
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: During fermentation, the mixture was turned every 12 h, and a moisture
+      content was maintained at 40% to ensure aeration and looseness of the compost


### PR DESCRIPTION
Part of #183.

## A refusal I got wrong

**`Tobacco_Chemotactic_Biocontrol_SynCom`** is curated here, correcting a refusal I made earlier in this thread.

I had concluded the paper gave conditions only for individual strains (30 °C, 170 rpm in TSB) and for a 96-well chemotaxis assay. It **also** gives the SynCom's own solid-state fermentation, further into the Methods: each strain into composite organic fertiliser at 5% (v/w) with its screened prebiotic, **moisture held at 40%, 23 °C, turned every 12 h, 7–10 days**, three replicates.

I stopped reading too early. The refusal was recorded with a confident reason, which is the part worth flagging — a wrong refusal looks exactly like a right one.

The moisture figure is recorded as a **control** rather than a description: the paper says 40% is maintained specifically *"to ensure aeration and looseness of the compost"*, which is the job agitation does in a liquid culture.

## The open-access route is exhausted

A second retrieval round, restricted to the non-host records, fetched **zero of 182** references. Every one returned a clean `not open-access` — no errors, no timeouts, nothing to retry. Spot-checked individually to be sure the batch loop was not silently failing.

## What is actually left, decomposed

That makes the remaining **231** records without a `cultivation_setup` separable, and they are four different problems rather than one backlog:

| count | class | resolution |
|---|---|---|
| **75** | host-associated | no schema slot — **#615**, a modelling decision |
| **70** | non-host, no full text obtainable | paywalled; needs a route this repo does not have |
| **81** | non-host, full text but the community is never the subject of a cultivation verb | mostly environmental communities that were **sampled, not grown** — the absence is correct |
| **5** | non-host, full text, community-subject sentence | the tractable set |

And of those five: one is **#605** (`Synechococcus_Yarrowia`, wrong organism — must not be curated), one is the Tobacco record above, and three are genuinely too thin to record without inventing the rest.

**So #183's remaining gap is not curation work.** It is one modelling decision, a paywall, and a large set of records where no `cultivation_setup` is the right answer. That seems worth stating plainly on the issue, because "231 records lack growth conditions" reads like a backlog and is not one.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, **2502 passed**.