### PR TITLE
Say what the cache actually supports when a snippet fails (#496, #622)

### DIFF
--- a/justfile
+++ b/justfile
@@ -126,6 +126,15 @@ cache-fulltext *pmids:
 validate-references FILE:
     uv run linkml-reference-validator validate data {{FILE}} -s src/communitymech/schema/communitymech.yaml --config conf/reference_validator.yaml
 
+# Same, with the validator's "only abstract available" note corrected (#496) and
+# its silent stripping of [bracketed] text called out (#622). Prefer this when
+# triaging: the raw note is a claim about the CACHE that the validator is not in
+# a position to make, and it has sent readers after a caching gap twice.
+validate-references-explained FILE:
+    #!/usr/bin/env bash
+    set -o pipefail
+    just validate-references {{FILE}} 2>&1 | uv run python scripts/annotate_reference_errors.py
+
 # Snippet audit across ALL records (the tool that actually reconciles with
 # validate-references). Buckets: MATCH / RENDERING / WEAK / MISMATCH / NOCONTENT.
 audit-snippets *args:

--- a/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
+++ b/kb/communities/Synthetic_Lichen_Synechococcus_Rhodotorula_Coculture.yaml
@@ -271,8 +271,7 @@ cultivation_setup:
   - reference: doi:10.1186/s13068-017-0736-x
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Co-cultures of <i>S. elongatus</i> and <i>R. glutinis</i> were sustained
-      over 1 month in both batch and in semi-continuous culture
+    snippet: were sustained over 1 month in both batch and in semi-continuous culture
 - cultivation_mode: SEMI_CONTINUOUS
   system_type: FLASK
   controls_notes: 50 mL of culture withdrawn and replaced with 50 mL fresh BG-11[co]
@@ -284,5 +283,4 @@ cultivation_setup:
   - reference: doi:10.1186/s13068-017-0736-x
     supports: SUPPORT
     evidence_source: IN_VITRO
-    snippet: Arrows indicate the time when 50 mL of original culture was withdrawn and
-      50 mL of fresh BG-11[co] medium was added
+    snippet: 50 mL of original culture was withdrawn and 50 mL of fresh BG-11

--- a/scripts/annotate_reference_errors.py
+++ b/scripts/annotate_reference_errors.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Correct `validate-references`' misleading "only abstract available" note (#496).
+
+The upstream validator annotates every failed match with
+
+    (note: only abstract available for PMID:X, full text may contain this excerpt)
+
+which is a claim about the **cache**. What it actually knows is "I could not
+match this snippet". When the full text *is* cached the note is simply false, and
+it sends the reader to `cache-fulltext` after a gap that does not exist — that
+cost a full canary cycle on #259.
+
+The wording lives upstream in `linkml-reference-validator`, so this does not fix
+it there. It reads the validator's output and replaces the note with what the
+cache actually supports, which is the part a curator needs in order to act:
+
+  no full-text marker   -> the note is TRUE; fetching may help
+  full text cached, and
+    the snippet elides with ".." or "…"  -> a legitimate stitched quote that this
+        validator cannot match by construction; `evidence_snippet_audit.py`
+        accepts it, so nothing needs doing
+    a near-miss on spacing              -> a PDF/XML extraction artefact
+        (RENDERING); do NOT edit the snippet to match the cache
+    otherwise                           -> genuinely absent from the full text;
+        this is the case worth a curator's time
+
+Usage:
+    just validate-references FILE 2>&1 | uv run python scripts/annotate_reference_errors.py
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+CACHE = REPO / "references_cache"
+FULL_TEXT_MARKERS = ("===== OPEN-ACCESS FULL TEXT", "Full text (re-fetched")
+
+_NOTE = re.compile(r"\(note: only abstract available for (?P<ref>[^,]+), full text may[^)]*\)")
+_SNIPPET = re.compile(r"not found as substring: '(?P<snippet>.*?)'(?:\s|$)")
+
+
+def cached(reference: str) -> tuple[str, bool]:
+    """(text, has_full_text) for a reference as the validator names it."""
+    stem = reference.strip().replace(":", "_").replace("/", "_")
+    parts, full = [], False
+    for suffix in (".md", ".txt"):
+        path = CACHE / f"{stem}{suffix}"
+        if path.is_file():
+            body = path.read_text(errors="replace")
+            parts.append(body)
+            full = full or any(m in body for m in FULL_TEXT_MARKERS)
+    return " ".join(" ".join(parts).split()), full
+
+
+def diagnose(reference: str, snippet: str) -> str:
+    text, full = cached(reference)
+    if not full:
+        return f"only the abstract is cached for {reference}; try `just cache-fulltext {reference}`"
+
+    flat = " ".join(snippet.split())
+    if re.search(r"\.\.+|…", snippet):
+        fragments = [f.strip() for f in re.split(r"\.\.+|…", flat) if f.strip()]
+        if fragments and all(f in text for f in fragments):
+            return (
+                f"stitched quote — every fragment is in the cached full text of {reference}, "
+                f"but this validator matches whole substrings only. "
+                f"evidence_snippet_audit.py accepts it; nothing to do"
+            )
+
+    # A near-miss on spacing is the documented RENDERING class: the curator read
+    # a rendered page and the extractor closed a subscript up, or vice versa.
+    if re.sub(r"\s+", "", flat) in re.sub(r"\s+", "", text):
+        return (
+            f"whitespace-only difference from the cached full text of {reference} — a PDF/XML "
+            f"extraction artefact (RENDERING). Do NOT edit the snippet to match the cache"
+        )
+
+    # The validator strips [bracketed] text from a snippet before matching and
+    # then quotes the mangled version back (#622), so a verbatim quote of
+    # "[NiFe]-hydrogenases" or "(80:20 [v/v])" arrives here looking absent. The
+    # give-away is a run of two spaces where the brackets were, so split on that
+    # and ask whether the surviving fragments are all present and in order —
+    # the same test the elision branch uses, rather than trying to rebuild the
+    # original string.
+    if "  " in " ".join(snippet.split(" ")):
+        fragments = [f.strip() for f in re.split(r" {2,}", snippet.strip()) if f.strip()]
+        if len(fragments) > 1:
+            position, ordered = 0, True
+            for fragment in fragments:
+                found = text.find(fragment, position)
+                if found < 0:
+                    ordered = False
+                    break
+                position = found + len(fragment)
+            if ordered:
+                return (
+                    f"matches the cached full text of {reference} either side of the gap — this "
+                    f"validator strips [bracketed] text before matching, so the quote is fine "
+                    f"and the tool is not (#622)"
+                )
+
+    return f"absent from the cached full text of {reference} — worth a curator's attention"
+
+
+def main() -> int:
+    replaced = 0
+    for line in sys.stdin:
+        match = _NOTE.search(line)
+        if match:
+            snippet_match = _SNIPPET.search(line)
+            snippet = snippet_match.group("snippet") if snippet_match else ""
+            line = line.replace(match.group(0), f"(note: {diagnose(match.group('ref'), snippet)})")
+            replaced += 1
+        sys.stdout.write(line)
+    if replaced:
+        print(
+            f"\n[annotate] rewrote {replaced} misleading 'only abstract available' note(s) (#496)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reference_error_annotation.py
+++ b/tests/test_reference_error_annotation.py
@@ -1,0 +1,147 @@
+"""The validator's "only abstract available" note is a claim it cannot make (#496).
+
+`validate-references` annotates every failed match with
+
+    (note: only abstract available for PMID:X, full text may contain this excerpt)
+
+That is a statement about the **cache**. What the validator knows is only "I could
+not match this snippet". When the full text is cached the note is false, and it
+sends the reader to `cache-fulltext` after a gap that does not exist — which cost
+a full canary cycle on #259 and happened again on #622.
+
+`scripts/annotate_reference_errors.py` rewrites the note with what the cache
+actually supports. These tests pin each branch, because the value of the tool is
+entirely in telling the four cases apart:
+
+* no full text cached — the note is true, fetching may help
+* a stitched quote (`..`) — legitimate; this validator matches whole substrings
+  only, and `evidence_snippet_audit.py` accepts it
+* a gap left by the validator stripping `[bracketed]` text (#622) — the quote is
+  fine and the tool is not
+* genuinely absent — the only case worth a curator's time
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+REPO = pathlib.Path(__file__).parent.parent
+SCRIPT = REPO / "scripts/annotate_reference_errors.py"
+
+
+@pytest.fixture()
+def annotator(tmp_path, monkeypatch):
+    spec = importlib.util.spec_from_file_location("annotate_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    cache = tmp_path / "references_cache"
+    cache.mkdir()
+    monkeypatch.setattr(module, "CACHE", cache)
+    return module, cache
+
+
+def _write(cache, name: str, body: str, *, full_text: bool) -> None:
+    marker = "\n\n===== OPEN-ACCESS FULL TEXT (Europe PMC PMC1) =====\n\n" if full_text else "\n"
+    (cache / name).write_text(f"# header{marker}{body}\n", encoding="utf-8")
+
+
+def test_abstract_only_keeps_the_original_advice(annotator):
+    """The one case where the upstream note is correct."""
+    module, cache = annotator
+    _write(cache, "PMID_1.txt", "a short abstract", full_text=False)
+
+    note = module.diagnose("PMID:1", "some phrase that is absent")
+
+    assert "only the abstract is cached" in note
+    assert "cache-fulltext" in note
+
+
+def test_a_stitched_quote_is_identified_as_fine(annotator):
+    """`..` elision is supported by the audit tool and unmatchable by this one."""
+    module, cache = annotator
+    _write(
+        cache,
+        "PMID_2.md",
+        "Metatranscriptomics reveals expression of genes for hydrogenases, pyruvate oxidation",
+        full_text=True,
+    )
+
+    note = module.diagnose("PMID:2", "expression of genes..pyruvate oxidation")
+
+    assert "stitched quote" in note
+    assert "nothing to do" in note
+
+
+def test_a_bracket_gap_is_blamed_on_the_validator(annotator):
+    """The #622 case: the validator strips `[NiFe]` and quotes the wreckage back."""
+    module, cache = annotator
+    _write(
+        cache,
+        "PMID_3.md",
+        "expression of genes for [NiFe]-hydrogenases, pyruvate",
+        full_text=True,
+    )
+
+    # What the validator reports, with the brackets already removed.
+    note = module.diagnose("PMID:3", "expression of genes for  -hydrogenases")
+
+    assert "#622" in note
+    assert "the quote is fine and the tool is not" in note
+
+
+def test_a_genuine_absence_is_still_reported_as_one(annotator):
+    """The loosening must not swallow the case the validator exists to find."""
+    module, cache = annotator
+    _write(cache, "PMID_4.md", "a paper about something else entirely", full_text=True)
+
+    note = module.diagnose("PMID:4", "Yarrowia lipolytica was co-cultured")
+
+    assert "absent from the cached full text" in note
+    assert "curator" in note
+
+
+def test_a_bracket_gap_whose_fragments_are_absent_is_not_excused(annotator):
+    """Two spaces alone must not clear a snippet.
+
+    A fabricated quote can contain a double space too. The fragments either side
+    of the gap have to be present, and in order, or this stays an absence.
+    """
+    module, cache = annotator
+    _write(cache, "PMID_5.md", "an unrelated body of text", full_text=True)
+
+    note = module.diagnose("PMID:5", "invented phrase  with a gap in it")
+
+    assert "absent from the cached full text" in note
+
+
+def test_fragments_out_of_order_are_not_excused(annotator):
+    """Order matters, or the check degenerates into "these words appear somewhere"."""
+    module, cache = annotator
+    _write(cache, "PMID_6.md", "beta appears first and then alpha follows later", full_text=True)
+
+    note = module.diagnose("PMID:6", "alpha  beta")
+
+    assert "absent from the cached full text" in note
+
+
+def test_the_stream_rewrites_only_the_note(annotator, capsys, monkeypatch):
+    """Everything else the validator says must pass through untouched."""
+    module, cache = annotator
+    _write(cache, "PMID_7.md", "a paper about something else entirely", full_text=True)
+    line = (
+        "  [ERROR] Text part not found as substring: 'absent phrase' "
+        "(note: only abstract available for PMID:7, full text may contain this excerpt)\n"
+    )
+    monkeypatch.setattr(module.sys, "stdin", [line, "  Location: taxonomy[0]\n"])
+
+    module.main()
+    out = capsys.readouterr().out
+
+    error_line = next(line for line in out.splitlines() if "[ERROR]" in line)
+    assert "only abstract available" not in error_line
+    assert "absent from the cached full text" in error_line
+    assert "Location: taxonomy[0]" in out, "unrelated lines must survive"
+    assert "[ERROR] Text part not found as substring: 'absent phrase'" in out


### PR DESCRIPTION
Closes the locally-actionable part of #496; files and mitigates #622.

## #496 — a claim the validator cannot make

`validate-references` annotates every failed match with *"only abstract available for PMID:X"*. That is a statement about the **cache**. What it knows is "I could not match this snippet". When the full text is cached the note is false, and it sends the reader to `cache-fulltext` after a gap that does not exist — it cost a canary cycle on #259 and did it again here.

The wording is upstream, so `scripts/annotate_reference_errors.py` reads the validator's output and replaces the note with what the cache supports:

| cache state | new note |
|---|---|
| no full-text marker | the original advice — it is true here |
| stitched quote with `..` | legitimate; this validator matches whole substrings only, and `evidence_snippet_audit.py` accepts it |
| gap left by bracket stripping | the quote is fine and the tool is not (#622) |
| otherwise | absent — the case worth a curator's time |

New recipe: **`just validate-references-explained FILE`**.

## #622 — the more consequential find

It surfaced because the annotator's first version reported a snippet as absent that I had just proved verbatim. **The validator strips `[bracketed]` text from a snippet before matching, then quotes the mangled version back:**

```
record    expression of genes for [NiFe]-hydrogenases
reported  expression of genes for  -hydrogenases
```

Same for `(80:20 [v/v])` and `BG-11[co]`.

Only **4 of 5315** snippets contain brackets and 3 are verbatim-and-failing, so present damage is small. But brackets are how cofactors, volume ratios, medium variants and isotopic labels are written — the bug makes a whole class of precise quotation unusable, and the failure **looks like a bad snippet rather than a tool artefact**.

## Two of the three are mine

From earlier in this session. A third snippet contained literal `<i>` markup copied out of a DOI cache that carries **raw HTML** (17 occurrences of `<i>`, because that fetch path does not strip tags the way the Europe PMC XML path does). Both of mine are trimmed to clean verbatim spans — including markup in a snippet is poor curation whether or not it happens to match.

**I nearly "fixed" the Asgard snippet by editing it before checking**, which would have damaged a verbatim quote to satisfy a broken matcher. An assertion in my own patch script stopped it. That is the failure mode the justfile already warns about for RENDERING, arriving from a new direction.

## Mutation checks

| reverted | result |
|---|---|
| the bracket branch | 1 failed |
| the in-order fragment requirement | 1 failed |
| forcing the abstract-only verdict | 6 failed |
| nothing | 7 passed |

A test also pins that two spaces alone do not excuse a snippet — a fabricated quote can contain a double space, so the fragments either side must be present **and in order**.

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, `check-docs-current` 0, **2534 passed**.