### PR TITLE
Examine the comment after a flow collection, in both rules (#489)

### DIFF
--- a/src/communitymech/validators/yaml_scalars.py
+++ b/src/communitymech/validators/yaml_scalars.py
@@ -130,11 +130,49 @@ def find_truncated_scalars(path: Path, *, require_gap: bool = False) -> list[Sca
         return []
 
     issues: list[ScalarIssue] = []
+    # PyYAML puts `flow_style` on the START events only — Sequence/MappingEnd
+    # carry no such attribute, so `getattr(event, "flow_style", None) is not
+    # False` (my first attempt) was always true and excluded nothing. Track it
+    # from the starts instead.
+    #
+    # This restriction is DEFENSIVE, not load-bearing, and no test can make it
+    # fail: a block collection's end_mark lands on the next *token*, so it skips
+    # over comment lines entirely and can never produce a remainder starting
+    # with `#`. Removing the restriction changes nothing observable today. It is
+    # here so the intent is stated rather than accidental — the same reason
+    # `_species_denominator` documents a rule that is currently a no-op on the
+    # KB. Verified by inspection: for `k:\n  - a\nnext: 1`, the SequenceEnd
+    # remainder is "next: 1"; with a trailing comment it is past EOF.
+    flow_stack: list[bool] = []
     for event in events:
-        # A quoted scalar ('"', "'") or a block scalar ('|', '>') delimits itself,
-        # so a `#` inside it is literal and a `#` after it ends a value that was
-        # already complete. Only `style is None` — a plain scalar — can be cut.
-        if not isinstance(event, yaml.ScalarEvent) or event.style is not None:
+        if isinstance(event, (yaml.SequenceStartEvent, yaml.MappingStartEvent)):
+            flow_stack.append(bool(event.flow_style))
+        # Two kinds of event can have a comment eat their tail.
+        #
+        # A plain scalar. A quoted ('"', "'") or block ('|', '>') scalar
+        # delimits itself, so a `#` inside it is literal and a `#` after it ends
+        # a value that was already complete. Only `style is None` can be cut.
+        #
+        # And the END of a FLOW collection (#489). `key: [a, b] # comment`
+        # anchors nothing useful on the last scalar: `b`'s end_mark sits before
+        # the `]`, so the remainder is `] # comment`, which does not start with
+        # `#`, and the line was skipped under both rules. The collection's own
+        # end event carries an end_mark after the bracket, where the same
+        # remainder logic works. Flow style only — a block collection ends on a
+        # later line and its end_mark says nothing about this one.
+        if isinstance(event, yaml.ScalarEvent) and event.style is None:
+            value, is_collection = event.value, False
+        elif isinstance(event, (yaml.SequenceEndEvent, yaml.MappingEndEvent)) and (
+            flow_stack.pop() if flow_stack else False
+        ):
+            # A flag, not an empty `value`. Overloading `value = ""` here made
+            # the gap rule treat every flow collection as total loss — for a
+            # SCALAR an empty value means the whole thing became a comment — and
+            # `deliberate_flow: [a, b]   # note` was reported. A collection that
+            # ends before the `#` has its value intact; only the comment after
+            # it is in question.
+            value, is_collection = "", True
+        else:
             continue
 
         end = event.end_mark
@@ -143,7 +181,11 @@ def find_truncated_scalars(path: Path, *, require_gap: bool = False) -> list[Sca
         remainder = lines[end.line][end.column :]
         if not remainder.lstrip().startswith("#"):
             continue
-        if require_gap and event.value != "" and len(remainder) - len(remainder.lstrip()) >= 2:
+        if (
+            require_gap
+            and (value != "" or is_collection)
+            and len(remainder) - len(remainder.lstrip()) >= 2
+        ):
             # Two or more spaces: written as a deliberate end-of-line comment.
             #
             # Except when the value is EMPTY. `description:  #400 all of it` is
@@ -161,7 +203,7 @@ def find_truncated_scalars(path: Path, *, require_gap: bool = False) -> list[Sca
                 file=str(path),
                 line=end.line + 1,
                 key=key,
-                truncated_to=event.value.strip(),
+                truncated_to=value.strip(),
                 lost=remainder.strip(),
             )
         )

--- a/tests/test_yaml_scalar_truncation.py
+++ b/tests/test_yaml_scalar_truncation.py
@@ -417,3 +417,103 @@ def test_the_gap_rule_still_catches_a_real_truncation(tmp_path):
     assert len(issues) == 1, issues
     assert issues[0].truncated_to == "no clean CHEBI term"
     assert "needs minting" in issues[0].lost
+
+
+# --------------------------------------------------------------------------
+# Flow collections (#489)
+# --------------------------------------------------------------------------
+
+
+def _flow_fixture(tmp_path, body: str):
+    path = tmp_path / "r.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    ("line", "key"),
+    [
+        ("flow_seq: [a, b] #489 lost", "flow_seq"),
+        ("flow_map: {x: 1, y: 2} #489 lost", "flow_map"),
+        ("nested: [[a], [b]] #489 lost", "nested"),
+    ],
+)
+def test_a_comment_after_a_flow_collection_is_reported(tmp_path, line, key):
+    """The blind spot #489 found, in both rules.
+
+    `find_truncated_scalars` anchored only on scalar `end_mark`s. For
+    `key: [a, b] # c` the last scalar's end_mark sits BEFORE the `]`, so the
+    remainder was `] # c`, which does not start with `#`, and the line was
+    skipped — under the strict rule and the relaxed one alike. The check's
+    promise is that a mid-line `#` cannot silently eat a value, and this was a
+    shape where it could.
+    """
+    path = _flow_fixture(tmp_path, f"id: CommunityMech:000999\n{line}\n")
+
+    for require_gap in (False, True):
+        found = [issue.key for issue in find_truncated_scalars(path, require_gap=require_gap)]
+        assert key in found, f"not reported with require_gap={require_gap}"
+
+
+def test_a_deliberate_comment_after_a_flow_collection_is_exempt(tmp_path):
+    """And the relaxed rule must still exempt a real end-of-line comment.
+
+    The first version of this fix set `value = ""` for collection-end events.
+    That collided with the empty-value special case — for a SCALAR, an empty
+    value means the whole value became a comment, so the gap exemption does not
+    apply — and every flow collection with a deliberate comment was reported.
+    A flag distinguishes the two; an overloaded sentinel did not.
+    """
+    path = _flow_fixture(
+        tmp_path,
+        "id: CommunityMech:000998\ndeliberate: [a, b]   # three spaces, a real comment\n",
+    )
+
+    assert find_truncated_scalars(path, require_gap=True) == []
+    # Still reported under the strict rule, which is what "strict" means.
+    assert [i.key for i in find_truncated_scalars(path, require_gap=False)] == ["deliberate"]
+
+
+def test_a_block_collection_is_not_anchored_on(tmp_path):
+    """Flow style only. A block collection ends on a later line.
+
+    Its `end_mark` says nothing about the line the comment is on, so anchoring
+    on it would report a standalone comment as a truncation.
+
+    **This test documents behaviour it cannot gate**, and says so rather than
+    implying otherwise. Two fixtures were tried and neither discriminates,
+    because a block collection's end_mark lands on the next *token*: before an
+    ordinary key it reads "next: 1", and before a trailing comment it lands past
+    EOF. Either way the remainder never starts with `#`, so anchoring on block
+    collections changes nothing observable — a mutation that does it still passes
+    all 55 tests.
+
+    The restriction in the validator is therefore defensive. Keeping this test
+    records the shape and stops a future refactor from reporting standalone
+    comments, even though it would not have caught the mutation.
+    """
+    path = _flow_fixture(
+        tmp_path,
+        "id: CommunityMech:000997\nblock:\n  - a\n  - b\n# a standalone comment\n",
+    )
+
+    assert find_truncated_scalars(path, require_gap=False) == [], (
+        "a standalone comment after a block sequence was reported as a "
+        "truncation; block collections must not be anchored on"
+    )
+
+
+def test_a_quoted_scalar_inside_a_flow_collection_is_still_safe(tmp_path):
+    """The reason `conf/id_label_targets.yaml` was safe before this fix.
+
+    Every value there is quoted, and a quoted scalar delimits itself. The fix
+    must not turn that into a report — the collection ends before the comment,
+    so only a genuine trailing `#` is in question.
+    """
+    path = _flow_fixture(
+        tmp_path,
+        "id: CommunityMech:000996\n"
+        'entry: { id: "CHEBI:33104", reason: "no clean term; needs minting" }\n',
+    )
+
+    assert find_truncated_scalars(path, require_gap=False) == []


### PR DESCRIPTION
Closes #489. Second of the named list (#479 done, #489, #480, #482).

## Reproduced before fixing

`find_truncated_scalars` anchored only on **scalar** `end_mark`s. For `key: [a, b] # c` the last scalar's end_mark sits *before* the `]`, so the remainder is `] # c` — it does not start with `#`, and the line was skipped under the strict rule and the relaxed one alike.

A probe with one truncated plain scalar and two truncated flow collections reported **only the scalar**. After the fix, all three.

No corpus change: 318 files, 0 truncations, and `conf/id_label_targets.yaml` — the file #489 named as at-risk — stays clean under the relaxed rule it is actually checked with (it is in `RELAXED_FILES`).

## Three mistakes, each caught by a check rather than by reading

1. **Overloaded sentinel.** Setting `value = ""` for collection ends collided with the empty-value special case — for a *scalar*, an empty value means the whole value became a comment, so the gap exemption does not apply. Result: `deliberate: [a, b]   # note` was reported. A flag distinguishes the two; a sentinel did not.

2. **Helper shadowing.** My new `_write` shadowed an existing one in the test file that takes a `name` keyword. Two pre-existing tests failed; I checked whether my change or the tests were at fault before touching either.

3. **Dead guard.** `getattr(event, "flow_style", None) is not False` was a no-op: PyYAML puts `flow_style` on the **Start** events only, so End events have no such attribute and the expression was always true — it excluded nothing. Replaced with a stack tracking the corresponding starts.

## One thing I could not test, now stated rather than implied

The restriction to flow style is **defensive, not load-bearing**. A block collection's `end_mark` lands on the next *token* — `"next: 1"` before an ordinary key, past EOF before a trailing comment — so the remainder never begins with `#`. Anchoring on block collections changes nothing observable: **that mutation passes all 55 tests.**

I tried two fixtures trying to make it discriminate before establishing that. The test now records the shape and says plainly that it does not gate it, rather than reading as coverage it isn't.

## Mutation checks

| reverted | result |
|---|---|
| the flow-collection branch | **4 failed** |
| the flag, back to `value == ""` | **1 failed** (the deliberate-comment exemption) |
| treat block collections as flow | 55 passed — documented above as untestable |

## Gates

`lint` 0, `validate-strict` 0, **2546 passed**.
