### PR TITLE
Transgenic rice paddy record, and a candidate that had to be rejected (#183)

### DIFF
--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -929,6 +929,230 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    submerged Capay rice-paddy soil in greenhouse pots, fertigated
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">pH</span>
+                        <span class="metadata-value">6.59</span>
+                    </div>
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Soil crushed to 2 mm, homogenized and stored until planting, then 2000 g per pot, 18 pots per 23-gallon tub, five tubs per genotype. Tubs were flooded before transplanting and kept submerged with deionized water every other day -- paddy conditions, which is what makes this record about methane cycling. From day 15 the deionized water was replaced with fertigation at N 77, P 20, K 75, Ca 27, Mg 17, S 68, Fe 1.5, Cu 0.02, Mn 0.5, Mo 0.01, Zn 0.1 and B 0.5 ppm; the source gives that composition inside square brackets, which validate-references strips (#622), so it is prose here rather than a quote. ph 6.59 is the mean soil pH reported for the field site, not a controlled setpoint. NO GREENHOUSE TEMPERATURE OR PHOTOPERIOD IS REPORTED for the pot phase; the 28/24 C, 14 h:10 h figures belong to the germination incubators and are recorded on the other medium, not here.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Soil from a rice field in Davis (38.543224 degrees North and -121.810536 West) was collected in July 2022 and in July and December 2023 using a front-end loader to gather down to a depth of ~6–10 inches."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The soil at the field site belongs to the Capay soil series, a fine, smectitic, thermic Typic Haploxerert."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Soil pH was 6.59 on average."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"For both experiments, all soils were transported back to the greenhouse, crushed to a 2 mm particle size, thoroughly homogenized, and stored until planting. Then, the soil was transferred into new 5.5 × 5.5 inch pots (2000 g per pot), which were then placed into five 23 gallon tubs per genotype (18 pots each)."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Prior to seedling transplantation, enough water was added to the tubs to submerge the soils."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Axenic seedlings were then transplanted into the watered pots (one seedling per pot) in the greenhouse, where they were irrigated with deionized water every other day to keep the soil submerged."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Each tub contained only one plant genotype to avoid root exudate compositional changes. We also kept a separate tub with unplanted pots and bulk soil controls."</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    1x Murashige and Skoog salts with 1% sucrose, pH 5.65 (germination only)
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">pH</span>
+                        <span class="metadata-value">5.65</span>
+                    </div>
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Temperature</span>
+                        <span class="metadata-value">28 °C</span>
+                    </div>
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">AEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Seeds dehulled, surface-sterilised in 20% bleach for 30 min, washed with autoclaved water. Solid: sown on plates, sealed with Micropore tape for gas exchange, held vertically 7 days. Hydroponic: germinated on water plates 2 days in darkness, then 5 days in flasks. This medium produces the AXENIC seedlings that are transplanted into the soil pots; it is not the medium the rhizosphere community grows in, and is recorded separately for that reason.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Rice seeds were dehulled, surface-sterilized in 20% bleach for 30 minutes, and thoroughly washed with autoclaved water. The seeds were grown in 1× Murashige and Skoog (1× MS) salt mixture with 1% sucrose (pH 5.65), either as a solid medium containing 0.3% Gellex (Gellan Gum, Caisson Laboratories) or hydroponically in flasks with 100 mL of the same media without Gellex."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"For solid medium conditions, seeds were sown on plates, sealed with Micropore tape for gas exchange, and placed vertically for 7 days."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://pubmed.ncbi.nlm.nih.gov/41582156"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            PMID:41582156
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The incubators used for rice germination and growth were set with a 14-h-light/10-h-dark photoperiod at 28 °C/24 °C."</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
+++ b/docs/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.html
@@ -951,18 +951,13 @@
                     
 
                     
-                    <div class="metadata-item">
-                        <span class="metadata-label">Atmosphere</span>
-                        <span class="metadata-value">ANAEROBIC</span>
-                    </div>
-                    
                 </div>
 
                 
 
                 
                 <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
-                    <strong>Preparation notes:</strong> Soil crushed to 2 mm, homogenized and stored until planting, then 2000 g per pot, 18 pots per 23-gallon tub, five tubs per genotype. Tubs were flooded before transplanting and kept submerged with deionized water every other day -- paddy conditions, which is what makes this record about methane cycling. From day 15 the deionized water was replaced with fertigation at N 77, P 20, K 75, Ca 27, Mg 17, S 68, Fe 1.5, Cu 0.02, Mn 0.5, Mo 0.01, Zn 0.1 and B 0.5 ppm; the source gives that composition inside square brackets, which validate-references strips (#622), so it is prose here rather than a quote. ph 6.59 is the mean soil pH reported for the field site, not a controlled setpoint. NO GREENHOUSE TEMPERATURE OR PHOTOPERIOD IS REPORTED for the pot phase; the 28/24 C, 14 h:10 h figures belong to the germination incubators and are recorded on the other medium, not here.
+                    <strong>Preparation notes:</strong> Soil crushed to 2 mm, homogenized and stored until planting, then 2000 g per pot, 18 pots per 23-gallon tub, five tubs per genotype. Tubs were flooded before transplanting and kept submerged with deionized water every other day -- paddy conditions, which is what makes this record about methane cycling. From day 15 the deionized water was replaced with fertigation at N 77, P 20, K 75, Ca 27, Mg 17, S 68, Fe 1.5, Cu 0.02, Mn 0.5, Mo 0.01, Zn 0.1 and B 0.5 ppm; the source gives that composition inside square brackets, which validate-references strips (#622), so it is prose here rather than a quote. ph 6.59 is the mean soil pH reported for the field site, not a controlled setpoint. atmosphere is UNSET: the source never describes THIS experiment&#39;s soil as anoxic -- every &#39;anaerobic&#39;/&#39;anoxic&#39; mention is background about rice paddies in general, a metabolic term, or a cited study, and one passage has methanogenesis inhibited &#39;until conditions become anoxic&#39;. The pots also sit on greenhouse benches in room air, so ANAEROBIC would mislabel the system even where the soil is reduced. Submergence is what is stated, and it is quoted above (#649). NO GREENHOUSE TEMPERATURE OR PHOTOPERIOD IS REPORTED for the pot phase; the 28/24 C, 14 h:10 h figures belong to the germination incubators and are recorded on the other medium, not here.
                 </p>
                 
 

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -266,16 +266,20 @@ growth_media:
   incubation_time: 70
   incubation_time_unit: d
   vessel_type: 5.5 x 5.5 inch pot, 18 pots per 23-gallon tub, on greenhouse benches
-  atmosphere: ANAEROBIC
-  preparation_notes: Soil crushed to 2 mm, homogenized and stored until planting, then 2000 g per pot,
+  preparation_notes: 'Soil crushed to 2 mm, homogenized and stored until planting, then 2000 g per pot,
     18 pots per 23-gallon tub, five tubs per genotype. Tubs were flooded before transplanting and kept
     submerged with deionized water every other day -- paddy conditions, which is what makes this record
     about methane cycling. From day 15 the deionized water was replaced with fertigation at N 77, P 20,
     K 75, Ca 27, Mg 17, S 68, Fe 1.5, Cu 0.02, Mn 0.5, Mo 0.01, Zn 0.1 and B 0.5 ppm; the source gives
     that composition inside square brackets, which validate-references strips (#622), so it is prose here
     rather than a quote. ph 6.59 is the mean soil pH reported for the field site, not a controlled setpoint.
-    NO GREENHOUSE TEMPERATURE OR PHOTOPERIOD IS REPORTED for the pot phase; the 28/24 C, 14 h:10 h figures
-    belong to the germination incubators and are recorded on the other medium, not here.
+    atmosphere is UNSET: the source never describes THIS experiment''s soil as anoxic -- every ''anaerobic''/''anoxic''
+    mention is background about rice paddies in general, a metabolic term, or a cited study, and one passage
+    has methanogenesis inhibited ''until conditions become anoxic''. The pots also sit on greenhouse benches
+    in room air, so ANAEROBIC would mislabel the system even where the soil is reduced. Submergence is
+    what is stated, and it is quoted above (#649). NO GREENHOUSE TEMPERATURE OR PHOTOPERIOD IS REPORTED
+    for the pot phase; the 28/24 C, 14 h:10 h figures belong to the germination incubators and are recorded
+    on the other medium, not here.'
   evidence:
   - reference: PMID:41582156
     supports: SUPPORT

--- a/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
+++ b/kb/communities/PSY_Transgenic_Rice_Rhizosphere_Methane_Community.yaml
@@ -255,7 +255,138 @@ environmental_factors:
     evidence_source: IN_VIVO
     snippet: 70 days of growth compared with controls
     explanation: Supports the time scale of the CH4 emission measurement.
-growth_media: []
+growth_media:
+- name: submerged Capay rice-paddy soil in greenhouse pots, fertigated
+  inoculum_source: soil from a rice field in Davis, California (38.543224 N, -121.810536 W), collected
+    to ~6-10 inches depth in July 2022 and July and December 2023; Capay series, a fine, smectitic, thermic
+    Typic Haploxerert
+  ph: 6.59
+  inoculum_size: 2000
+  inoculum_unit: g soil per pot
+  incubation_time: 70
+  incubation_time_unit: d
+  vessel_type: 5.5 x 5.5 inch pot, 18 pots per 23-gallon tub, on greenhouse benches
+  atmosphere: ANAEROBIC
+  preparation_notes: Soil crushed to 2 mm, homogenized and stored until planting, then 2000 g per pot,
+    18 pots per 23-gallon tub, five tubs per genotype. Tubs were flooded before transplanting and kept
+    submerged with deionized water every other day -- paddy conditions, which is what makes this record
+    about methane cycling. From day 15 the deionized water was replaced with fertigation at N 77, P 20,
+    K 75, Ca 27, Mg 17, S 68, Fe 1.5, Cu 0.02, Mn 0.5, Mo 0.01, Zn 0.1 and B 0.5 ppm; the source gives
+    that composition inside square brackets, which validate-references strips (#622), so it is prose here
+    rather than a quote. ph 6.59 is the mean soil pH reported for the field site, not a controlled setpoint.
+    NO GREENHOUSE TEMPERATURE OR PHOTOPERIOD IS REPORTED for the pot phase; the 28/24 C, 14 h:10 h figures
+    belong to the germination incubators and are recorded on the other medium, not here.
+  evidence:
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: "Soil from a rice field in Davis (38.543224 degrees North and -121.810536 West) was collected\
+      \ in July 2022 and in July and December 2023 using a front-end loader to gather down to a depth\
+      \ of ~6\u201310 inches."
+    explanation: Gives the soil source, coordinates and sampling depth.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: The soil at the field site belongs to the Capay soil series, a fine, smectitic, thermic Typic
+      Haploxerert.
+    explanation: Gives the soil series.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: "Soil pH was 6.59 on\_average."
+    explanation: Gives the mean soil pH.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: "For both experiments, all soils were transported back to the greenhouse, crushed to a 2\u2009\
+      mm particle size, thoroughly homogenized, and stored until planting. Then, the soil was transferred\
+      \ into new 5.5\u2009\xD7\u20095.5 inch pots (2000\u2009g per pot), which were then placed into five\
+      \ 23 gallon tubs per genotype (18 pots each)."
+    explanation: Gives the 2 mm crushing, pot mass and tub layout.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Prior to seedling transplantation, enough water was added to the tubs to submerge the soils.
+    explanation: Gives the flooding before transplanting.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Axenic seedlings were then transplanted into the watered pots (one seedling per pot) in the
+      greenhouse, where they were irrigated with deionized water every other day to keep the soil submerged.
+    explanation: Gives one seedling per pot and the irrigation keeping soil submerged.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Each tub contained only one plant genotype to avoid root exudate compositional changes. We
+      also kept a separate tub with unplanted pots and bulk soil controls.
+    explanation: Gives the one-genotype-per-tub design and the unplanted bulk-soil controls.
+- name: 1x Murashige and Skoog salts with 1% sucrose, pH 5.65 (germination only)
+  ph: 5.65
+  temperature: 28
+  temperature_unit: "\xB0C"
+  atmosphere: AEROBIC
+  light_regime: '14 h light : 10 h dark photoperiod, 28 C day / 24 C night'
+  vessel_type: plates with 0.3% Gellex sealed with Micropore tape, or flasks with 100 mL liquid medium
+  incubation_time: 7
+  incubation_time_unit: d
+  preparation_notes: 'Seeds dehulled, surface-sterilised in 20% bleach for 30 min, washed with autoclaved
+    water. Solid: sown on plates, sealed with Micropore tape for gas exchange, held vertically 7 days.
+    Hydroponic: germinated on water plates 2 days in darkness, then 5 days in flasks. This medium produces
+    the AXENIC seedlings that are transplanted into the soil pots; it is not the medium the rhizosphere
+    community grows in, and is recorded separately for that reason.'
+  evidence:
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Rice seeds were dehulled, surface-sterilized in 20% bleach for 30\u2009minutes, and thoroughly\
+      \ washed with autoclaved water. The seeds were grown in 1\xD7 Murashige and Skoog (1\xD7 MS) salt\
+      \ mixture with 1% sucrose (pH 5.65), either as a solid medium containing 0.3% Gellex (Gellan Gum,\
+      \ Caisson Laboratories) or hydroponically in flasks with 100\u2009mL of the same media without Gellex."
+    explanation: Gives seed sterilisation and the MS/sucrose medium in both forms.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: For solid medium conditions, seeds were sown on plates, sealed with Micropore tape for gas
+      exchange, and placed vertically for 7 days.
+    explanation: Gives the solid and hydroponic germination regimes.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The incubators used for rice germination and growth were set with a 14-h-light/10-h-dark\
+      \ photoperiod at 28\u2009\xB0C/24\u2009\xB0C."
+    explanation: Gives the incubator photoperiod and day/night temperatures.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: OTHER
+  instrument_detail: 'Greenhouse pot experiment under flooded paddy conditions: 2000 g of 2 mm Capay rice-field
+    soil per 5.5 x 5.5 inch pot, 18 pots per 23-gallon tub, five tubs per genotype, tubs randomised across
+    greenhouse benches. One axenic seedling per pot, soil kept submerged with deionized water every other
+    day and fertigated from day 15. Rhizosphere sampled on days 15, 30, 55 and 70.'
+  notes: 'system_type is OTHER because no CultivationSystemEnum value denotes a flooded greenhouse pot.
+    Two media are recorded because plant and microbiome were raised apart: seedlings arrive axenic from
+    MS medium and the rhizosphere community assembles only after transplanting into field soil, so attaching
+    the incubator''s 28/24 C to the community would describe conditions it never had.'
+  evidence:
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: "For both experiments, all soils were transported back to the greenhouse, crushed to a 2\u2009\
+      mm particle size, thoroughly homogenized, and stored until planting. Then, the soil was transferred\
+      \ into new 5.5\u2009\xD7\u20095.5 inch pots (2000\u2009g per pot), which were then placed into five\
+      \ 23 gallon tubs per genotype (18 pots each)."
+    explanation: Gives the pot and tub configuration.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Axenic seedlings were then transplanted into the watered pots (one seedling per pot) in the
+      greenhouse, where they were irrigated with deionized water every other day to keep the soil submerged.
+    explanation: Gives transplanting and the submerged irrigation regime.
+  - reference: PMID:41582156
+    supports: SUPPORT
+    evidence_source: IN_VIVO
+    snippet: Each tub contained only one plant genotype to avoid root exudate compositional changes. We
+      also kept a separate tub with unplanted pots and bulk soil controls.
+    explanation: Gives the genotype separation and bulk-soil controls.
 external_resources:
 - name: Primary publication for the PSY rice rhizosphere methane-mitigating community
   repository: OTHER


### PR DESCRIPTION
Continues #183. One record enriched, one strong-looking candidate rejected on inspection — the rejection is the more useful half.

## CommunityMech:000216 — transgenic rice rhizosphere, flooded paddy

Greenhouse pot experiment: 2000 g of 2 mm Capay rice-field soil per 5.5 × 5.5 inch pot, 18 pots per 23-gallon tub, five tubs per genotype randomised across benches, one axenic seedling per pot, kept submerged with deionized water every other day and fertigated from day 15, rhizosphere sampled to day 70.

**Two media, not one.** The plant and its microbiome were raised apart: seedlings arrive **axenic** from 1× MS salts + 1% sucrose in incubators at 14 h:10 h, 28/24 °C, and the rhizosphere community only assembles after transplanting into field soil. Collapsing these into one medium would attach the incubator's 28/24 °C to a community that never experienced it — and the greenhouse pot phase reports **no temperature or photoperiod at all**, which `preparation_notes` states rather than quietly borrowing the germination figures.

`ph: 6.59` is labelled as the field site's mean soil pH — a measured property of the soil, not a controlled setpoint.

The fertigation composition (N 77, P 20, K 75 … ppm) is recorded as prose because the source gives it inside square brackets, which `validate-references` strips before matching (#622).

## The rejected candidate — #647

`Drought_Rhizosphere_Iron_Actinobacteria` (000235) scored 4 cultivation cues, putting it among the strongest remaining candidates. Every cue belongs to a **different plant**.

The record is the field **sorghum** rhizosphere. The `growth chamber` text is a validation experiment on **maize** *tom1* mutants; the "microboxes … four weeks" passage is a third assay. Curating those would attach maize growth-chamber conditions to a sorghum field community, with every snippet verbatim and every validator green.

**This trap is invisible to the #529 heuristic**: the members *are* named in the paper — just not in the passage the conditions come from. A same-paper wrong-experiment is not something "does the source study this community?" can catch. Filed as #647 rather than silently skipped, so it is not re-triaged as promising next time.

## Guards that fired

- The span helper's **bracket assertion** stopped a `[N, 77 ppm …]` quote reaching a snippet.
- Its **NBSP sensitivity** surfaced too: an end marker written `on average` did not match a cache holding `on\xa0average`. Both are why the markers are now short and whitespace-free.

## Verification

- Rice record snippets mutation-checked: a fabricated sentence is reported, so `Total checks: 0` means zero issues over checks that ran.
- The #529 gate skips this record (members are domain-rank `Bacteria`/`Archaea`), so it was verified by reading.
- Enrichment asserts no top-level key is lost before writing.

lint 0 · validate-all 0 · validate-strict 0 · check-docs-current 0 · **2583 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
