### PR TITLE
Build the synonym-aware taxon check I described twice (#605)

### DIFF
--- a/scripts/taxon_absent_from_source.py
+++ b/scripts/taxon_absent_from_source.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Find taxa that appear in NO cited source, under any name (#605).
+
+A membership claim can be backed by verbatim, validating snippets and still be
+unsupported. `Synechococcus_Yarrowia_SPC` asserts *Yarrowia lipolytica* on a
+paper whose three heterotrophs are *B. subtilis*, *E. coli* and *S. cerevisiae*;
+`PGM_Spent_Catalyst_Bioleaching` asserts *Thiobacillus thioparus* on two papers
+that never mention it. Every snippet in both records is a real quote. That is the
+failure mode snippet validation structurally cannot see, because it checks
+whether the quote is real, not whether the quote supports the claim.
+
+The obvious detector — "is this taxon's genus in the paper?" — does not work on
+its own. Run naively it returns ~79 hits, and most are **nomenclature
+modernisation**: the KB uses `Mediterraneibacter gnavus` and the paper, being
+older, writes `Ruminococcus gnavus`. Flagging those would be worse than not
+checking, because they are correct curation.
+
+So the question has to be asked properly: does the current name **or any of its
+NCBITaxon synonyms** appear? Only what survives that is a candidate defect.
+
+Usage:
+    uv run python scripts/taxon_absent_from_source.py            # summary
+    uv run python scripts/taxon_absent_from_source.py --list     # every hit
+    uv run python scripts/taxon_absent_from_source.py --drift    # renamings only
+
+Needs the NCBITaxon OAK adapter, so it is a script rather than a test: the
+blocking gate is deliberately pure arithmetic with no ontology download.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+COMMUNITIES = REPO / "kb/communities"
+CACHE = REPO / "references_cache"
+
+FULL_TEXT_MARKERS = ("===== OPEN-ACCESS FULL TEXT", "Full text (re-fetched")
+
+# Ranks and prefixes that cannot discriminate: a paper about anything microbial
+# contains "Bacteria", and "Candidatus" is a status marker rather than a name.
+# "Bacterium" belongs here for a reason worth stating: it is a real obsolete
+# genus that survives in NCBITaxon synonyms — Thiobacillus thioparus carries
+# "Bacterium thioparum" — and it appears in essentially every microbiology
+# paper, so it rescued a known-bad claim as if it were a renaming.
+UNINFORMATIVE = {
+    "bacteria",
+    "bacterium",
+    "archaea",
+    "fungi",
+    "eukaryota",
+    "viruses",
+    "cellular",
+}
+STATUS_PREFIXES = {"candidatus", "ca."}
+
+
+def cached_text(reference: str) -> str:
+    """Full text for a reference, or "" if only an abstract (or nothing) is cached.
+
+    Abstract-only entries are excluded deliberately. A member named once in a
+    Methods table will not appear in an abstract, so checking against one
+    measures cache depth rather than support — the mistake corrected in #577.
+    """
+    stem = str(reference).replace(":", "_").replace("/", "_")
+    for suffix in (".md", ".txt"):
+        path = CACHE / f"{stem}{suffix}"
+        if path.is_file():
+            body = path.read_text(errors="replace")
+            if any(marker in body for marker in FULL_TEXT_MARKERS):
+                return " ".join(body.split())
+    return ""
+
+
+def aliases(curie: str) -> set[str]:
+    """Every label and synonym NCBITaxon carries for this id."""
+    result = subprocess.run(
+        ["uv", "run", "runoak", "-i", "sqlite:obo:ncbitaxon", "aliases", curie],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    names = set()
+    for line in result.stdout.splitlines()[1:]:
+        parts = line.split("\t")
+        if len(parts) >= 3 and parts[2].strip():
+            names.add(parts[2].strip())
+    return names
+
+
+def search_keys(name: str, *, require_capital: bool = True) -> list[str]:
+    """The distinctive word(s) to look for in a source, from one name.
+
+    The genus alone, because a source may write "R. gnavus" or give the species
+    only in a table. Names whose head word cannot discriminate are dropped
+    rather than counted either way.
+
+    `require_capital` is False for synonyms. NCBITaxon stores many of them
+    lower-cased — `Bacillota` carries "firmicutes", `Cyanobacteriota` carries
+    "cyanobacteria" — and requiring a capital threw every one of those away, so
+    twenty phylum renamings were being reported as unsupported claims. Matching
+    is case-insensitive anyway; the capital was only ever a proxy for "looks
+    like a proper name", and it is the wrong proxy here.
+    """
+    words = name.split()
+    if words and words[0].lower() in STATUS_PREFIXES:
+        words = words[1:]
+    if not words:
+        return []
+    head = words[0]
+    if len(head) < 5 or head.lower() in UNINFORMATIVE:
+        return []
+    if require_capital and not head[0].isupper():
+        return []
+    return [head]
+
+
+def taxa(document: object):
+    """(label, curie, [references]) for every taxonomy entry with evidence."""
+    for entry in (document or {}).get("taxonomy", []) or []:
+        term = (entry.get("taxon_term") or {}).get("term") or {}
+        label, curie = term.get("label"), term.get("id")
+        refs = [e.get("reference") for e in (entry.get("evidence") or []) if e.get("reference")]
+        if label and curie and refs:
+            yield label, curie, refs
+
+
+def main() -> int:
+    list_all = "--list" in sys.argv
+    drift_only = "--drift" in sys.argv
+
+    absent, drift, checked = [], [], 0
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for label, curie, refs in taxa(document):
+            texts = [t for t in (cached_text(r) for r in refs) if t]
+            if not texts:
+                continue  # nothing to check against; not this script's business
+            keys = search_keys(label)
+            if not keys:
+                continue
+            checked += 1
+            if any(re.search(rf"\b{re.escape(k)}", t, re.I) for k in keys for t in texts):
+                continue
+
+            # Current name is absent. Before calling it unsupported, ask whether
+            # the source uses an older name for the same NCBITaxon id.
+            hit = None
+            for name in aliases(curie):
+                if name == label:
+                    continue
+                keys_for = search_keys(name, require_capital=False)
+                if not keys_for:
+                    continue
+                # A synonym must match MORE strictly than the primary name.
+                # Genus alone is right for the primary check, since a paper may
+                # write "R. gnavus" — but for a synonym it is a licence to
+                # forgive: "Candida lipolytica" is a synonym of Yarrowia
+                # lipolytica, and matching only "Candida" cleared a claim on a
+                # paper that discusses an unrelated Candida. Require the species
+                # epithet too, so the rescue is about THIS organism.
+                epithet = name.split()[1] if len(name.split()) > 1 else None
+                needed = keys_for + ([epithet] if epithet and len(epithet) > 3 else [])
+                if all(
+                    any(re.search(rf"\b{re.escape(k)}", t, re.I) for t in texts) for k in needed
+                ):
+                    hit = " ".join(needed)
+                    break
+            if hit:
+                drift.append((path.name, label, hit))
+            else:
+                absent.append((path.name, label, curie, refs))
+
+    print(f"# {checked} taxon claims checked against a full-text source")
+    print(f"  nomenclature drift (source uses an older name): {len(drift)}")
+    print(f"  ABSENT under every known name:                  {len(absent)}")
+
+    if drift_only or list_all:
+        print("\n# Drift — correct curation, source is simply older")
+        for name, label, hit in drift:
+            print(f"  {name[:52]:52} {label} <- source says {hit}")
+
+    if list_all or not drift_only:
+        print("\n# Absent under every NCBITaxon synonym — candidate #605 defects")
+        for name, label, curie, refs in absent:
+            print(f"  {name[:52]:52} {label} ({curie})  refs={refs}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes the tooling half of #605.

## Why

A membership claim can be backed by **verbatim, validating snippets** and still be unsupported. `Synechococcus_Yarrowia_SPC` asserts *Yarrowia lipolytica* on a paper whose three heterotrophs are *B. subtilis*, *E. coli* and *S. cerevisiae*. Snippet validation cannot see this — it checks whether the quote is real, not whether the quote supports the claim.

The naive detector ("is the genus in the paper?") returns ~79 hits and is worse than useless: most are **nomenclature modernisation**, where the KB says `Mediterraneibacter gnavus` and the older paper says *Ruminococcus gnavus*. Flagging correct curation would train people to ignore it.

Asking properly means asking whether the current name **or any NCBITaxon synonym** appears.

## Result

Of **478** taxon claims with a full-text source:

| | count |
|---|---|
| nomenclature drift (source uses an older name) | **59** |
| **absent under every known name** | **20** |

## Three bugs, all found by canarying against the two cases it was built for

The first version reported **both motivating cases as clean**. Each bug was independently capable of hiding a real defect:

1. **`Bacterium` is a real obsolete genus** that survives as a synonym — *Thiobacillus thioparus* carries "Bacterium thioparum" — and it appears in essentially every microbiology paper. It rescued a known-bad claim as if it were a renaming.

2. **Matching a synonym on genus alone forgives too much.** "Candida lipolytica" is a synonym of *Yarrowia lipolytica*; matching just "Candida" cleared the claim against a paper discussing an unrelated *Candida*. Synonyms now require the **species epithet** too. The primary name still matches on genus, because a source may legitimately write "R. gnavus" — the asymmetry is deliberate and commented.

3. **NCBITaxon stores many synonyms lower-cased** — `Bacillota` carries "firmicutes", `Cyanobacteriota` carries "cyanobacteria" — and requiring an initial capital discarded every one of them, reporting **twenty phylum renamings as unsupported claims**. That single fix moved 8 records from "absent" to "drift".

Without the canary all three would have shipped, and the tool would have looked like it worked.

## The 20 that survive

Includes both known #605 cases (`Yarrowia lipolytica`, `Thiobacillus thioparus`). The rest are mostly high-rank or candidate-status taxa — `Patescibacteria group` ×5, `Candidatus Methanogaster`, `Desulfobacterales` — where the paper may describe the lineage without ever using the NCBITaxon name. **They are candidates, not verdicts**; each needs a look before anything is changed, which is why this prints a report rather than failing a gate.

## Why a script and not a test

It needs the NCBITaxon OAK adapter. `tests/test_cultivation_source_studied_the_community.py` is deliberately pure arithmetic so it can run in the blocking `validate-strict` step; putting an ontology download there would trade a fast gate for a flaky one.

## Gates

`lint` 0, **2504 passed**.