### PR TITLE
The third #605 candidate was a synonym-parsing bug, not a bad claim

### DIFF
--- a/scripts/taxon_absent_from_source.py
+++ b/scripts/taxon_absent_from_source.py
@@ -136,6 +136,28 @@ def aliases(curie: str) -> set[str]:
     return names
 
 
+# NCBITaxon synonyms are not clean names. They arrive quoted and carrying
+# authorship, e.g. '"""Candidatus Eisenbacteria"" Anantharaman et al. 2016"' and
+# 'Mediterraneibacter gnavus (Moore et al. 1976) Togo et al. 2023'. Left as-is,
+# the first of those yielded the search key '"""Candidatus' and reported
+# Mercury_SFA_EFPC_Sediment_Community as making an unsupported claim — while its
+# source names "Eisenbacteria" three times.
+_AUTHORSHIP = re.compile(
+    r"\s*\(?[A-Z][A-Za-z-]+(?:\s+(?:and|&)\s+[A-Z][A-Za-z-]+)?"
+    r"(?:\s+et\s+al\.?)?,?\s*\d{4}\)?\s*$"
+)
+
+
+def clean_name(name: str) -> str:
+    """A synonym reduced to the name itself, without quotes or authorship."""
+    name = name.replace('"', " ").replace("'", " ")
+    previous = None
+    while previous != name:  # authorship can be stacked: "(Moore 1976) Togo 2023"
+        previous = name
+        name = _AUTHORSHIP.sub("", name).strip()
+    return " ".join(name.split())
+
+
 def search_keys(name: str, *, require_capital: bool = True) -> list[str]:
     """The distinctive word(s) to look for in a source, from one name.
 
@@ -150,7 +172,7 @@ def search_keys(name: str, *, require_capital: bool = True) -> list[str]:
     is case-insensitive anyway; the capital was only ever a proxy for "looks
     like a proper name", and it is the wrong proxy here.
     """
-    words = name.split()
+    words = clean_name(name).split()
     if words and words[0].lower() in STATUS_PREFIXES:
         words = words[1:]
     if not words:
@@ -226,7 +248,13 @@ def main() -> int:
                 # lipolytica, and matching only "Candida" cleared a claim on a
                 # paper that discusses an unrelated Candida. Require the species
                 # epithet too, so the rescue is about THIS organism.
-                epithet = name.split()[1] if len(name.split()) > 1 else None
+                # From the CLEANED, prefix-stripped name. Using the raw string
+                # here looked for 'Eisenbacteria""' and never matched, so the
+                # quote fix above did nothing on its own.
+                parts_of = clean_name(name).split()
+                if parts_of and parts_of[0].lower() in STATUS_PREFIXES:
+                    parts_of = parts_of[1:]
+                epithet = parts_of[1] if len(parts_of) > 1 else None
                 needed = keys_for + ([epithet] if epithet and len(epithet) > 3 else [])
                 if all(any(mentions(k, t) for t in texts) for k in needed):
                     hit = " ".join(needed)

--- a/tests/test_taxon_stem_matching.py
+++ b/tests/test_taxon_stem_matching.py
@@ -185,3 +185,47 @@ def test_matching_reads_abstracts_but_reporting_needs_full_text(check, tmp_path,
     # Full text: both.
     assert "body text" in check.cached_text("PMID:2")
     assert check.has_full_text("PMID:2")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # The real NCBITaxon synonym that produced a false accusation.
+        ('"""Candidatus Eisenbacteria"" Anantharaman et al. 2016"', "Candidatus Eisenbacteria"),
+        # Stacked authorship — the reason the stripper loops.
+        (
+            "Mediterraneibacter gnavus (Moore et al. 1976) Togo et al. 2023",
+            "Mediterraneibacter gnavus",
+        ),
+        ("Ruminococcus gnavus", "Ruminococcus gnavus"),
+        ("Thiobacillus thioparus", "Thiobacillus thioparus"),
+    ],
+)
+def test_synonyms_are_stripped_of_quotes_and_authorship(check, raw, expected):
+    """NCBITaxon synonyms are not clean names (#605).
+
+    They arrive quoted and carrying authorship. Left alone, the first case here
+    yielded the search key '\"\"\"Candidatus' and reported
+    `Mercury_SFA_EFPC_Sediment_Community` as making an unsupported claim about
+    *Candidatus Eiseniibacteriota* — while its source names "Eisenbacteria"
+    three times.
+    """
+    assert check.clean_name(raw) == expected
+
+
+def test_the_eisenbacteria_synonym_yields_a_usable_key(check):
+    """End of the same chain: cleaning must survive into `search_keys`."""
+    raw = '"""Candidatus Eisenbacteria"" Anantharaman et al. 2016"'
+    assert check.search_keys(raw, require_capital=False) == ["Eisenbacteria"]
+    assert _matches(check, "Eisenbacteria", "the candidate phyla Eisenbacteria and Rokubacteria")
+
+
+def test_cleaning_does_not_swallow_a_real_epithet(check):
+    """The stripper must not mistake a species name for an author.
+
+    `_AUTHORSHIP` keys on a trailing four-digit year, so a binomial with no year
+    is untouched. Without this, "Bacillus cereus" could lose its epithet and the
+    synonym check would match on genus alone — the looseness #619 removed.
+    """
+    assert check.clean_name("Bacillus cereus") == "Bacillus cereus"
+    assert check.clean_name("Leptospirillum ferriphilum") == "Leptospirillum ferriphilum"


### PR DESCRIPTION
Closes out the #605 triage.

## The candidate I called least-examined was not a defect

`Candidatus Eiseniibacteriota` in `Mercury_SFA_EFPC_Sediment_Community`. Its source **names "Eisenbacteria" three times**. The claim is supported.

The accusation came from NCBITaxon synonyms not being clean names. This one arrives as:

```
"""Candidatus Eisenbacteria"" Anantharaman et al. 2016"
```

so `search_keys` returned `['"""Candidatus']` — the embedded quotes stopped the `Candidatus` prefix from being recognised, and the authorship trailed along. **The synonym that would have cleared the record was unusable.**

Synonyms are now stripped of quotes and trailing authorship, and the stripper **loops**, because authorship stacks: `Mediterraneibacter gnavus (Moore et al. 1976) Togo et al. 2023`.

## The quote fix alone did nothing

Worth recording. The drift check also extracts the species epithet, and it was reading the **raw** synonym — so it looked for `Eisenbacteria""` and never matched. Both halves had to be fixed, and testing only the first would have looked like progress while changing nothing.

Absent falls **15 → 14**, drift rises 39 → 40, both known defects still flagged. Mutation-checked. A further test pins that the stripper does not swallow a real epithet, since it keys on a trailing four-digit year and "Bacillus cereus" has none — without that, the genus-only looseness #619 removed could creep back.

## What the checker was actually worth

**Two** genuine defects out of the original 79 naive hits: `Synechococcus_Yarrowia_SPC` and `PGM_Spent_Catalyst_Bioleaching`. Both were already known before this checker existed.

So its value was not finding new ones — it was **establishing that there are no others**, which could not be asserted before. Getting there cost six bugs, every one found by canarying against the two cases it was built for:

| bug | effect if shipped |
|---|---|
| `Bacterium` as a genus synonym | rescued a known-bad claim as a renaming |
| genus-only synonym matching | cleared *Yarrowia* on an unrelated *Candida* |
| lower-cased synonyms discarded | 20 phylum renamings reported as unsupported |
| whole-word matching | rank changes reported as absent |
| the test helper rebuilt the regex | removing the safety property left **all 14 tests green** |
| quoted/authored synonyms unparsed | this record accused |

## Gates

`lint` 0, `validate-strict` 0, **2525 passed**.