### PR TITLE
Match against abstracts, report only where full text exists (#605)

### DIFF
--- a/scripts/taxon_absent_from_source.py
+++ b/scripts/taxon_absent_from_source.py
@@ -78,20 +78,46 @@ def stem_of(word: str) -> str:
 
 
 def cached_text(reference: str) -> str:
-    """Full text for a reference, or "" if only an abstract (or nothing) is cached.
+    """Every cached word for a reference — abstract included.
 
-    Abstract-only entries are excluded deliberately. A member named once in a
-    Methods table will not appear in an abstract, so checking against one
-    measures cache depth rather than support — the mistake corrected in #577.
+    **Abstracts count here, and that is the opposite of the rule in the
+    cultivation check.** There, an abstract-only cache is excluded because
+    growth conditions live in Methods, so matching against an abstract measures
+    cache depth rather than support (#577). Membership is different: a paper
+    almost always names its organisms in the abstract, so an abstract that names
+    a taxon is real evidence for it.
+
+    Importing the cultivation rule here produced a false positive worth naming.
+    `Ferroplasma_Leptospirillum_Syntrophy` was reported as claiming
+    *Leptospirillum ferriphilum* unsupported, while one of its two references —
+    a 2.8 KB abstract with no full-text marker — names "ferriphilum" six times.
+    The check had skipped the file that answered the question.
+    """
+    stem = str(reference).replace(":", "_").replace("/", "_")
+    parts = []
+    for suffix in (".md", ".txt"):
+        path = CACHE / f"{stem}{suffix}"
+        if path.is_file():
+            parts.append(path.read_text(errors="replace"))
+    return " ".join(" ".join(parts).split())
+
+
+def has_full_text(reference: str) -> bool:
+    """Whether a reference has retrieved full text, not just an abstract.
+
+    Used to decide whether ABSENCE is worth reporting, which is a different
+    question from what to MATCH against. Matching uses every cached word,
+    including abstracts, because a paper names its organisms there. But absence
+    from an abstract alone means little — an abstract will not list every minor
+    member — so reporting it would bury the real cases: allowing abstract-only
+    references to be reported took this list from 17 entries to 78.
     """
     stem = str(reference).replace(":", "_").replace("/", "_")
     for suffix in (".md", ".txt"):
         path = CACHE / f"{stem}{suffix}"
-        if path.is_file():
-            body = path.read_text(errors="replace")
-            if any(marker in body for marker in FULL_TEXT_MARKERS):
-                return " ".join(body.split())
-    return ""
+        if path.is_file() and any(m in path.read_text(errors="replace") for m in FULL_TEXT_MARKERS):
+            return True
+    return False
 
 
 def aliases(curie: str) -> set[str]:
@@ -172,7 +198,11 @@ def main() -> int:
         for label, curie, refs in taxa(document):
             texts = [t for t in (cached_text(r) for r in refs) if t]
             if not texts:
-                continue  # nothing to check against; not this script's business
+                continue  # nothing cached; not this script's business
+            # Match against everything, but only report absence where at least
+            # one reference has real full text behind it.
+            if not any(has_full_text(r) for r in refs):
+                continue
             keys = search_keys(label)
             if not keys:
                 continue

--- a/tests/test_taxon_stem_matching.py
+++ b/tests/test_taxon_stem_matching.py
@@ -154,3 +154,34 @@ def test_candidatus_prefix_is_skipped(check):
     """ "Candidatus" is a status marker, not a genus; 53 KB taxa carry it."""
     assert check.search_keys("Candidatus Methanogaster") == ["Methanogaster"]
     assert check.search_keys("Candidatus Brocadia") == ["Brocadia"]
+
+
+def test_matching_reads_abstracts_but_reporting_needs_full_text(check, tmp_path, monkeypatch):
+    """Two different questions, deliberately answered by two different rules.
+
+    `cached_text` returns every cached word including abstracts, because a paper
+    names its organisms in the abstract — excluding them reported
+    *Leptospirillum ferriphilum* as unsupported while one of its references named
+    "ferriphilum" six times in a 2.8 KB abstract.
+
+    `has_full_text` is separate, and gates whether ABSENCE is worth reporting.
+    Absence from an abstract alone means little, since an abstract will not list
+    every minor member; letting abstract-only references be reported took the
+    list from 17 entries to 78 and would have buried the real cases.
+    """
+    cache = tmp_path / "references_cache"
+    cache.mkdir()
+    (cache / "PMID_1.txt").write_text("an abstract naming Leptospirillum ferriphilum", "utf-8")
+    (cache / "PMID_2.md").write_text(
+        "header\n\n===== OPEN-ACCESS FULL TEXT (Europe PMC PMC1) =====\n\nbody text",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check, "CACHE", cache)
+
+    # Abstract-only: its words are matchable, but it cannot justify a report.
+    assert "ferriphilum" in check.cached_text("PMID:1")
+    assert not check.has_full_text("PMID:1")
+
+    # Full text: both.
+    assert "body text" in check.cached_text("PMID:2")
+    assert check.has_full_text("PMID:2")


### PR DESCRIPTION
Follow-on from #619. Triaging its 17 candidates found one false positive with a cause worth fixing, and classified the rest.

## The false positive, and why it happened

`Ferroplasma_Leptospirillum_Syntrophy` was reported as claiming *Leptospirillum ferriphilum* unsupported — while one of its two references, a 2.8 KB abstract with no full-text marker, names **"ferriphilum" six times**. The checker had skipped the file that answered the question.

The cause was **reasoning imported from the cultivation check**, where excluding abstract-only caches is correct because growth conditions live in Methods (#577). Membership is not like that: a paper names its organisms in the abstract. Applying one rule to two different questions was the error.

But simply including abstracts took the list from **17 to 78** — an abstract legitimately will not name every minor member, and reporting that buries the real cases. So the two questions now have two rules:

| function | question |
|---|---|
| `cached_text` | every cached word, abstracts included — what to **match** against |
| `has_full_text` | whether absence is worth **reporting** at all |

**15 absent**, down from 17, Leptospirillum rescued, both known defects still flagged. Mutation-checked: making `cached_text` skip abstracts again reddens the test that pins the distinction.

## A fifth false-positive class, identified and deliberately not encoded

11 of the remaining 15 are papers using a **vernacular or abbreviation** that NCBITaxon does not carry as a synonym:

```
Patescibacteria group     -> "CPR" / "Candidate Phyla Radiation"   (5 records)
Candidatus Methanogaster  -> "ANME"                                (128 mentions)
Desulfobacterales/-aceae  -> "SRB" (105), "sulfate-reducing"
Bacillariophyceae         -> "diatom" (21)
Basidiomycota             -> "yeast", "Rhodotorula"
Methanomicrobia           -> "Methanosarcina", "methanogen"
```

All correct curation — "CPR" **is** Patescibacteria, diatoms **are** Bacillariophyceae.

**Not encoded on purpose.** A vernacular map is unbounded, and every entry loosens a defect-finder further — the direction that has already cost this checker three bugs (the `Bacterium` synonym, genus-only synonym matching, lower-cased synonyms). Fifteen entries is a list a person reads in a minute, which is what the script is for. The classification is written up on #605 instead, where it costs nothing and cannot rot into a false rescue.

## What is left

Three genuine candidates: the two known cases plus **`Candidatus Eiseniibacteriota`** (new — its source contains nothing related under any spelling tried). Those need a curator with the literature, not more tooling.

## Gates

`lint` 0, `validate-strict` 0, **2519 passed**.