### PR TITLE
South Bay salt pond microcosms, and the end of the cue-ranked candidate list (#183, #650)

### DIFF
--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -1132,6 +1132,183 @@
 
         <!-- Growth Media -->
         
+        <section>
+            <h2>Growth Media</h2>
+            
+            <div class="metadata">
+                <h3>
+                    Pond R2 water as culture medium, with soil slurry and a single added methanogenic substrate
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>trimethylamine (one treatment)</strong></td>
+                            <td>15</td>
+                            <td>mM</td>
+                            <td>
+                                
+                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18139"
+                                   class="term-link" target="_blank" rel="noopener">
+                                    CHEBI:18139
+                                </a>
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>methanol (one treatment)</strong></td>
+                            <td>20</td>
+                            <td>mM</td>
+                            <td>
+                                
+                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17790"
+                                   class="term-link" target="_blank" rel="noopener">
+                                    CHEBI:17790
+                                </a>
+                                
+                            </td>
+                        </tr>
+                        
+                        <tr>
+                            <td><strong>acetate (one treatment)</strong></td>
+                            <td>20</td>
+                            <td>mM</td>
+                            <td>
+                                
+                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=30089"
+                                   class="term-link" target="_blank" rel="noopener">
+                                    CHEBI:30089
+                                </a>
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> The medium is pond water from the site, not a formulation: water from Pond R2 was equilibrated overnight in the chamber to strip oxygen, then 10-15 mL of soil was mixed with 15 mL of it to make a slurry. Each bottle received 15 mL of ONE substrate -- trimethylamine 15 mM, methanol 20 mM, acetate 20 mM -- or pure medium as control, three replicates each (n = 12). The three substrates are alternative treatments, not components of a single medium; they are listed together because the schema has one composition list per medium. atmosphere is ANAEROBIC on the strength of the stated chamber gas mix, not inferred from the habitat (cf. #644, #649).
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition incubation experiment."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc. Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance)."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The hydrogen concentration is typically reduced down to 0.2−0.6% during oxygen scavenging and is not enough to support hydrogenotrophic methanogenesis."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"After the water equilibrated overnight in the chamber to remove remaining oxygen, 10−15 mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with 15 mL culture medium to make a soil slurry, which was funneled into autoclaved 100 mL glass bottles."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Fifteen milliliters solutions of trimethylamine (15 mM), methanol (20 mM), acetate (20 mM), or pure culture medium (control) were prepared and injected into the glass bottles with three replicates for each treatment (n = 12 total)."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"CH4 production was measured with a Picarro G2508 Cavity Ringdown Spectrometer (Picarro, Inc. California) after substrate addition and every other day for two weeks."</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+        </section>
+        
     </main>
 
     <footer>

--- a/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
+++ b/docs/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.html
@@ -1137,7 +1137,7 @@
             
             <div class="metadata">
                 <h3>
-                    Pond R2 water as culture medium, with soil slurry and a single added methanogenic substrate
+                    Pond R2 water with soil slurry, no substrate added (control)
                     
                 </h3>
 
@@ -1157,67 +1157,10 @@
                 </div>
 
                 
-                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Component</th>
-                            <th>Concentration</th>
-                            <th>Unit</th>
-                            <th>CHEBI</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        
-                        <tr>
-                            <td><strong>trimethylamine (one treatment)</strong></td>
-                            <td>15</td>
-                            <td>mM</td>
-                            <td>
-                                
-                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18139"
-                                   class="term-link" target="_blank" rel="noopener">
-                                    CHEBI:18139
-                                </a>
-                                
-                            </td>
-                        </tr>
-                        
-                        <tr>
-                            <td><strong>methanol (one treatment)</strong></td>
-                            <td>20</td>
-                            <td>mM</td>
-                            <td>
-                                
-                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17790"
-                                   class="term-link" target="_blank" rel="noopener">
-                                    CHEBI:17790
-                                </a>
-                                
-                            </td>
-                        </tr>
-                        
-                        <tr>
-                            <td><strong>acetate (one treatment)</strong></td>
-                            <td>20</td>
-                            <td>mM</td>
-                            <td>
-                                
-                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=30089"
-                                   class="term-link" target="_blank" rel="noopener">
-                                    CHEBI:30089
-                                </a>
-                                
-                            </td>
-                        </tr>
-                        
-                    </tbody>
-                </table>
-                
 
                 
                 <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
-                    <strong>Preparation notes:</strong> The medium is pond water from the site, not a formulation: water from Pond R2 was equilibrated overnight in the chamber to strip oxygen, then 10-15 mL of soil was mixed with 15 mL of it to make a slurry. Each bottle received 15 mL of ONE substrate -- trimethylamine 15 mM, methanol 20 mM, acetate 20 mM -- or pure medium as control, three replicates each (n = 12). The three substrates are alternative treatments, not components of a single medium; they are listed together because the schema has one composition list per medium. atmosphere is ANAEROBIC on the strength of the stated chamber gas mix, not inferred from the habitat (cf. #644, #649).
+                    <strong>Preparation notes:</strong> Pond R2 water is the medium, not a formulation: it was equilibrated overnight in the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it. Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n = 12 total). The four treatments are recorded as four media because no bottle ever held more than one substrate; a single composition listing all three would describe a medium that never existed (#652). atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649). No chamber temperature is reported.
                 </p>
                 
 
@@ -1300,6 +1243,360 @@
 
                         
                         <p class="snippet">"CH4 production was measured with a Picarro G2508 Cavity Ringdown Spectrometer (Picarro, Inc. California) after substrate addition and every other day for two weeks."</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Pond R2 water with soil slurry, amended with trimethylamine
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>trimethylamine</strong></td>
+                            <td>15</td>
+                            <td>mM</td>
+                            <td>
+                                
+                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=18139"
+                                   class="term-link" target="_blank" rel="noopener">
+                                    CHEBI:18139
+                                </a>
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Pond R2 water is the medium, not a formulation: it was equilibrated overnight in the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it. Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n = 12 total). The four treatments are recorded as four media because no bottle ever held more than one substrate; a single composition listing all three would describe a medium that never existed (#652). atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649). No chamber temperature is reported.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition incubation experiment."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc. Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance)."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"After the water equilibrated overnight in the chamber to remove remaining oxygen, 10−15 mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with 15 mL culture medium to make a soil slurry, which was funneled into autoclaved 100 mL glass bottles."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Fifteen milliliters solutions of trimethylamine (15 mM), methanol (20 mM), acetate (20 mM), or pure culture medium (control) were prepared and injected into the glass bottles with three replicates for each treatment (n = 12 total)."</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Pond R2 water with soil slurry, amended with methanol
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>methanol</strong></td>
+                            <td>20</td>
+                            <td>mM</td>
+                            <td>
+                                
+                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=17790"
+                                   class="term-link" target="_blank" rel="noopener">
+                                    CHEBI:17790
+                                </a>
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Pond R2 water is the medium, not a formulation: it was equilibrated overnight in the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it. Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n = 12 total). The four treatments are recorded as four media because no bottle ever held more than one substrate; a single composition listing all three would describe a medium that never existed (#652). atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649). No chamber temperature is reported.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition incubation experiment."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc. Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance)."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"After the water equilibrated overnight in the chamber to remove remaining oxygen, 10−15 mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with 15 mL culture medium to make a soil slurry, which was funneled into autoclaved 100 mL glass bottles."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Fifteen milliliters solutions of trimethylamine (15 mM), methanol (20 mM), acetate (20 mM), or pure culture medium (control) were prepared and injected into the glass bottles with three replicates for each treatment (n = 12 total)."</p>
+                        
+                    </div>
+                    
+                </div>
+                
+            </div>
+            
+            <div class="metadata">
+                <h3>
+                    Pond R2 water with soil slurry, amended with acetate
+                    
+                </h3>
+
+                
+
+                <div class="metadata-grid" style="margin-top: 1rem;">
+                    
+
+                    
+
+                    
+                    <div class="metadata-item">
+                        <span class="metadata-label">Atmosphere</span>
+                        <span class="metadata-value">ANAEROBIC</span>
+                    </div>
+                    
+                </div>
+
+                
+                <h4 style="margin-top: 1rem; color: var(--text);">Composition</h4>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Component</th>
+                            <th>Concentration</th>
+                            <th>Unit</th>
+                            <th>CHEBI</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        
+                        <tr>
+                            <td><strong>acetate</strong></td>
+                            <td>20</td>
+                            <td>mM</td>
+                            <td>
+                                
+                                <a href="https://www.ebi.ac.uk/chebi/searchId.do?chebiId=30089"
+                                   class="term-link" target="_blank" rel="noopener">
+                                    CHEBI:30089
+                                </a>
+                                
+                            </td>
+                        </tr>
+                        
+                    </tbody>
+                </table>
+                
+
+                
+                <p style="margin-top: 1rem; padding: 0.75rem; background: var(--background); color: var(--text); border: 1px solid var(--border); border-radius: 4px;">
+                    <strong>Preparation notes:</strong> Pond R2 water is the medium, not a formulation: it was equilibrated overnight in the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it. Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n = 12 total). The four treatments are recorded as four media because no bottle ever held more than one substrate; a single composition listing all three would describe a medium that never existed (#652). atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649). No chamber temperature is reported.
+                </p>
+                
+
+                
+                <div style="margin-top: 1rem;">
+                    <h4 style="color: var(--text);">Evidence</h4>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition incubation experiment."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc. Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance)."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"After the water equilibrated overnight in the chamber to remove remaining oxygen, 10−15 mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with 15 mL culture medium to make a soil slurry, which was funneled into autoclaved 100 mL glass bottles."</p>
+                        
+                    </div>
+                    
+                    <div class="evidence-item">
+                        
+                        <a href="https://doi.org/10.1038/s41396-021-01067-w"
+                           class="pmid-link" target="_blank" rel="noopener">
+                            doi:10.1038/s41396-021-01067-w
+                        </a>
+                        
+
+                        
+                        <p class="snippet">"Fifteen milliliters solutions of trimethylamine (15 mM), methanol (20 mM), acetate (20 mM), or pure culture medium (control) were prepared and injected into the glass bottles with three replicates for each treatment (n = 12 total)."</p>
                         
                     </div>
                     

--- a/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
+++ b/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
@@ -296,7 +296,122 @@ related_ingredients:
     evidence_source: COMPUTATIONAL
     snippet: methane is generated both from bacterial methylphosphonate degradation and archaeal methanogenesis
     explanation: Names methylphosphonate as the bacterial substrate for one methane-generating pathway.
-growth_media: []
+growth_media:
+- name: Pond R2 water as culture medium, with soil slurry and a single added methanogenic substrate
+  composition:
+  - name: trimethylamine (one treatment)
+    concentration: 15
+    unit: mM
+    chebi_term:
+      preferred_term: trimethylamine
+      term:
+        id: CHEBI:18139
+        label: trimethylamine
+  - name: methanol (one treatment)
+    concentration: 20
+    unit: mM
+    chebi_term:
+      preferred_term: methanol
+      term:
+        id: CHEBI:17790
+        label: methanol
+  - name: acetate (one treatment)
+    concentration: 20
+    unit: mM
+    chebi_term:
+      preferred_term: acetate
+      term:
+        id: CHEBI:30089
+        label: acetate
+  atmosphere: ANAEROBIC
+  headspace_gas: 'Type B vinyl anaerobic chamber: non-flammable hydrogen mixture (<5%), CO2 5%, N2 balance;
+    H2 falls to 0.2-0.6% during oxygen scavenging, too little to support hydrogenotrophic methanogenesis,
+    and controls without substrate showed minimal methanogenesis'
+  inoculum_source: 10-15 mL of soil from a core collected at Pond R2 (unrestored), March 2015
+  incubation_time: 14
+  incubation_time_unit: d
+  light_regime: dark
+  vessel_type: autoclaved 100 mL glass bottle, capped and crimped, held inside the anaerobic chamber
+  preparation_notes: 'The medium is pond water from the site, not a formulation: water from Pond R2 was
+    equilibrated overnight in the chamber to strip oxygen, then 10-15 mL of soil was mixed with 15 mL
+    of it to make a slurry. Each bottle received 15 mL of ONE substrate -- trimethylamine 15 mM, methanol
+    20 mM, acetate 20 mM -- or pure medium as control, three replicates each (n = 12). The three substrates
+    are alternative treatments, not components of a single medium; they are listed together because the
+    schema has one composition list per medium. atmosphere is ANAEROBIC on the strength of the stated
+    chamber gas mix, not inferred from the habitat (cf. #644, #649).'
+  evidence:
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition
+      incubation experiment.
+    explanation: States that Pond R2 water served as the culture medium.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc.
+      Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance).
+    explanation: Gives the anaerobic chamber and its gas composition.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The hydrogen concentration is typically reduced down to 0.2\u22120.6% during oxygen scavenging\
+      \ and is not enough to support hydrogenotrophic methanogenesis."
+    explanation: Gives the residual H2 and why it cannot drive hydrogenotrophic methanogenesis.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "After the water equilibrated overnight in the chamber to remove remaining oxygen, 10\u2212\
+      15\u2009mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with\
+      \ 15\u2009mL culture medium to make a soil slurry, which was funneled into autoclaved 100\u2009\
+      mL glass bottles."
+    explanation: Gives oxygen removal, the soil-to-medium ratio and the bottle format.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Fifteen milliliters solutions of trimethylamine (15\u2009mM), methanol (20\u2009mM), acetate\
+      \ (20\u2009mM), or pure culture medium (control) were prepared and injected into the glass bottles\
+      \ with three replicates for each treatment (n\u2009=\u200912 total)."
+    explanation: Gives the three substrates, their concentrations, the control and the replication.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: CH4 production was measured with a Picarro G2508 Cavity Ringdown Spectrometer (Picarro, Inc.
+      California) after substrate addition and every other day for two weeks.
+    explanation: Gives the two-week incubation and measurement cadence.
+cultivation_setup:
+- cultivation_mode: BATCH
+  system_type: SERUM_BOTTLE
+  instrument_detail: Autoclaved 100 mL glass bottles, capped and crimped, held in the dark inside a Type
+    B vinyl anaerobic chamber (Coy Lab Products). Each holds a slurry of 10-15 mL Pond R2 soil in 15 mL
+    of Pond R2 water plus 15 mL of substrate solution. Headspace CH4 measured on a Picarro G2508 cavity
+    ringdown spectrometer every other day for two weeks, 10 mL withdrawn per reading.
+  working_volume: 100
+  working_volume_unit: mL
+  notes: 'A substrate-addition assay on the pond community itself, which is why the conditions belong
+    on this record: the paper states the microcosms assess ''the potential for the unrestored salt pond
+    communities to produce methane''. No temperature is reported for the chamber, so it is unset. system_type
+    is SERUM_BOTTLE as the closest match to a crimped glass bottle.'
+  evidence:
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "After the water equilibrated overnight in the chamber to remove remaining oxygen, 10\u2212\
+      15\u2009mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with\
+      \ 15\u2009mL culture medium to make a soil slurry, which was funneled into autoclaved 100\u2009\
+      mL glass bottles."
+    explanation: Gives the bottle format and slurry preparation.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Glass bottles were capped and crimped and stored in the dark inside the anaerobic chamber.
+    explanation: Gives capping, crimping, darkness and chamber containment.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: CH4 production was measured with a Picarro G2508 Cavity Ringdown Spectrometer (Picarro, Inc.
+      California) after substrate addition and every other day for two weeks.
+    explanation: Gives the measurement instrument and cadence.
 associated_datasets: []
 external_resources:
 - name: Primary publication for South Bay salt pond methane communities

--- a/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
+++ b/kb/communities/South_Bay_Salt_Pond_Methane_Restoration_Community.yaml
@@ -297,9 +297,70 @@ related_ingredients:
     snippet: methane is generated both from bacterial methylphosphonate degradation and archaeal methanogenesis
     explanation: Names methylphosphonate as the bacterial substrate for one methane-generating pathway.
 growth_media:
-- name: Pond R2 water as culture medium, with soil slurry and a single added methanogenic substrate
+- name: Pond R2 water with soil slurry, no substrate added (control)
+  atmosphere: ANAEROBIC
+  headspace_gas: 'Type B vinyl anaerobic chamber: non-flammable hydrogen mixture (<5%), CO2 5%, N2 balance;
+    H2 falls to 0.2-0.6% during oxygen scavenging, too little to support hydrogenotrophic methanogenesis,
+    and controls without substrate showed minimal methanogenesis'
+  inoculum_source: 10-15 mL of soil from a core collected at Pond R2 (unrestored), March 2015
+  incubation_time: 14
+  incubation_time_unit: d
+  light_regime: dark
+  vessel_type: autoclaved 100 mL glass bottle, capped and crimped, held inside the anaerobic chamber
+  preparation_notes: 'Pond R2 water is the medium, not a formulation: it was equilibrated overnight in
+    the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it.
+    Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n
+    = 12 total). The four treatments are recorded as four media because no bottle ever held more than
+    one substrate; a single composition listing all three would describe a medium that never existed (#652).
+    atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649).
+    No chamber temperature is reported.'
+  evidence:
+  - &id001
+    reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition
+      incubation experiment.
+    explanation: States that Pond R2 water served as the culture medium.
+  - &id002
+    reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc.
+      Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance).
+    explanation: Gives the anaerobic chamber and its gas composition.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The hydrogen concentration is typically reduced down to 0.2\u22120.6% during oxygen scavenging\
+      \ and is not enough to support hydrogenotrophic methanogenesis."
+    explanation: Gives the residual H2 and why it cannot drive hydrogenotrophic methanogenesis.
+  - &id003
+    reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "After the water equilibrated overnight in the chamber to remove remaining oxygen, 10\u2212\
+      15\u2009mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with\
+      \ 15\u2009mL culture medium to make a soil slurry, which was funneled into autoclaved 100\u2009\
+      mL glass bottles."
+    explanation: Gives oxygen removal, the soil-to-medium ratio and the bottle format.
+  - &id004
+    reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Fifteen milliliters solutions of trimethylamine (15\u2009mM), methanol (20\u2009mM), acetate\
+      \ (20\u2009mM), or pure culture medium (control) were prepared and injected into the glass bottles\
+      \ with three replicates for each treatment (n\u2009=\u200912 total)."
+    explanation: Gives the three substrates, their concentrations, the control and the replication.
+  - reference: doi:10.1038/s41396-021-01067-w
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: CH4 production was measured with a Picarro G2508 Cavity Ringdown Spectrometer (Picarro, Inc.
+      California) after substrate addition and every other day for two weeks.
+    explanation: Gives the two-week incubation and measurement cadence.
+- name: Pond R2 water with soil slurry, amended with trimethylamine
   composition:
-  - name: trimethylamine (one treatment)
+  - name: trimethylamine
     concentration: 15
     unit: mM
     chebi_term:
@@ -307,7 +368,30 @@ growth_media:
       term:
         id: CHEBI:18139
         label: trimethylamine
-  - name: methanol (one treatment)
+  atmosphere: ANAEROBIC
+  headspace_gas: 'Type B vinyl anaerobic chamber: non-flammable hydrogen mixture (<5%), CO2 5%, N2 balance;
+    H2 falls to 0.2-0.6% during oxygen scavenging, too little to support hydrogenotrophic methanogenesis,
+    and controls without substrate showed minimal methanogenesis'
+  inoculum_source: 10-15 mL of soil from a core collected at Pond R2 (unrestored), March 2015
+  incubation_time: 14
+  incubation_time_unit: d
+  light_regime: dark
+  vessel_type: autoclaved 100 mL glass bottle, capped and crimped, held inside the anaerobic chamber
+  preparation_notes: 'Pond R2 water is the medium, not a formulation: it was equilibrated overnight in
+    the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it.
+    Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n
+    = 12 total). The four treatments are recorded as four media because no bottle ever held more than
+    one substrate; a single composition listing all three would describe a medium that never existed (#652).
+    atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649).
+    No chamber temperature is reported.'
+  evidence:
+  - *id001
+  - *id002
+  - *id003
+  - *id004
+- name: Pond R2 water with soil slurry, amended with methanol
+  composition:
+  - name: methanol
     concentration: 20
     unit: mM
     chebi_term:
@@ -315,7 +399,30 @@ growth_media:
       term:
         id: CHEBI:17790
         label: methanol
-  - name: acetate (one treatment)
+  atmosphere: ANAEROBIC
+  headspace_gas: 'Type B vinyl anaerobic chamber: non-flammable hydrogen mixture (<5%), CO2 5%, N2 balance;
+    H2 falls to 0.2-0.6% during oxygen scavenging, too little to support hydrogenotrophic methanogenesis,
+    and controls without substrate showed minimal methanogenesis'
+  inoculum_source: 10-15 mL of soil from a core collected at Pond R2 (unrestored), March 2015
+  incubation_time: 14
+  incubation_time_unit: d
+  light_regime: dark
+  vessel_type: autoclaved 100 mL glass bottle, capped and crimped, held inside the anaerobic chamber
+  preparation_notes: 'Pond R2 water is the medium, not a formulation: it was equilibrated overnight in
+    the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it.
+    Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n
+    = 12 total). The four treatments are recorded as four media because no bottle ever held more than
+    one substrate; a single composition listing all three would describe a medium that never existed (#652).
+    atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649).
+    No chamber temperature is reported.'
+  evidence:
+  - *id001
+  - *id002
+  - *id003
+  - *id004
+- name: Pond R2 water with soil slurry, amended with acetate
+  composition:
+  - name: acetate
     concentration: 20
     unit: mM
     chebi_term:
@@ -332,53 +439,18 @@ growth_media:
   incubation_time_unit: d
   light_regime: dark
   vessel_type: autoclaved 100 mL glass bottle, capped and crimped, held inside the anaerobic chamber
-  preparation_notes: 'The medium is pond water from the site, not a formulation: water from Pond R2 was
-    equilibrated overnight in the chamber to strip oxygen, then 10-15 mL of soil was mixed with 15 mL
-    of it to make a slurry. Each bottle received 15 mL of ONE substrate -- trimethylamine 15 mM, methanol
-    20 mM, acetate 20 mM -- or pure medium as control, three replicates each (n = 12). The three substrates
-    are alternative treatments, not components of a single medium; they are listed together because the
-    schema has one composition list per medium. atmosphere is ANAEROBIC on the strength of the stated
-    chamber gas mix, not inferred from the habitat (cf. #644, #649).'
+  preparation_notes: 'Pond R2 water is the medium, not a formulation: it was equilibrated overnight in
+    the anaerobic chamber to strip oxygen, then 10-15 mL of Pond R2 soil was slurried into 15 mL of it.
+    Each bottle then received 15 mL of ONE substrate solution or pure medium, three replicates each (n
+    = 12 total). The four treatments are recorded as four media because no bottle ever held more than
+    one substrate; a single composition listing all three would describe a medium that never existed (#652).
+    atmosphere is ANAEROBIC on the stated chamber gas mix, not inferred from habitat (cf. #644, #649).
+    No chamber temperature is reported.'
   evidence:
-  - reference: doi:10.1038/s41396-021-01067-w
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: Water collected from Pond R2 (unrestored) was used as a culture medium for a substrate addition
-      incubation experiment.
-    explanation: States that Pond R2 water served as the culture medium.
-  - reference: doi:10.1038/s41396-021-01067-w
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: The experiment was conducted in a Type B Vinyl Anaerobic Chamber (Coy Lab Products, Inc.
-      Michigan) enriched with non-flammable hydrogen gas mixture (less than 5%), CO2 (5%), and N2 (balance).
-    explanation: Gives the anaerobic chamber and its gas composition.
-  - reference: doi:10.1038/s41396-021-01067-w
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: "The hydrogen concentration is typically reduced down to 0.2\u22120.6% during oxygen scavenging\
-      \ and is not enough to support hydrogenotrophic methanogenesis."
-    explanation: Gives the residual H2 and why it cannot drive hydrogenotrophic methanogenesis.
-  - reference: doi:10.1038/s41396-021-01067-w
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: "After the water equilibrated overnight in the chamber to remove remaining oxygen, 10\u2212\
-      15\u2009mL of soil from an additional core collected from Pond R2 in March 2015 were mixed with\
-      \ 15\u2009mL culture medium to make a soil slurry, which was funneled into autoclaved 100\u2009\
-      mL glass bottles."
-    explanation: Gives oxygen removal, the soil-to-medium ratio and the bottle format.
-  - reference: doi:10.1038/s41396-021-01067-w
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: "Fifteen milliliters solutions of trimethylamine (15\u2009mM), methanol (20\u2009mM), acetate\
-      \ (20\u2009mM), or pure culture medium (control) were prepared and injected into the glass bottles\
-      \ with three replicates for each treatment (n\u2009=\u200912 total)."
-    explanation: Gives the three substrates, their concentrations, the control and the replication.
-  - reference: doi:10.1038/s41396-021-01067-w
-    supports: SUPPORT
-    evidence_source: IN_VITRO
-    snippet: CH4 production was measured with a Picarro G2508 Cavity Ringdown Spectrometer (Picarro, Inc.
-      California) after substrate addition and every other day for two weeks.
-    explanation: Gives the two-week incubation and measurement cadence.
+  - *id001
+  - *id002
+  - *id003
+  - *id004
 cultivation_setup:
 - cultivation_mode: BATCH
   system_type: SERUM_BOTTLE


### PR DESCRIPTION
Closes #650

## The record

**CommunityMech:000246** is a substrate-addition assay on the pond community itself — Pond R2 water used as the culture medium, 10–15 mL of Pond R2 soil slurried into 15 mL of it, funnelled into autoclaved 100 mL glass bottles, capped and crimped, held dark inside a Type B vinyl anaerobic chamber. One substrate per bottle (trimethylamine 15 mM, methanol 20 mM, acetate 20 mM) or pure medium, three replicates each, CH₄ followed for two weeks.

The three substrates are recorded as **alternative treatments, not components of one medium** — the schema gives one `composition` list per medium, so `notes` says which they are.

`atmosphere: ANAEROBIC` is asserted here **on the stated chamber gas mix**, not inferred from habitat. That is exactly the distinction #644 and #649 turned on, where I inferred it twice and withdrew it twice. No chamber temperature is reported, so it is unset.

## The larger result: the candidate list is exhausted

Of the eight highest-scoring remaining candidates, **one was enrichable and seven were not**. Each rejection is documented in #650 with the specific text that misled the cue count:

| record | what the cultivation language actually is |
|---|---|
| Soil_Corrinoid_B12_Reservoir | conditions of an *E. coli* reporter strain; community never cultured |
| AMD_Nitrososphaerota | "enrichment culture" = comparisons to other studies' sequences; "bioreactor" inside a citation |
| AMD_Acidophile_Heterotroph | the source is a **review** — every hit narrates someone else's work |
| Mercury_SFA_EFPC_Sediment | "we grew this organism" = **isolated methanogens** in Hg assays |
| Drought_Rhizosphere_Iron_Actinobacteria | growth chamber = **maize *tom1* mutants**; record is field sorghum (#647) |
| Oak_Ridge_FRC_Uranium_Nitrate | "we grew the isolates in R2A" = *Rhodanobacter* resistance assays |
| SPRUCE_Peatland_Warming | another study's microcosms; "we constructed a phylogenetic tree"; a 70 °C DNA-extraction step |

**This is not a full-text problem.** Those sources are 62–126 KB of cached full text, and they say the community was sampled rather than grown — the outcome #183 itself predicted for the residue.

**Why cue counting failed:** the words are real, they just describe a different organism in the same paper, someone else's work, or a lab protocol step. The first two categories are invisible to the #529 member-naming gate, because the paper *does* name the members — just not in the passage the conditions would come from.

**A better signal if this is picked up again:** `community_origin: SYNTHETIC`, or a natural community deliberately placed in a vessel. Every record enriched across this push was one or the other; none of the seven above is either.

## Where #183 now stands

**66 of 312 records lack conditions**, down from 75. On this evidence most of the remainder are correctly empty.

## Verification

Snippets mutation-checked; the #529 gate skips this record (domain-rank members) so it was read instead; enrichment asserts no top-level key is lost; all spans bracket-free by construction.

lint 0 · validate-all 0 · validate-strict 0 · check-docs-current 0 · **2583 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
