### PR TITLE
One definition of is_reclassified, and a dropped strain is not one (#480, #482)

### DIFF
--- a/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
+++ b/data/isolates/Methylobacterium_REE_Ewaste_Platform.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:408
       majority_fraction: 0.88
       total_genomes: 42
-      is_reclassified: false
+      is_reclassified: true
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Mesophilic methylotrophic alphaproteobacterium engineered for enhanced REE bioaccumulation from electronic waste.
       The AM1 strain naturally grows on methanol and C1 compounds, utilizing the serine cycle for carbon assimilation. M.

--- a/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
+++ b/kb/communities/Altered_Schaedler_Flora_Gnotobiotic_Mouse_Community.yaml
@@ -108,7 +108,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1379858
       majority_fraction: 1.0
       total_genomes: 73
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Spiral, mucus-associated member of the ASF.
   functional_role:

--- a/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
+++ b/kb/communities/Bacteroides_Eubacterium_Gnotobiotic_Gut_Model.yaml
@@ -50,7 +50,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:226186
       majority_fraction: 1.0
       total_genomes: 2039
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Human gut Bacteroidetes member used as the polysaccharide-foraging partner.
   strain_designation:
@@ -89,7 +89,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:515619
       majority_fraction: 1.0
       total_genomes: 13850
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature name retained in preferred_term; NCBI currently labels the strain as Agathobacter
       rectalis ATCC 33656 and lists Eubacterium rectale ATCC 33656 as an equivalent name.

--- a/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
+++ b/kb/communities/BioModels_MODEL2405300001_Infant_Gut_HMO_SynCom.yaml
@@ -206,7 +206,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
       total_genomes: 50
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   strain_designation:
     strain_name: MG1655

--- a/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
+++ b/kb/communities/Caldicellulosiruptor_TwoSpecies_Hydrogen_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:351627
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Extreme thermophilic anaerobe used as one hydrogen-producing member of the defined coculture.
   strain_designation:
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:632335
       majority_fraction: 1.0
       total_genomes: 4
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       The primary paper reports this member as C. kristjanssonii DSM 12137.

--- a/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
+++ b/kb/communities/Cellulose_Methane_Quad_Culture_SynCom.yaml
@@ -65,7 +65,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:323259
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   functional_role:
   - SYNTROPHIC_PARTNER

--- a/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
+++ b/kb/communities/Clostridium_Caldicellulosiruptor_Minimal_Medium_Coculture.yaml
@@ -98,7 +98,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:521460
       majority_fraction: 1.0
       total_genomes: 3
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain DSM 6725 is also available as ATCC BAA-1888 and was
       previously reported as Anaerocellum thermophilum DSM 6725.

--- a/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
+++ b/kb/communities/Clostridium_Phytofermentans_Ecoli_Cellobiose_Biofilm_Consortium.yaml
@@ -67,7 +67,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The paper uses the name C. phytofermentans; NCBI currently places strain ISDg under
       Lachnoclostridium phytofermentans.
@@ -109,7 +109,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
       total_genomes: 37
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic secondary-resource specialist in the artificial consortium.
   strain_designation:

--- a/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
+++ b/kb/communities/Clostridium_Saccharomyces_Cellulose_Ethanol_Coculture.yaml
@@ -60,7 +60,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:357809
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the name C. phytofermentans; NCBI currently represents
       the strain as Lachnoclostridium phytofermentans ISDg.

--- a/kb/communities/Dangl_SynComm_35.yaml
+++ b/kb/communities/Dangl_SynComm_35.yaml
@@ -211,7 +211,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:668369
       majority_fraction: 1.0
       total_genomes: 4
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
   abundance_level: COMMON
   functional_role:

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Lactate_TCE_Syntrophy.yaml
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The main 2011 publication uses the historical name Dehalococcoides
       ethenogenes strain 195; this record uses the current NCBI strain taxon.
@@ -101,7 +101,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       total_genomes: 7
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publications use Desulfovibrio vulgaris Hildenborough or DvH; NCBI
       currently represents the strain as Nitratidesulfovibrio vulgaris str.

--- a/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
+++ b/kb/communities/Dehalococcoides_Desulfovibrio_Pelosinus_Corrinoid_Triculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring strain that depends on partner-supplied hydrogen,
       acetate, vitamins, and corrinoids in simplified dechlorinating consortia.
@@ -103,7 +103,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       total_genomes: 7
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Desulfovibrio vulgaris Hildenborough or DvH; NCBI
       currently represents the strain as Nitratidesulfovibrio vulgaris str.
@@ -144,7 +144,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1122947
       majority_fraction: 1.0
       total_genomes: 3
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses Pelosinus fermentans R7 or PfR7; NCBI represents the
       strain as Pelosinus fermentans DSM 17108 and lists Pelosinus fermentans R7

--- a/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Pelobacter_Acetylene_TCE_Coculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring partner used for TCE reductive dechlorination in the defined
       SFB93 coculture.

--- a/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
+++ b/kb/communities/Dehalococcoides_Syntrophomonas_TCE_Dechlorination_Coculture.yaml
@@ -67,7 +67,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243164
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Organohalide-respiring bacterium that uses hydrogen as the electron donor for reductive
       dechlorination of TCE in the coculture.

--- a/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
+++ b/kb/communities/Desulfovibrio_Methanococcus_Syntrophy.yaml
@@ -39,7 +39,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       total_genomes: 7
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic sulfate-reducing bacterium that can also grow syntrophically in the absence of sulfate.
       When grown without sulfate, D. vulgaris oxidizes lactate to acetate, producing H2 and CO2 as electron
@@ -74,7 +74,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:267377
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Hydrogenotrophic methanogen that consumes H2 and CO2 to produce methane. Essential syntrophic
       partner that maintains low H2 partial pressure, enabling thermodynamically unfavorable lactate oxidation

--- a/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
+++ b/kb/communities/Emiliania_Phaeobacter_Dynamic_Interaction.yaml
@@ -66,7 +66,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:391619
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Heterotrophic Roseobacter-group bacterium that attaches to E. huxleyi and produces IAA.
   strain_designation:

--- a/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
+++ b/kb/communities/Engineered_Gut_Amino_Acid_CrossFeeding_Consortium.yaml
@@ -75,7 +75,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:90371
       majority_fraction: 1.0
       total_genomes: 21226
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Salmonella member used as a genetically tractable gut-associated strain.
   functional_role:

--- a/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
+++ b/kb/communities/Methylomicrobium_Chlorella_Methane_Sequestration_Coculture.yaml
@@ -64,7 +64,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       The source publication uses Methylomicrobium alcaliphilum 20Z; NCBI

--- a/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
+++ b/kb/communities/Methylotuvimicrobium_Synechococcus_Gas_Feedstock_Coculture.yaml
@@ -55,7 +55,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1091494
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Source publications use Methylomicrobium alcaliphilum 20z or 20ZR; NCBI Taxonomy
       records the strain under Methylotuvimicrobium alcaliphilum 20Z.

--- a/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
+++ b/kb/communities/ORNL_Clostridium_Desulfovibrio_Geobacter_Trophic_Model.yaml
@@ -93,7 +93,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:882
       majority_fraction: 1.0
       total_genomes: 7
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The source uses the historical Desulfovibrio vulgaris Hildenborough name; NCBI
       currently represents this taxon as Nitratidesulfovibrio vulgaris str. Hildenborough.

--- a/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
+++ b/kb/communities/SIHUMIx_Human_Intestinal_Model_Community.yaml
@@ -221,7 +221,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:511145
       majority_fraction: 1.0
       total_genomes: 37
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Facultative anaerobic Proteobacteria member of SIHUMIx.
   strain_designation:

--- a/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
+++ b/kb/communities/Shewanella_Streptococcus_Starch_Microbial_Fuel_Cell.yaml
@@ -59,7 +59,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
       total_genomes: 3
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Exoelectrogenic strain that generates electricity from lactic acid in the MFC.
   strain_designation:

--- a/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
+++ b/kb/communities/Synechococcus_Azotobacter_Photoproduction_Mutualism.yaml
@@ -56,7 +56,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1140
       majority_fraction: 1.0
       total_genomes: 3
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered PCC 7942 derivative expressing cscB for sucrose export.
   strain_designation:

--- a/kb/communities/Synechococcus_Ecoli_SPC.yaml
+++ b/kb/communities/Synechococcus_Ecoli_SPC.yaml
@@ -86,7 +86,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:83333
       majority_fraction: 1.0
       total_genomes: 50
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Heterotrophic partner that utilizes secreted sucrose from the cyanobacterium.
 

--- a/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
+++ b/kb/communities/Synechococcus_Halomonas_Light_Driven_PHB_Coculture.yaml
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1072583
       majority_fraction: 1.0
       total_genomes: 4
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: The publication and culture collections use Halomonas boliviensis LC1; NCBI Taxonomy currently
       represents the strain as Vreelandella boliviensis LC1.

--- a/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
+++ b/kb/communities/Synechococcus_Shewanella_Dlactate_Biophotovoltaic_Consortium.yaml
@@ -62,7 +62,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1350461
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered Syn2973-omcS-ldh cyanobacterial charging unit that produces D-lactate.
   strain_designation:
@@ -94,7 +94,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:211586
       majority_fraction: 1.0
       total_genomes: 3
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Engineered napA deletion discharging unit used for D-lactate oxidation and anode electron transfer.
   strain_designation:

--- a/kb/communities/Syntrophus_Benzoate_Degrader.yaml
+++ b/kb/communities/Syntrophus_Benzoate_Degrader.yaml
@@ -38,7 +38,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:56780
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: 'Anaerobic, syntrophic bacterium that degrades benzoate and other aromatic compounds to acetate,
       H2, and formate. Cannot grow on benzoate alone; requires syntrophic association with H2-utilizing

--- a/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
+++ b/kb/communities/Thalassiosira_Marinobacter_Marine_Snow_Coculture.yaml
@@ -84,7 +84,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:225937
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Diatom-attaching marine gammaproteobacterium originally isolated from

--- a/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
+++ b/kb/communities/Thermacetogenium_Methanothermobacter_Acetate_Oxidation_Coculture.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1089553
       majority_fraction: 1.0
       total_genomes: 5
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Type strain PB/DSM 12270; acetate-oxidizing syntrophic bacterium in the defined coculture.
   strain_designation:

--- a/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
+++ b/kb/communities/Thermotoga_Methanocaldococcus_Hyperthermophilic_Syntrophy.yaml
@@ -61,7 +61,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243274
       majority_fraction: 1.0
       total_genomes: 8
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Hyperthermophilic anaerobic heterotroph and hydrogen-producing fermentative member.
   strain_designation:
@@ -101,7 +101,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:243232
       majority_fraction: 1.0
       total_genomes: 2
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: >
       Source publications use the historical name Methanococcus jannaschii.

--- a/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
+++ b/kb/communities/Trichodesmium_Alteromonas_Marine_Consortium.yaml
@@ -31,7 +31,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:203124
       majority_fraction: 1.0
       total_genomes: 1
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Nitrogen-fixing cyanobacterial colony former and photoautotrophic host of the consortium.
   functional_role:

--- a/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+++ b/kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
@@ -93,7 +93,7 @@ taxonomy:
       ncbi_source_id: NCBITaxon:1585
       majority_fraction: 1.0
       total_genomes: 220
-      is_reclassified: true
+      is_reclassified: false
       mapping_source: kg-microbe NCBI2GTDB.tsv.gz; GTDB release latest (built 2026-07-25)
     notes: Literature often uses Lactobacillus bulgaricus; NCBI taxon captures the accepted subspecies.
       The record is species/subspecies-level because publications use different L. bulgaricus strains.

--- a/scripts/gtdb_ground.py
+++ b/scripts/gtdb_ground.py
@@ -238,6 +238,42 @@ def _clean_label(label: str | None) -> str:
     return s
 
 
+def name_differs(ncbi_label: str | None, gtdb_name: str | None, *, fallback: str = "") -> bool:
+    """Does the GTDB name say something the NCBI name did not? (#480, #482)
+
+    ONE definition, used by both the species and the higher-rank path. They used
+    to compute this separately and disagree: the species path had a crosswalk
+    fallback and a null-guard yielding False when either side was missing, while
+    the higher-rank path had neither and returned True for the same absence of
+    information (#482). 121 of the 154 true values came from the species path,
+    so the expression usually quoted for this slot governed the minority of the
+    data.
+
+    A **dropped strain designation is not a difference** (#480 option 1). GTDB
+    carries no strain designations, so `Escherichia coli K-12` maps to
+    `Escherichia coli`: the names differ and the organism has not moved. 40 of
+    the 154 true values were this, and no reading of "reclassified" covers it.
+
+    Polyphyly suffixes — `Bacillota` -> `Bacillota_A` — are deliberately still
+    reported. They are a real GTDB-specific distinction a consumer may want to
+    see, and #480 records that burying them in this boolean is the arguable
+    middle rather than the obvious next step. The slot stays a name-inequality
+    indicator; #480 option 3 (an enum) is where this wants to end up.
+    """
+    reference = _clean_label(ncbi_label) or (fallback or "").strip()
+    gtdb = (gtdb_name or "").strip()
+    if not gtdb or not reference:
+        # Missing information is not a difference. This is the species path's
+        # null-guard, now applied at both ranks.
+        return False
+    if reference == gtdb:
+        return False
+    # `Escherichia coli K-12` against `Escherichia coli`: the GTDB name is the
+    # NCBI name with a strain designation removed. Anchored on a word boundary
+    # so `Bacillota` does not swallow `Bacillota_A`, which is a different fact.
+    return not reference.startswith(gtdb + " ")
+
+
 def _is_species(clean: str) -> bool:
     """Binomial heuristic: >=2 tokens with a lowercase second token (species epithet)."""
     toks = clean.split()
@@ -446,7 +482,7 @@ def _ground_species(rows, source_id, label, via, exclude_unnamed=True):
         "gtdb_lineage": _lineage(top, COL_GTDB_SPECIES),
         "majority_fraction": fraction,
         "total_genomes": total,
-        "is_reclassified": bool(sp and ref and sp != ref),
+        "is_reclassified": name_differs(label, sp, fallback=top[COL_NCBI_SPECIES]),
         "via": via,
     }
 
@@ -633,7 +669,7 @@ def resolve_higher(
                 # from it — 4/7 and 4000/7000 both store as 0.571.
                 "support_genomes": int(tw),
                 "total_genomes": int(total),
-                "is_reclassified": top != _clean_label(label),
+                "is_reclassified": name_differs(label, top),
                 "via": f"ncbi_rank_{prefix}",
                 "n_alt": len(weights),
                 # The majority answer is a non-type clade, so it disagrees with

--- a/src/communitymech/schema/communitymech.yaml
+++ b/src/communitymech/schema/communitymech.yaml
@@ -973,14 +973,16 @@ classes:
           the name is a poor guide to what it holds.
 
           It said "species name ... (a GTDB reclassification/rename)". Neither
-          half held. Of the 154 blocks currently true, 33 are grounded above
+          half held. Of the 115 blocks currently true, 33 are grounded above
           species — through genus, family, order, class and phylum — so the rank
-          was wrong for a fifth of them. And it does not mean GTDB reclassified
-          anything. Partitioning the 154 by why the names differ (#441):
+          is wrong for nearly a third of them. And it does not mean GTDB
+          reclassified anything. Partitioning the 115 by why the names differ
+          (#441):
 
-          * 40 dropped strain designations — `Escherichia coli K-12` ->
-            `Escherichia coli`. GTDB carries no strain suffixes, so the names
-            differ while the placement does not.
+          * 0 dropped strain designations. There were 40 — `Escherichia coli
+            K-12` -> `Escherichia coli` — and #480 removed them: GTDB carries no
+            strain suffixes, so the names differed while the placement did not.
+            `name_differs` now treats that as no difference.
           * 24 GTDB polyphyly suffixes — `Bacillota` -> `Bacillota_A`. A split
             marker on the same name, not a rename.
           * 11 that are both at once — `Buchnera aphidicola BCc` ->
@@ -990,7 +992,7 @@ classes:
           * 3 rank-appropriate nomenclatural endings on one stem —
             `Chlorobiota` -> `Chlorobiia`, `Nitrososphaerota` ->
             `Nitrososphaeria`.
-          * 71 genuinely different names, and only some of those are GTDB
+          * 72 genuinely different names, and only some of those are GTDB
             reclassifications. `Allobosea` -> `Bosea` is an *NCBI* rename: both
             databases place the organism in the same genus concept, and NCBI
             moved its label because the bacterial name was a later homonym of
@@ -998,19 +1000,27 @@ classes:
             `Nitrosotalea devaniterrae` -> `Nitrosotalea devanaterra`,
             `Methylocystis parvus` -> `Methylocystis parva`.
 
-          So 83 of 154 — 54% — are not reclassifications under any reading, and
-          that is a floor: the 71 "genuinely different" include an unknown
+          So 43 of 115 — 37% — are not reclassifications under any reading, and
+          that is a floor: the 72 "genuinely different" include an unknown
           number of NCBI renames and spelling variants. Filter on this slot to
           find "the two labels are not identical", which is what it computes.
-          Do not read it as provenance. #480 proposes narrowing it, which is a
-          data migration and a modelling decision rather than a doc fix.
+          Do not read it as provenance.
 
-          Two call sites compute it, not one: `gtdb_ground.py` uses
+          #480 narrowed it: dropping the 40 strain-designation cases took the
+          non-reclassification share from 54% to 37%, and the genuinely-different
+          share from 46% to 63%. Polyphyly suffixes are deliberately still
+          reported — `Bacillota` -> `Bacillota_A` is a real GTDB distinction, and
+          #480 records that folding it in here is the arguable middle rather than
+          the obvious next step. An enum (#480 option 3) is where this wants to
+          end up.
+
+          ONE call site computes it now, `name_differs` (#482). Two used to:
           `bool(sp and ref and sp != ref)` on the species path, which produced
-          121 of these 154, and `top != _clean_label(label)` on the
-          genus-and-higher path. They differ — the first has a crosswalk
-          fallback for `ref` and a null-guard that returns False where the
-          second returns True.
+          121 of the then-154, and `top != _clean_label(label)` on the
+          genus-and-higher path. They disagreed — the first had a crosswalk
+          fallback for `ref` and a null-guard returning False where the second
+          returned True, so a missing label read as a name change at genus rank
+          and not at species rank.
 
           Counts are pinned by `tests/test_is_reclassified_semantics.py`, which
           fails when they drift; a count in this text reaches no generated

--- a/tests/test_is_reclassified_semantics.py
+++ b/tests/test_is_reclassified_semantics.py
@@ -34,6 +34,7 @@ schema now says.
 from __future__ import annotations
 
 import glob
+import importlib.util
 import pathlib
 import re
 
@@ -41,6 +42,7 @@ import pytest
 import yaml
 
 REPO = pathlib.Path(__file__).parent.parent
+GROUND = REPO / "scripts/gtdb_ground.py"
 SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
 RECORD_GLOBS = ("kb/communities/*.yaml", "data/isolates/*.yaml", "kb/taxa/*.yaml")
 
@@ -57,15 +59,17 @@ _PLACEHOLDER = re.compile(r"\bsp\d{6,}$")
 # notice. Exact numbers mean curation updates them deliberately, and the
 # failure message says where else the same number is written.
 EXPECTED = {
-    "different_name": 71,
-    "strain_dropped": 40,
+    "different_name": 72,
+    # 0 since #480: a dropped strain designation is no longer a difference.
+    # The key stays, with its reason, so the bucket cannot silently repopulate.
+    "strain_dropped": 0,
     "polyphyly_only": 24,
     "strain_dropped_and_polyphyly": 11,
     "gtdb_placeholder_same_genus": 5,
     "nomenclatural_ending": 3,
 }
-NOT_A_RECLASSIFICATION = 83
-TOTAL_TRUE = 154
+NOT_A_RECLASSIFICATION = 43
+TOTAL_TRUE = 115
 ABOVE_SPECIES = 33
 
 
@@ -189,9 +193,14 @@ def test_the_majority_of_true_values_are_not_reclassifications():
         f"{not_reclassified} of {TOTAL_TRUE} are not reclassifications, "
         f"expected {NOT_A_RECLASSIFICATION}. {_DRIFT}"
     )
-    assert not_reclassified / TOTAL_TRUE > 0.5, (
-        "fewer than half are now non-reclassifications; the schema says 54% "
-        "and should be recomputed"
+    # No longer a majority, and that is the #480 improvement rather than a
+    # regression: removing the 40 strain-drop blocks took the
+    # non-reclassification share from 54% to 38%, and the genuinely-different
+    # share from 46% to 62%. Pinned as a band so the direction cannot quietly
+    # reverse.
+    assert 0.3 < not_reclassified / TOTAL_TRUE < 0.45, (
+        f"{not_reclassified / TOTAL_TRUE:.0%} of true values are not "
+        "reclassifications; #480 left this at 38% and the schema says so"
     )
 
 
@@ -279,3 +288,141 @@ def test_the_schema_and_this_file_quote_the_same_numbers():
 def test_the_classifier_itself(ncbi: str, gtdb: str, expected: str):
     """Every count above is only as good as this function."""
     assert classify(ncbi, gtdb) == expected
+
+
+def _blocks_with_stored_flag():
+    """(ncbi_label, gtdb_taxon, gtdb_id, stored_flag) for EVERY grounded block.
+
+    `_blocks` yields only the ones already flagged true, which is right for
+    counting buckets and wrong for checking that the tool would reproduce what
+    is stored — a block wrongly left `false` would be invisible to it.
+    """
+    for pattern in RECORD_GLOBS:
+        for path in sorted(glob.glob(str(REPO / pattern))):
+            stack = [yaml.safe_load(pathlib.Path(path).read_text()) or {}]
+            while stack:
+                node = stack.pop()
+                if isinstance(node, dict):
+                    grounding = node.get("gtdb_classification")
+                    if isinstance(grounding, dict) and "is_reclassified" in grounding:
+                        yield (
+                            (node.get("term") or {}).get("label") or "",
+                            grounding.get("gtdb_taxon") or "",
+                            grounding.get("gtdb_id") or "",
+                            grounding["is_reclassified"],
+                        )
+                    stack.extend(node.values())
+                elif isinstance(node, list):
+                    stack.extend(node)
+
+
+# --------------------------------------------------------------------------
+# One definition, and a dropped strain is not one (#480, #482)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ground():
+    spec = importlib.util.spec_from_file_location("gtdb_ground_semantics", GROUND)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("label", "gtdb"),
+    [
+        ("Escherichia coli K-12", "Escherichia coli"),
+        ("Mucispirillum schaedleri ASF457", "Mucispirillum schaedleri"),
+        ("Bacteroides thetaiotaomicron VPI-5482", "Bacteroides thetaiotaomicron"),
+    ],
+)
+def test_a_dropped_strain_designation_is_not_a_difference(ground, label, gtdb):
+    """#480. GTDB carries no strain designations, so the organism has not moved."""
+    assert ground.name_differs(label, gtdb) is False
+
+
+@pytest.mark.parametrize(
+    ("label", "gtdb"),
+    [
+        ("Agrobacterium deltae", "Agrobacterium leguminum"),
+        ("Bacillota", "Bacillota_A"),
+        ("Veillonella parvula", "Veillonella parvula_A"),
+    ],
+)
+def test_a_real_name_difference_is_still_reported(ground, label, gtdb):
+    assert ground.name_differs(label, gtdb) is True
+
+
+def test_the_polyphyly_suffix_is_not_swallowed_by_the_strain_rule(ground):
+    """Polyphyly survives the strain rule, though NOT for the reason I first wrote.
+
+    I claimed the trailing space in `gtdb + " "` was what protected it. It is
+    not, and a mutation removing the space passed every test. The real reason is
+    direction: for a dropped strain the NCBI label is the LONGER string
+    (`Escherichia coli K-12` starts with `Escherichia coli`), while for polyphyly
+    the GTDB name is longer (`Bacillota_A` against `Bacillota`), so no prefix
+    test on the label can match it either way.
+
+    The space still earns its place — it stops a GTDB name that is a bare prefix
+    of the label, such as `Bacillus` against a label `Bacillusfoo`, from reading
+    as a strain drop — but that is a different guarantee, and no data exercises
+    it. Recorded so the next person does not trust the wrong mechanism.
+    """
+    assert ground.name_differs("Bacillota", "Bacillota_A") is True
+    assert ground.name_differs("Veillonella parvula", "Veillonella parvula_A") is True
+    assert ground.name_differs("Escherichia coli K-12", "Escherichia coli") is False
+    # The guarantee the space actually provides, on synthetic input.
+    assert ground.name_differs("Bacillusfoo", "Bacillus") is True
+
+
+@pytest.mark.parametrize(
+    ("label", "gtdb"),
+    [(None, "Escherichia coli"), ("Escherichia coli", None), ("", "Escherichia coli")],
+)
+def test_missing_information_is_not_a_difference(ground, label, gtdb):
+    """#482's disagreement: the higher-rank path returned True here.
+
+    `top != ""` is true for any non-empty name, so an unparseable label read as
+    a name change at genus rank and not at species rank — for the same absence
+    of information.
+    """
+    assert ground.name_differs(label, gtdb) is False
+
+
+def test_both_call_sites_use_the_shared_function():
+    """#482. Two expressions was the defect; one function is the fix.
+
+    Asserted on the source, because a second copy drifts silently — the two
+    disagreed for as long as they both existed and nothing noticed.
+    """
+    source = GROUND.read_text(encoding="utf-8")
+    assignments = [line.strip() for line in source.splitlines() if '"is_reclassified":' in line]
+    assert len(assignments) >= 2, f"expected both call sites, found {assignments}"
+    for line in assignments:
+        assert (
+            "name_differs(" in line or 'g["is_reclassified"]' in line
+        ), f"an is_reclassified assignment computes its own answer: {line!r}"
+
+
+def test_the_corpus_agrees_with_the_tool():
+    """Stored data and tool must agree, or the next --apply reverts the migration.
+
+    #480 names this as the constraint on the migration. Recomputing every stored
+    block from its own label and gtdb_taxon must reproduce what is on disk.
+    """
+    spec = importlib.util.spec_from_file_location("gtdb_ground_corpus", GROUND)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    disagreements = []
+    for label, gtdb, _gtdb_id, stored in _blocks_with_stored_flag():
+        expected = module.name_differs(label, gtdb)
+        if bool(stored) != expected:
+            disagreements.append(f"{label!r} -> {gtdb!r}: stored={stored} computed={expected}")
+
+    assert disagreements == [], (
+        "stored is_reclassified values disagree with the current rule, so the "
+        "next `gtdb_ground.py --apply` would rewrite them (#480):\n"
+        + "\n".join(f"  {line}" for line in disagreements[:20])
+    )


### PR DESCRIPTION
Closes #480 (option 1) and #482. Last two of the named list (#479 ✓, #489 ✓).

## #482 — two call sites, two expressions

The species path computed `bool(sp and ref and sp != ref)` with a crosswalk fallback and a null-guard; the genus-and-higher path computed `top != _clean_label(label)` with neither. A block with a missing label got `False` at species rank and `True` at genus rank — for the same absence of information. 121 of the then-154 true values came from the species path, so the expression usually quoted for this slot governed the minority of the data.

Both now call one function, `name_differs`.

## #480 option 1 — 40 of 154 were not reclassifications

A **dropped strain designation**: GTDB carries none, so `Escherichia coli K-12` maps to `Escherichia coli` — the names differ and the organism has not moved. #480 calls this "unambiguously correct ... whatever else happens".

| | before | after |
|---|---|---|
| true values | 154 | **115** |
| not reclassifications | 83 (54%) | **43 (37%)** |
| genuinely different | 71 (46%) | **72 (63%)** |

**Polyphyly suffixes stay true on purpose.** `Bacillota` → `Bacillota_A` is a real GTDB distinction, and #480 records that folding it into this boolean is the arguable middle rather than the obvious next step. Option 3 (an enum) is where this wants to end up.

## The migration constraint, met

#480 warns the tool and the data must change together or the next `--apply` reverts it. Verified: `gtdb_ground.py --community ... --emit-yaml` on a flipped record now produces exactly what is stored. `test_the_corpus_agrees_with_the_tool` pins it.

Only `is_reclassified` lines changed — 41 insertions, 41 deletions, **zero** other lines.

## Three things the checks caught that reading did not

1. **My migration walked only `kb/`**, missing `data/isolates/`. The corpus-agreement test then found `Methylorubrum extorquens` → `Methylobacterium extorquens` stored `false` while the rule says `true` — a genuine pre-existing wrong value in a tree my script never visited.

2. **The schema and test file quote exact counts deliberately**, so a data change forces a deliberate update — the test file's comment even anticipates "a simulated #480 migration". Both updated.

3. **I claimed the trailing space in `gtdb + " "` protects polyphyly from the strain rule. It does not** — a mutation removing it passed all 38 tests. The real reason is direction: for a strain drop the NCBI label is the longer string; for polyphyly the GTDB name is, so no prefix test can match either way. The space guards a different case that no data exercises. The test now says which is which and pins the real guarantee on synthetic input.

## Mutation checks

| reverted | result |
|---|---|
| the strain-designation exemption | **5 failed** |
| the null-guard | **3 failed** |
| the space (after the test was corrected) | **1 failed** |
| nothing | 38 passed |

## Gates

`lint` 0, `validate-all` 0, `validate-strict` 0, `check-docs-current` 0, **2558 passed**.
