### PR TITLE
Audit whether a grounding reproduces from the crosswalk, and withdraw #624's claim

### DIFF
--- a/scripts/audit_grounding_provenance.py
+++ b/scripts/audit_grounding_provenance.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Can each recorded grounding be reproduced from the source it names? (#624)
+
+Every `gtdb_classification` block records the `ncbi_source_id` it was resolved
+from, plus a `majority_fraction` and `total_genomes`. Those numbers are what a
+curator reads to decide whether to trust the grounding — #383 exists because the
+fraction alone hid its own evidence, and `total_genomes` was added so the
+denominator could be seen.
+
+That only helps if the numbers can be checked against the id they claim to come
+from. On `GLBRC_UFMP_Fermentation_Community` they cannot: the block records
+`ncbi_source_id: NCBITaxon:133926`, `total_genomes: 29`, and that id has **zero**
+rows in the crosswalk. *Olsenella uli* is there under NCBI 633147 with 27
+genomes. So the grounding is not reproducible from what it says produced it.
+
+This reports three states per block:
+
+  OK          the id is in the crosswalk and total_genomes agrees
+  DRIFTED     the id is present but total_genomes differs — most likely a
+              grounding written against an older GTDB release, which nothing in
+              the record identifies (that is the underlying gap)
+  UNSOURCED   the id has no rows at all; the numbers cannot have come from here
+
+A script, not a test: it reads a large external file from a local kg-microbe
+checkout, so it cannot run in the blocking gate.
+
+Usage:
+    uv run python scripts/audit_grounding_provenance.py [--list] [--kg-microbe-dir DIR]
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import pathlib
+import sys
+from collections import Counter
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+COMMUNITIES = REPO / "kb/communities"
+
+
+def _ground_module():
+    """Reuse gtdb_ground's column constants and directory resolution.
+
+    Imported rather than copied: the column indices are load-bearing and a
+    duplicate set would drift silently the first time the crosswalk changed
+    shape. Same reason `audit_writers.py` is read rather than re-derived.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "gtdb_ground_for_audit", REPO / "scripts/gtdb_ground.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def crosswalk_totals(mapping: pathlib.Path, ground) -> dict[str, int]:
+    """NCBI species NAME -> genome count, computed exactly as `gtdb_ground` does.
+
+    Keyed by name because that is how groundings resolve: `COL_NCBI_ID` is a
+    strain/genome-level taxid, so *Acetobacterium woodii* (species 33952) sits
+    on a row keyed 931626 with the species in `COL_NCBI_SPECIES`.
+
+    The count comes from `ground._species_denominator`, not from summing. That
+    function exists precisely because a species-rank row and its strain rows
+    describe overlapping genome sets, and its rule is "take the larger depth,
+    never the sum". A naive sum here reported 160 blocks as drifted with the
+    tell-tale signature of doubling — 2 against 4, 7 against 15 — which is what
+    sent me to read it. Reusing it is also the point: a second copy of this
+    arithmetic would disagree with the tool the moment either changed.
+    """
+    rows_by_name: dict[str, list] = {}
+    with gzip.open(mapping, "rt") as handle:
+        next(handle, None)  # header
+        for line in handle:
+            row = line.rstrip("\n").split("\t")
+            if len(row) <= max(ground.COL_TOTAL_GENOMES, ground.COL_NCBI_STRAIN):
+                continue
+            name = row[ground.COL_NCBI_SPECIES].strip()
+            if name:
+                rows_by_name.setdefault(name, []).append(row)
+    return {name: ground._species_denominator(rows)[0] for name, rows in rows_by_name.items()}
+
+
+def blocks():
+    """(file, preferred_term, gtdb_classification) for every grounding."""
+    for path in sorted(COMMUNITIES.glob("*.yaml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+        def walk(node, filename=path.name):
+            if isinstance(node, dict):
+                classification = node.get("gtdb_classification")
+                if isinstance(classification, dict) and classification.get("ncbi_source_id"):
+                    # The NCBI label is what the crosswalk is keyed by, so it is
+                    # what a recorded total can be checked against.
+                    label = ((node.get("term") or {}) or {}).get("label") or ""
+                    yield filename, node.get("preferred_term") or "", classification, label
+                for value in node.values():
+                    yield from walk(value, filename)
+            elif isinstance(node, list):
+                for value in node:
+                    yield from walk(value, filename)
+
+        yield from walk(document)
+
+
+def main() -> int:
+    ground = _ground_module()
+    kg_dir = ground.resolve_kg_microbe_dir(
+        sys.argv[sys.argv.index("--kg-microbe-dir") + 1] if "--kg-microbe-dir" in sys.argv else None
+    )
+    mapping = kg_dir / ground.MAPPING_REL
+    if not mapping.is_file():
+        print(f"[audit] crosswalk not found at {mapping}", file=sys.stderr)
+        return 2
+
+    totals = crosswalk_totals(mapping, ground)
+    verdicts: Counter[str] = Counter()
+    detail = []
+
+    skipped_higher = 0
+    for filename, preferred, classification, ncbi_label in blocks():
+        recorded = classification.get("total_genomes")
+
+        # Only species-rank groundings are comparable: a higher rank sums a
+        # different set of rows, and reproducing that means reimplementing
+        # `resolve_higher` rather than auditing it.
+        if not str(classification.get("gtdb_id", "")).startswith("GTDB:s__"):
+            skipped_higher += 1
+            continue
+        if not ncbi_label or recorded is None:
+            skipped_higher += 1
+            continue
+
+        actual = totals.get(ncbi_label)
+        if actual is None:
+            verdicts["UNSOURCED"] += 1
+            detail.append(("UNSOURCED", filename, preferred, ncbi_label, recorded, None))
+        elif int(recorded) != actual:
+            verdicts["DRIFTED"] += 1
+            detail.append(("DRIFTED", filename, preferred, ncbi_label, recorded, actual))
+        else:
+            verdicts["OK"] += 1
+
+    total = sum(verdicts.values())
+    print(f"# {total} SPECIES-level gtdb_classification blocks checked against {mapping.name}")
+    print(f"  ({skipped_higher} higher-rank blocks skipped — resolved by name, not by taxid)")
+    for state in ("OK", "DRIFTED", "UNSOURCED"):
+        print(f"  {state:<10} {verdicts[state]}")
+
+    if "--list" in sys.argv or verdicts["UNSOURCED"]:
+        print("\n# Not reproducible from the ncbi_source_id they record")
+        for state, filename, preferred, source, recorded, actual in detail:
+            actual_text = "no rows" if actual is None else f"crosswalk says {actual}"
+            print(
+                f"  [{state}] {filename[:46]:46} {preferred[:30]:30} "
+                f"{source!r} total_genomes={recorded} ({actual_text})"
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds `scripts/audit_grounding_provenance.py`, and corrects the issue that prompted it.

## #624's central claim was wrong

I filed it saying the `Olsenella uli` block's `majority_fraction` and `total_genomes` "cannot have come from" the `ncbi_source_id` it records. **The grounding reproduces exactly.**

`Olsenella uli` has **two** strain rows in the crosswalk:

```
taxid=633147   genomes=27   strain='Olsenella uli DSM 7084'
taxid=1190621  genomes=2    strain='Olsenella uli MSTE5'
```

`gtdb_ground._species_denominator` over those returns **total=29, majority=1.0** — precisely what the record carries.

## Three compounding mistakes, four attempts

Each intermediate version looked like a finding:

| attempt | reported | why it was wrong |
|---|---|---|
| 1 | 421 of 728 unsourced, incl. `NCBITaxon:2` | looked up the **species** taxid in `COL_NCBI_ID`, which is strain-level; groundings resolve by **name** |
| 2 | 78 unsourced | restricted to species rank, same wrong key |
| 3 | 160 drifted | hand-rolled the denominator by **summing** — doubling signature (2 vs 4, 7 vs 15) |
| 4 | correct | used `_species_denominator`, whose docstring says "without double-counting" |

I had written *"reuse rather than re-derive"* in this script's own docstring, and then hand-rolled the arithmetic anyway. The doubling signature is what sent me to read the function I should have used first.

I also read **one** crosswalk row, compared 27 against the record's 29, and called the difference unexplained — without noticing a second row existed.

## What the corrected audit reports

```
338 species-rank blocks checked   (390 higher-rank skipped — resolved by name, not taxid)
  OK         198
  DRIFTED     79
  UNSOURCED   61
```

The **79 drifted** are what survives, and they fit the stale-release hypothesis: **27 differ by 1–2 genomes, 32 by 3–20**. A crosswalk that gains genomes over time produces exactly that shape. The **61 unsourced** are mostly strain-level labels (`Mucispirillum schaedleri ASF457`) that a species-name lookup cannot reach — a limit of the audit, stated in the code, not a defect in the records.

## The gap that actually remains

Much smaller than #624 claimed, and the only part still standing: **nothing in a `gtdb_classification` records which GTDB release produced it**, so a block that differs from today's crosswalk cannot be distinguished from one that is wrong. `gtdb_ground.py` prints the release it read and does not persist it into the record.

That is what makes the 79 uninterpretable rather than actionable, and it is a one-field fix if someone wants it.

## Gates

`lint` 0, **2536 passed**. A script rather than a test — it reads a large external file from a local kg-microbe checkout, so it cannot run in the blocking gate.