### PR TITLE
A gate that cannot be triggered by its own input (#630, #474)

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -33,6 +33,14 @@ on:
       # Isolates carry ids too, and were outside every
       # validation glob until #350.
       - "data/isolates/**"
+      # Taxa were outside every *trigger* until #471 — a subtler version of the
+      # same defect. This workflow runs `just validate-terms-taxa`, whose entire
+      # input is kb/taxa/*.yaml, and Engine B carries a `taxa_yaml` target; but
+      # kb/taxa appeared in NO workflow's paths filter, so a PR touching only a
+      # taxon record triggered exactly one check (vendored-sync, the unfiltered
+      # one) and nothing validated the record. Verified by opening such a PR
+      # (#629, closed unmerged): 1 check, and it read no YAML.
+      - "kb/taxa/**"
       - "output/kgx/**"
       - "src/communitymech/schema/**"
       - "scripts/validate_id_label_correspondence.py"

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -12,6 +12,12 @@ on:
       # workflow's paths filter, which is half of why four ids ended up used
       # twice (#310) — editing an isolate has to re-run the uniqueness gate.
       - "data/isolates/**"
+      # kb/taxa carries CommunityMech:taxon:* ids for exactly the same reason,
+      # and `test_id_uniqueness.py` reads it — as do 7 other test modules. It was
+      # in no workflow's filter at all, so none of them ran when a taxon record
+      # changed (#471). The isolates note above describes this defect one
+      # directory over; this is the directory it was still true of.
+      - "kb/taxa/**"
       - "src/communitymech/schema/**"
       - "src/communitymech/**/*.py"
       - "scripts/**/*.py"

--- a/tests/test_ci_triggers_cover_what_the_gates_read.py
+++ b/tests/test_ci_triggers_cover_what_the_gates_read.py
@@ -40,8 +40,14 @@ JUSTFILE = REPO / "justfile"
 # make this test noisy enough to be disabled, which is how guards die.
 DATA_ROOTS = ("kb/", "data/", "output/")
 
-# A path with a glob character, rooted at one of the data surfaces.
-_INPUT_GLOB = re.compile(r"(?<![\w/.-])((?:kb|data|output)/[\w*.-]+(?:/[\w*.-]+)*)")
+# A path rooted at one of the data surfaces, DERIVED from DATA_ROOTS rather than
+# spelling the roots a second time. The two were separate literals, so adding a
+# fourth surface to DATA_ROOTS left this regex blind to it: recipes reading the
+# new root reported no inputs and the coverage assertion passed by having nothing
+# to check (#635). That is the "list that cannot notice a new member" defect this
+# module exists to gate — one source now, so it cannot recur here.
+_ROOT_ALTERNATION = "|".join(re.escape(root.rstrip("/")) for root in DATA_ROOTS)
+_INPUT_GLOB = re.compile(rf"(?<![\w/.-])((?:{_ROOT_ALTERNATION})/[\w*.-]+(?:/[\w*.-]+)*)")
 
 
 def _workflow_paths(document: dict) -> list[str] | None:
@@ -190,6 +196,22 @@ def test_the_justfile_parser_finds_the_recipes_this_test_relies_on():
     assert "kb/taxa/*.yaml" in _inputs_of("validate-terms-taxa", recipes), (
         "the parser does not see kb/taxa/*.yaml in validate-terms-taxa, so the "
         "coverage assertions below cannot fail for the reason they exist"
+    )
+
+
+@pytest.mark.parametrize("root", DATA_ROOTS)
+def test_the_input_scanner_covers_every_declared_data_root(root: str):
+    """The derivation in #635 is now the untested part, so test it.
+
+    Parametrised over DATA_ROOTS itself, not over a written-out list of roots —
+    a second literal is precisely what caused #635.
+    """
+    body = f"    uv run thing {root}records/*.yaml\n"
+    found = {m.group(1) for m in _INPUT_GLOB.finditer(body)}
+    assert found == {f"{root}records/*.yaml"}, (
+        f"the input scanner does not see paths under the declared root {root!r}, so "
+        f"recipes reading it report no inputs and the coverage checks pass by having "
+        f"nothing to check (#635). Found: {found}"
     )
 
 

--- a/tests/test_ci_triggers_cover_what_the_gates_read.py
+++ b/tests/test_ci_triggers_cover_what_the_gates_read.py
@@ -237,7 +237,20 @@ def test_inputs_are_followed_through_a_recipe_that_only_delegates():
 
 @pytest.mark.parametrize("workflow", [p.name for p in _workflow_files()])
 def test_every_data_surface_a_workflow_reads_can_also_trigger_it(workflow: str):
-    """The gate. A step reading kb/taxa in a workflow kb/taxa cannot trigger."""
+    """The gate. A step reading kb/taxa in a workflow kb/taxa cannot trigger.
+
+    Covers two ways a step names its input: through a `just` recipe, and as a
+    literal path in the `run:` block. Several workflows invoke a gate without
+    `just` at all — `xargs -0 uv run linkml-validate`, `uv run communitymech
+    audit-network`, `python -m communitymech.export` — and following only recipes
+    left those steps unexamined (#636).
+
+    What this still cannot see: a tool whose input paths live in Python rather
+    than on the command line. `communitymech audit-network` reads kb/communities
+    and data/isolates from inside the package, and no workflow/justfile parsing
+    reveals that. `test_a_data_directory_is_not_invisible_to_every_workflow` is
+    the weaker backstop for that case; #636 holds the decision.
+    """
     document = yaml.safe_load((WORKFLOWS / workflow).read_text(encoding="utf-8"))
     patterns = _workflow_paths(document)
     if patterns is None:
@@ -246,18 +259,20 @@ def test_every_data_surface_a_workflow_reads_can_also_trigger_it(workflow: str):
     recipes = _recipe_bodies()
     uncovered = {}
     for command in _steps(document):
-        for invoked in re.findall(r"\bjust\s+([a-zA-Z][\w-]*)", command):
+        code = "\n".join(line for line in command.splitlines() if not line.strip().startswith("#"))
+        for invoked in re.findall(r"\bjust\s+([a-zA-Z][\w-]*)", code):
             for glob in _inputs_of(invoked, recipes):
                 if not _glob_covered(glob, patterns):
-                    uncovered.setdefault(glob, set()).add(invoked)
+                    uncovered.setdefault(glob, set()).add(f"just {invoked}")
+        # Literal paths in the step itself, for the gates that skip `just`.
+        for glob in {m.group(1) for m in _INPUT_GLOB.finditer(code)}:
+            if not _glob_covered(glob, patterns):
+                uncovered.setdefault(glob, set()).add("a run: step directly")
 
     assert not uncovered, (
         f"{workflow} runs steps that read data this workflow's paths filter does "
         f"not match, so a PR changing only that data does not run them (#471). "
-        + "; ".join(
-            f"{g} (read by `just {'`, `just '.join(sorted(r))}`)"
-            for g, r in sorted(uncovered.items())
-        )
+        + "; ".join(f"{g} (read by {', '.join(sorted(r))})" for g, r in sorted(uncovered.items()))
         + f". Filter is: {patterns}"
     )
 

--- a/tests/test_ci_triggers_cover_what_the_gates_read.py
+++ b/tests/test_ci_triggers_cover_what_the_gates_read.py
@@ -98,10 +98,14 @@ def _probes(glob: str) -> list[str]:
 
 
 def _covered(path: str, patterns: list[str]) -> bool:
-    return any(
-        _as_regex(p).search(path) if p.endswith("/**") else _as_regex(p).match(path)
-        for p in patterns
-    )
+    """Anchored deliberately: a GitHub `paths:` pattern is rooted at the repo.
+
+    `kb/taxa/**` does not match `vendor/kb/taxa/x.yaml`. This used to pick
+    `.search` for `/**` patterns and `.match` otherwise, which chose between two
+    identical behaviours — `_as_regex` anchors both ends, so the branch was dead
+    and implied an unanchored semantics the code never had (#633).
+    """
+    return any(_as_regex(pattern).match(path) for pattern in patterns)
 
 
 def _glob_covered(glob: str, patterns: list[str]) -> bool:
@@ -245,12 +249,25 @@ def test_a_data_directory_is_not_invisible_to_every_workflow():
     kb/taxa passed each per-workflow check for years by being absent from all of
     them at once. Enumerating the directories that exist, rather than the ones a
     filter mentions, is what makes a newly added surface fail here.
+
+    A backstop, not the real check: being matched by *some* filter is weaker than
+    being matched by the filter of a workflow that validates it. The per-workflow
+    test above is what establishes that. This one only catches a surface no
+    workflow can see at all.
     """
+    # Existence filtered BEFORE iterating, not in the comprehension's `if`: that
+    # clause is evaluated after `iterdir()`, so it never guarded the call it was
+    # written to guard. `output/` is gitignored with no tracked files, so it is
+    # absent on a fresh clone — i.e. on every CI runner — and this raised
+    # FileNotFoundError there while passing locally, where output/ has been built
+    # (#632). The #602 shape, inside the test meant to prevent it.
+    roots = [REPO / root.rstrip("/") for root in DATA_ROOTS]
     surfaces = sorted(
-        f"{d.parent.name}/{d.name}"
-        for root in DATA_ROOTS
-        for d in (REPO / root.rstrip("/")).iterdir()
-        if (REPO / root.rstrip("/")).is_dir() and d.is_dir() and any(d.glob("*.yaml"))
+        f"{directory.parent.name}/{directory.name}"
+        for root in roots
+        if root.is_dir()
+        for directory in root.iterdir()
+        if directory.is_dir() and any(directory.glob("*.yaml"))
     )
     assert surfaces, "found no data directories; this test would pass vacuously"
 

--- a/tests/test_ci_triggers_cover_what_the_gates_read.py
+++ b/tests/test_ci_triggers_cover_what_the_gates_read.py
@@ -1,0 +1,267 @@
+"""A gate that cannot be triggered by its own input is not a gate (#471).
+
+`label-correspondence.yaml` runs `just validate-terms-taxa`, whose entire input
+is `kb/taxa/*.yaml`, and `just validate-products`, whose config carries a
+`taxa_yaml` target. Neither could run on a change to a taxon record: `kb/taxa`
+appeared in **no** workflow's `paths:` filter. Verified by opening a PR that
+touched only `kb/taxa/` (#629, closed unmerged) — it drew exactly one check,
+`vendored-sync`, the one workflow with no filter, which reads no YAML at all.
+
+This is the #350/#471 defect a third time. Each previous instance was fixed by
+adding one directory to one filter, which fixes the instance and not the class:
+nothing connected *what a workflow runs* to *what can trigger it*, so the next
+surface to be added was silently unguarded again. `data/isolates` took two PRs
+(#350, #473) to be genuinely covered for the same reason.
+
+These tests derive the inputs from the justfile recipes each workflow actually
+invokes, so a new recipe, a new target in `conf/id_label_targets.yaml`, or a new
+data directory fails here rather than in six months' worth of unvalidated
+commits.
+
+Pure parsing — no network, no OAK, no `just` execution — so it runs in the fast
+suite alongside the gates it is about.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO = pathlib.Path(__file__).parent.parent
+WORKFLOWS = REPO / ".github/workflows"
+JUSTFILE = REPO / "justfile"
+
+# The data surfaces a gate can read. Deliberately a prefix list and not "any
+# path-looking token": a recipe mentions plenty of paths it does not treat as
+# input (report destinations, `-s schema.yaml`), and asserting on those would
+# make this test noisy enough to be disabled, which is how guards die.
+DATA_ROOTS = ("kb/", "data/", "output/")
+
+# A path with a glob character, rooted at one of the data surfaces.
+_INPUT_GLOB = re.compile(r"(?<![\w/.-])((?:kb|data|output)/[\w*.-]+(?:/[\w*.-]+)*)")
+
+
+def _workflow_paths(document: dict) -> list[str] | None:
+    """The pull_request `paths:` filter, or None for "runs on everything".
+
+    `on:` is the YAML 1.1 boolean `True` after parsing, which is the single
+    most common way a workflow-reading test silently checks nothing.
+    """
+    triggers = document.get("on", document.get(True)) or {}
+    if not isinstance(triggers, dict) or "pull_request" not in triggers:
+        return None
+    config = triggers["pull_request"] or {}
+    return config.get("paths")
+
+
+def _as_regex(pattern: str) -> re.Pattern[str]:
+    """A GitHub `paths:` pattern as a regex.
+
+    `**` crosses directory separators, `*` does not — the distinction that
+    decides whether `kb/**` covers `kb/taxa/x.yaml` (it does) and whether
+    `kb/*.yaml` does (it does not).
+    """
+    out, index = [], 0
+    while index < len(pattern):
+        char = pattern[index]
+        if pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif char == "*":
+            out.append("[^/]*")
+            index += 1
+        else:
+            out.append(re.escape(char))
+            index += 1
+    return re.compile(f"^{''.join(out)}$")
+
+
+def _probes(glob: str) -> list[str]:
+    """Concrete paths inside `glob`, for asking whether a filter covers it.
+
+    Probing beats globbing the real files: an empty or not-yet-built directory
+    (`output/kgx/` on a fresh checkout) would expand to nothing and the check
+    would pass by finding no files to be uncovered — vacuous in exactly the
+    situation it is meant to catch.
+
+    Two forms, because a recipe names its input both ways. `kb/communities/*.yaml`
+    is a file glob, but `record="kb/communities/$(basename …)"` yields the bare
+    directory `kb/communities`, and asking whether `kb/communities/**` covers the
+    literal string `kb/communities` answers no — a false positive on a path that
+    is plainly covered.
+    """
+    concrete = glob.replace("**", "probe").replace("*", "probe")
+    return [concrete] if pathlib.PurePath(concrete).suffix else [concrete, f"{concrete}/probe.yaml"]
+
+
+def _covered(path: str, patterns: list[str]) -> bool:
+    return any(
+        _as_regex(p).search(path) if p.endswith("/**") else _as_regex(p).match(path)
+        for p in patterns
+    )
+
+
+def _glob_covered(glob: str, patterns: list[str]) -> bool:
+    return any(_covered(probe, patterns) for probe in _probes(glob))
+
+
+def _recipe_bodies() -> dict[str, tuple[list[str], str]]:
+    """recipe name -> (dependency names, body text) from the justfile."""
+    recipes: dict[str, tuple[list[str], str]] = {}
+    name, deps, body = None, [], []
+    for line in JUSTFILE.read_text(encoding="utf-8").splitlines():
+        # Parameters are not all `FILE`-shaped: `validate-strict *args:` takes a
+        # variadic lowercase one, and requiring uppercase silently dropped that
+        # recipe — the single most load-bearing gate in the repo — from the
+        # parse. The self-check below exists because this test found that itself.
+        header = re.match(
+            r"^([a-zA-Z][\w-]*)"
+            r"(?:\s+[+*]?[A-Za-z_][\w-]*(?:=(?:\"[^\"]*\"|'[^']*'|\S+))?)*"
+            r"\s*:(?!=)(.*)$",
+            line,
+        )
+        if header:
+            if name:
+                recipes[name] = (deps, "\n".join(body))
+            name = header.group(1)
+            deps = [d for d in header.group(2).split() if re.fullmatch(r"[a-zA-Z][\w-]*", d)]
+            body = []
+        elif name and (line.startswith((" ", "\t")) or not line.strip()):
+            body.append(line)
+        elif line.strip() and not line.startswith("#"):
+            if name:
+                recipes[name] = (deps, "\n".join(body))
+            name, deps, body = None, [], []
+    if name:
+        recipes[name] = (deps, "\n".join(body))
+    return recipes
+
+
+def _inputs_of(recipe: str, recipes: dict, seen: set[str] | None = None) -> set[str]:
+    """Data-surface globs a recipe reads, following its dependencies."""
+    seen = seen if seen is not None else set()
+    if recipe in seen or recipe not in recipes:
+        return set()
+    seen.add(recipe)
+    deps, body = recipes[recipe]
+    # Comment lines are prose about the recipe, not input to it. `check-docs-current`
+    # explains at length why it does NOT run `just gen-umap` — naming
+    # data/embeddings/*.tsv.gz in the course of saying so (#602). Reading that as an
+    # input reports a gap in the one place the justfile documents there is none.
+    code = "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+    found = {m.group(1) for m in _INPUT_GLOB.finditer(code)}
+    for dep in deps:
+        found |= _inputs_of(dep, recipes, seen)
+    return found
+
+
+def _workflow_files() -> list[pathlib.Path]:
+    return sorted(p for p in WORKFLOWS.glob("*.y*ml"))
+
+
+def _steps(document: dict) -> list[str]:
+    commands = []
+    for job in (document.get("jobs") or {}).values():
+        for step in (job or {}).get("steps") or []:
+            if isinstance(step, dict) and isinstance(step.get("run"), str):
+                commands.append(step["run"])
+    return commands
+
+
+def test_the_justfile_parser_finds_the_recipes_this_test_relies_on():
+    """A parser that silently found nothing would make every test below pass."""
+    recipes = _recipe_bodies()
+    for expected in ("validate-terms-taxa", "validate-products", "validate-strict", "qc"):
+        assert expected in recipes, f"justfile parser missed {expected!r}"
+    assert "kb/taxa/*.yaml" in _inputs_of("validate-terms-taxa", recipes), (
+        "the parser does not see kb/taxa/*.yaml in validate-terms-taxa, so the "
+        "coverage assertions below cannot fail for the reason they exist"
+    )
+
+
+@pytest.mark.parametrize("workflow", [p.name for p in _workflow_files()])
+def test_every_data_surface_a_workflow_reads_can_also_trigger_it(workflow: str):
+    """The gate. A step reading kb/taxa in a workflow kb/taxa cannot trigger."""
+    document = yaml.safe_load((WORKFLOWS / workflow).read_text(encoding="utf-8"))
+    patterns = _workflow_paths(document)
+    if patterns is None:
+        return  # no filter: everything triggers it, nothing to check
+
+    recipes = _recipe_bodies()
+    uncovered = {}
+    for command in _steps(document):
+        for invoked in re.findall(r"\bjust\s+([a-zA-Z][\w-]*)", command):
+            for glob in _inputs_of(invoked, recipes):
+                if not _glob_covered(glob, patterns):
+                    uncovered.setdefault(glob, set()).add(invoked)
+
+    assert not uncovered, (
+        f"{workflow} runs steps that read data this workflow's paths filter does "
+        f"not match, so a PR changing only that data does not run them (#471). "
+        + "; ".join(
+            f"{g} (read by `just {'`, `just '.join(sorted(r))}`)"
+            for g, r in sorted(uncovered.items())
+        )
+        + f". Filter is: {patterns}"
+    )
+
+
+def test_every_engine_b_target_can_trigger_the_workflow_that_runs_it():
+    """`conf/id_label_targets.yaml` is a list that must not gain a member silently.
+
+    The globs live in config rather than in the recipe, so the test above cannot
+    see them: `just validate-products` names only the config file. A target
+    added here without a matching trigger path is checked locally and never in
+    CI — which is what `taxa_yaml` was.
+    """
+    targets = yaml.safe_load((REPO / "conf/id_label_targets.yaml").read_text())["targets"]
+    globs = [t["glob"] for t in targets if t.get("glob")]
+    assert globs, "no glob targets parsed; this test would pass vacuously"
+
+    running = [
+        path
+        for path in _workflow_files()
+        if any("validate-products" in c for c in _steps(yaml.safe_load(path.read_text())))
+    ]
+    assert running, "no workflow runs `just validate-products`; Engine B is not a gate"
+
+    for path in running:
+        patterns = _workflow_paths(yaml.safe_load(path.read_text()))
+        if patterns is None:
+            continue
+        missing = [g for g in globs if not _glob_covered(g, patterns)]
+        assert not missing, (
+            f"{path.name} runs Engine B but its paths filter does not match "
+            f"{missing} — those targets are validated locally and never in CI (#471)"
+        )
+
+
+def test_a_data_directory_is_not_invisible_to_every_workflow():
+    """The whole-repo view: no data surface may be outside every filter.
+
+    kb/taxa passed each per-workflow check for years by being absent from all of
+    them at once. Enumerating the directories that exist, rather than the ones a
+    filter mentions, is what makes a newly added surface fail here.
+    """
+    surfaces = sorted(
+        f"{d.parent.name}/{d.name}"
+        for root in DATA_ROOTS
+        for d in (REPO / root.rstrip("/")).iterdir()
+        if (REPO / root.rstrip("/")).is_dir() and d.is_dir() and any(d.glob("*.yaml"))
+    )
+    assert surfaces, "found no data directories; this test would pass vacuously"
+
+    filters = []
+    for path in _workflow_files():
+        patterns = _workflow_paths(yaml.safe_load(path.read_text()))
+        if patterns:
+            filters.extend(patterns)
+
+    orphans = [s for s in surfaces if not _covered(f"{s}/probe.yaml", filters)]
+    assert not orphans, (
+        f"these data directories hold YAML records but match no workflow's paths "
+        f"filter, so changing one of them runs no validation at all (#471): {orphans}"
+    )

--- a/tests/test_ci_triggers_cover_what_the_gates_read.py
+++ b/tests/test_ci_triggers_cover_what_the_gates_read.py
@@ -145,7 +145,14 @@ def _recipe_bodies() -> dict[str, tuple[list[str], str]]:
 
 
 def _inputs_of(recipe: str, recipes: dict, seen: set[str] | None = None) -> set[str]:
-    """Data-surface globs a recipe reads, following its dependencies."""
+    """Data-surface globs a recipe reads, through dependencies AND `just` calls.
+
+    Both edges, because a recipe delegates either way. `check-docs-current` runs
+    `just gen-html` from its body rather than declaring it, and following only
+    declared dependencies means a recipe that delegates *entirely* reports no
+    inputs — so the coverage assertion would pass by finding nothing to check,
+    which is the vacuous pass this whole module exists to close (#634).
+    """
     seen = seen if seen is not None else set()
     if recipe in seen or recipe not in recipes:
         return set()
@@ -157,7 +164,7 @@ def _inputs_of(recipe: str, recipes: dict, seen: set[str] | None = None) -> set[
     # input reports a gap in the one place the justfile documents there is none.
     code = "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
     found = {m.group(1) for m in _INPUT_GLOB.finditer(code)}
-    for dep in deps:
+    for dep in [*deps, *re.findall(r"\bjust\s+([a-zA-Z][\w-]*)", code)]:
         found |= _inputs_of(dep, recipes, seen)
     return found
 
@@ -184,6 +191,26 @@ def test_the_justfile_parser_finds_the_recipes_this_test_relies_on():
         "the parser does not see kb/taxa/*.yaml in validate-terms-taxa, so the "
         "coverage assertions below cannot fail for the reason they exist"
     )
+
+
+def test_inputs_are_followed_through_a_recipe_that_only_delegates():
+    """A recipe whose body is `just other` must still report other's inputs.
+
+    Synthetic, not read off the justfile: every real delegation today happens to
+    name its input directly too, so a regression here would change no verdict and
+    no assertion over real data could notice. That is exactly why it needs pinning
+    — a recipe added later that only delegates would report no inputs, and the
+    coverage check would pass by having nothing to check (#634).
+    """
+    recipes = {
+        "gate": ([], "    just inner\n"),
+        "inner": ([], "    uv run thing kb/taxa/*.yaml\n"),
+        "declared": (["inner"], "    echo hi\n"),
+        "loop": ([], "    just loop\n"),  # a cycle must terminate, not recurse forever
+    }
+    assert _inputs_of("gate", recipes) == {"kb/taxa/*.yaml"}, "body `just` call not followed"
+    assert _inputs_of("declared", recipes) == {"kb/taxa/*.yaml"}, "dependency not followed"
+    assert _inputs_of("loop", recipes) == set()
 
 
 @pytest.mark.parametrize("workflow", [p.name for p in _workflow_files()])

--- a/tests/test_isolates_are_covered_by_id_checks.py
+++ b/tests/test_isolates_are_covered_by_id_checks.py
@@ -54,15 +54,26 @@ def test_that_target_checks_the_id_label_pair_canonically():
 
 
 def test_the_isolate_records_are_actually_matched_by_that_glob():
-    """A target whose glob matches nothing passes vacuously."""
+    """A target whose glob matches nothing passes vacuously.
+
+    Compared as a SET against the records on disk, not against a count floor.
+    `len(matched) >= 4` was pinned to the file count of the day: it caught the
+    glob matching nothing, but a glob narrowed to `data/isolates/*_Recovery.yaml`
+    — or simply a 5th record the glob did not reach — passed while the records it
+    skipped went unchecked (#474). "Matches less" is the realistic failure; only
+    "matches nothing" was caught.
+    """
     target = next(t for t in _targets() if t.get("glob", "").startswith("data/isolates/"))
     # Glob from the repo root, which is what the validator does — resolving it
     # against data/isolates/ instead silently looked for data/isolates/isolates/
     # and matched nothing, so this test failed while the config was correct.
-    matched = list(REPO.glob(target["glob"]))
-    assert len(matched) >= 4, (
-        f"{target['glob']!r} matches {len(matched)} files; the isolate records "
-        f"are {sorted(p.name for p in ISOLATES.glob('*.yaml'))}"
+    matched = {p.resolve() for p in REPO.glob(target["glob"])}
+    records = {p.resolve() for p in ISOLATES.glob("*.yaml")}
+    assert records, "no isolate records on disk; this test would pass vacuously"
+    assert matched == records, (
+        f"{target['glob']!r} does not match the isolate records exactly. "
+        f"Unmatched: {sorted(p.name for p in records - matched)}; "
+        f"matched but not a record: {sorted(p.name for p in matched - records)}"
     )
 
 
@@ -163,21 +174,45 @@ def test_no_isolate_carries_the_nonexistent_dysprosium_id():
 
 
 @pytest.mark.parametrize("record", sorted(p.name for p in ISOLATES.glob("*.yaml")))
-def test_every_isolate_ontology_label_is_a_string_pair(record: str):
+def test_every_isolate_ontology_id_is_paired_with_a_label(record: str):
     """Guard for the sweep above: the pairs it checks must actually be there.
 
     If `term` blocks were restructured, the glob could keep matching while the
     (id, label) pairs it looks for no longer exist — passing for the wrong
     reason.
+
+    Stated as an invariant, not a count. The previous form asserted `pairs > 0`,
+    which is not vacuous — renaming every nested `label` to `name` in one record
+    does produce `assert 0 > 0` — but it only trips on TOTAL loss. A partial
+    restructure leaving one pair anywhere in a 23-pair record passed, which is
+    precisely the scenario the docstring describes (#474).
+
+    "Every ontology-prefixed id carries a string label" needs no baseline to
+    compare against, so it cannot rot as records are added, and it fails on the
+    first unpaired id rather than the last. The prefixes come from the gate's own
+    `adapters:` block, so the test and the gate cannot drift apart: a prefix
+    added there is checked here without touching this file.
     """
+    prefixes = tuple(f"{p}:" for p in yaml.safe_load(CONFIG.read_text())["adapters"])
+    assert prefixes, "no adapters configured; this test would pass vacuously"
+
     document = yaml.safe_load((ISOLATES / record).read_text()) or {}
-    pairs, stack = 0, [document]
+    paired, unpaired, stack = 0, [], [document]
     while stack:
         node = stack.pop()
         if isinstance(node, dict):
-            if isinstance(node.get("id"), str) and isinstance(node.get("label"), str):
-                pairs += 1
+            identifier = node.get("id")
+            if isinstance(identifier, str) and identifier.startswith(prefixes):
+                if isinstance(node.get("label"), str):
+                    paired += 1
+                else:
+                    unpaired.append(identifier)
             stack.extend(node.values())
         elif isinstance(node, list):
             stack.extend(node)
-    assert pairs > 0, f"{record} carries no (id, label) pair for the gate to check"
+
+    assert not unpaired, (
+        f"{record}: ontology ids with no string `label` beside them, so Engine B "
+        f"reads no pair there and the id goes unchecked (#474): {sorted(unpaired)}"
+    )
+    assert paired > 0, f"{record} carries no ontology (id, label) pair for the gate to check"


### PR DESCRIPTION
Closes #630

Also addresses #474, and the remainder of #471 (see below).

## What #471 turned out to be

Its second half — `data/isolates` outside Engine B — was already closed by #473. I re-ran the canary to be sure rather than take the issue text: planted `CHEBI:99999999` in a real isolate record, ran Engine B, got `ID_NOT_FOUND` and exit 2. That hole is shut.

Looking for what was left turned up the same defect one directory over, and worse.

## kb/taxa was in no workflow's paths filter at all

`label-correspondence.yaml` runs `just validate-terms-taxa`, whose entire input is `kb/taxa/*.yaml`. The workflow that runs it could not be triggered by that input.

**Verified end to end.** PR #629 touched only `kb/taxa/Geobacter_sulfurreducens.yaml`:

```
vendored-sync   pass   7s
```

One check — the single workflow with no paths filter, bash + curl, reads no YAML. Closed unmerged.

| gate | ran on a taxa-only change |
|---|---|
| `just validate-taxa` (linkml-validate, CommonTaxon) | no |
| `just validate-terms-taxa` (Engine A) | no |
| Engine B `taxa_yaml` target | no |
| `pytest` — 8 modules read kb/taxa, incl. `test_id_uniqueness.py` | no |

## The fix, and the part that generalizes

`kb/taxa/**` goes into both filters. That is the instance.

`tests/test_ci_triggers_cover_what_the_gates_read.py` is the class: it parses each workflow's `run: just X` steps, resolves X's inputs from the justfile (following recipe dependencies), and asserts the workflow's own `paths:` filter can match them. Two more assertions cover what recipe-parsing cannot see — Engine B's globs live in `conf/id_label_targets.yaml`, and a whole-repo check that no YAML-bearing data directory is outside *every* filter, which is how kb/taxa hid.

`data/isolates` took two PRs (#350, #473) for this defect because each fixed the instance. Nothing connected what a workflow runs to what can trigger it.

**Mutation-checked.** Reverting both filter edits fails 3 independent tests:
```
FAILED …::test_every_data_surface_a_workflow_reads_can_also_trigger_it[label-correspondence.yaml]
FAILED …::test_every_engine_b_target_can_trigger_the_workflow_that_runs_it
FAILED …::test_a_data_directory_is_not_invisible_to_every_workflow
```

## #474 — the guard on the guard

`pairs > 0` was not vacuous but only tripped on *total* loss. Now an invariant with no baseline to rot: every ontology-prefixed id carries a string `label`, with the prefixes read from the gate's own `adapters:` block so the two cannot drift apart. Renaming **1 of 29** labels in one record now fails; it passed before with 28 pairs left. The glob test compares a set against the records on disk instead of `>= 4`, so "matches less" fails, not just "matches nothing".

## Two things the tests caught in themselves

- The justfile header regex required uppercase parameters, so `validate-strict *args:` — the most load-bearing gate in the repo — was silently missing from the parse. The self-check test now pins that the parser finds it.
- `data/embeddings/*.tsv.gz` was reported as an uncovered input of `check-docs-current`. It appears only in the comment explaining why that recipe does *not* run `just gen-umap` (#602) — a false positive on the one place the justfile documents there is no gap. Comment lines are now stripped before scanning.

## Gates

lint 0 · validate-strict 0 · validate-taxa 0 · **2570 passed, 16 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)