### PR TITLE
CANARY (do not merge): taxa-only change

### DIFF
--- a/kb/taxa/Geobacter_sulfurreducens.yaml
+++ b/kb/taxa/Geobacter_sulfurreducens.yaml
@@ -55,3 +55,4 @@ notes: >
   role in DIET cocultures, Fe(III)-reduction, and bioanode communities. Gene/role
   claims are literature-standard; per-interaction EvidenceItems can be added
   following the community-record evidence protocol.
+# canary: does a taxa-only change trigger any CI check? (#471)


### PR DESCRIPTION
Throwaway. Opened only to observe which CI checks a change touching **only `kb/taxa/`** triggers. Will be closed unmerged.