### PR TITLE
Add deep-research provider triage for ecological mechanism/dataset research

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,26 @@ just qc
 
 ---
 
+## Deep Research Provider Triage
+
+CommunityMech uses a community-specific version of DisMech's multi-provider
+workflow. `ecological_mechanism` prioritizes exact composition and directional
+interaction evidence; `datasets_environment` prioritizes repository-native
+accessions, ENVO context, cultivation, and perturbation metadata.
+
+```bash
+just deep-research-providers
+just deep-research-providers datasets_environment
+just deep-research-provider asta ecological_mechanism
+just research-community falcon <community-id-or-path> --dry-run
+```
+
+Triage ranks discovery, synthesis, and verification independently. Provider
+reports seed curation; taxa, strains, metabolites, conditions, causal claims,
+and dataset accessions must still resolve to the cited source.
+
+---
+
 ## 🎓 Citation
 
 (TBD once published)

--- a/conf/deep_research_provider.yaml
+++ b/conf/deep_research_provider.yaml
@@ -1,0 +1,47 @@
+mech: CommunityMech
+target: microbial community composition, ecological interactions, environments, cultivation, and datasets
+default_focus: ecological_mechanism
+evidence_policy: Curate exact taxa, interactions, conditions, and accessions only when explicitly supported; preserve community and experimental context.
+focuses:
+  ecological_mechanism:
+    label: community composition and mechanistic ecological interactions
+    objective: Find strain-resolved membership, cross-feeding, syntrophy, competition, facilitation, metabolites, and directional effects.
+    source_priorities:
+      - primary co-culture, synthetic-community, and community perturbation studies
+      - PubMed/PMC methods, supplements, and data availability sections
+      - NCBI, KBase, JGI/IMG/GOLD, NMDC, MGnify, and BioModels
+    provider_adjustments: {openscientist: 4, falcon: 4, asta: 3, claude_code: 2, cyberian: 2}
+    stages:
+      discovery:
+        objective: Retrieve interaction studies, exact compositions, conditions, and dataset records.
+        capabilities: {academic_search: 5, scientific_literature: 5, structured_databases: 3, citation_tracking: 3, snippets: 2}
+        speed_weight: 1
+      synthesis:
+        objective: Reconstruct direction, mediator, context, and endpoint for each ecological interaction.
+        capabilities: {synthesis: 5, scientific_literature: 4, citation_tracking: 4, hypothesis_tracking: 2, structured_databases: 2}
+        synthesis_weight: 2
+      verification:
+        objective: Cross-check taxon/strain identity, exchanged metabolites, conditions, and edge evidence.
+        capabilities: {citation_tracking: 5, scientific_literature: 4, structured_databases: 3, academic_search: 3, snippets: 2}
+        cost_weight: 1
+  datasets_environment:
+    label: environmental context, cultivation conditions, and dataset accessions
+    objective: Resolve ENVO context, perturbations, media, atmosphere, endpoints, and repository accessions.
+    source_priorities:
+      - repository-native study and sample metadata
+      - primary publication methods and data availability
+      - institutional protocol and project pages
+    provider_adjustments: {claude_code: 4, perplexity: 3, asta: 2, cyberian: 2}
+    stages:
+      discovery:
+        objective: Search repository records and linked publications across the web and literature.
+        capabilities: {structured_databases: 5, web_search: 5, academic_search: 3, citation_tracking: 3}
+        speed_weight: 1
+      synthesis:
+        objective: Join publication claims to exact projects, samples, environments, and experimental conditions.
+        capabilities: {synthesis: 5, structured_databases: 4, citation_tracking: 4, web_search: 3}
+        synthesis_weight: 2
+      verification:
+        objective: Resolve every accession and environment/taxon identifier at its source.
+        capabilities: {structured_databases: 5, citation_tracking: 5, web_search: 4}
+        cost_weight: 1

--- a/justfile
+++ b/justfile
@@ -578,6 +578,17 @@ research-provider provider:
         uv run --extra dev deep-research-client providers --provider {{provider}}
     fi
 
+# Rank providers for ecological mechanisms or dataset/environment research.
+deep-research-providers focus="ecological_mechanism" *args="":
+    uv run --extra dev python scripts/deep_research_provider.py \
+      --config conf/deep_research_provider.yaml --focus {{focus}} {{args}}
+
+# Show one provider's focus-specific fit, capabilities, and availability.
+deep-research-provider provider focus="ecological_mechanism" *args="":
+    uv run --extra dev python scripts/deep_research_provider.py \
+      --config conf/deep_research_provider.yaml --provider {{provider}} \
+      --focus {{focus}} {{args}}
+
 # Generate LLM-assisted repair suggestions for all communities
 suggest-network-repairs:
     uv run communitymech repair-network-batch --report-only

--- a/prompts/claude_code_deep_research.md
+++ b/prompts/claude_code_deep_research.md
@@ -1,0 +1,116 @@
+# Claude Code task: one CommunityMech deep-research curation
+
+Work from the CommunityMech repository root. Read `CLAUDE.md`, any applicable
+`AGENTS.md`, `history/README.md`, the LinkML schema, and the target community
+before editing.
+
+## Mission
+
+Select exactly one researchable microbial-community interaction question, use
+the `claude_code` deep-research provider once, and curate supported findings into
+one schema-compliant `MicrobialCommunity` YAML record.
+
+The Markdown report under `research/communities/` is the raw research artifact.
+It is not the schema-compliant deliverable. Accepted findings must be represented
+in the canonical community YAML and pass validation.
+
+## Constraints
+
+- Use only `claude_code`. Do not spend Falcon/Edison, Cyberian, or other provider
+  credits, and do not switch providers on failure. Run one new job at most.
+- Skip any candidate with an equivalent existing Claude Code report.
+- Do not read, print, modify, or commit credentials or `.env`.
+- Do not change the schema or validators to fit generated prose.
+- Do not infer an interaction from co-occurrence alone. Direction, exchanged
+  metabolites, functional roles, and downstream effects each need direct or
+  clearly attributable source support.
+- Keep natural communities, enrichments, isolates, and engineered consortia
+  distinct. Do not generalize a strain-pair experiment to an entire environment.
+- Never invent NCBI/GTDB/ENVO/CHEBI/GO identifiers, taxonomic membership,
+  causal direction, citations, or snippets.
+
+## 1. Pick one question
+
+Inspect:
+
+- `reports/knowledge_gap_scan.json` and `.md`, if present
+- records in `kb/communities/`
+- any relevant reusable taxon records in `kb/taxa/`
+- existing `research/communities/**/*claude_code*` reports
+
+Choose one existing community with a meaningful missing or weakly evidenced
+ecological mechanism. Prefer a target whose membership and environment are
+already usable but whose interaction, metabolite exchange, perturbation response,
+or downstream consequence is incomplete. State its ID, name, YAML path,
+selection rationale, and one precise question before starting research:
+
+> Which source-backed interactions among the members of **<community>** explain
+> its observed function or stability, including direction, exchanged metabolites
+> or processes, conditions, and measurable downstream effects?
+
+Do not run `knowledge-gap-scan --apply` or modify data during selection.
+
+## 2. Check provider fit and run one job
+
+Run:
+
+```bash
+just deep-research-provider claude_code ecological_mechanism
+```
+
+If unavailable, stop and do not fall back. Otherwise run exactly once:
+
+```bash
+just research-community claude_code <community-id-slug-or-yaml-path>
+```
+
+Capture the printed report and citations paths. Verify that the report is
+non-empty and that important claims resolve to traceable sources. Do not retry a
+failed/inconclusive job or manufacture YAML to make the session appear complete.
+
+## 3. Curate into MicrobialCommunity YAML
+
+Use the schema and strong neighboring records as structural guides. Make the
+smallest evidence-backed edit to the chosen file under `kb/communities/`.
+
+- Put member evidence on the corresponding taxonomy/member assertion.
+- Represent ecological interactions with supported source/target direction,
+  interaction type, metabolites/processes, and downstream effects only when
+  each is evidenced.
+- Use stable PMID/DOI identifiers. Add short verbatim snippets and explanations
+  at the exact assertion they support.
+- Verify ontology labels and CURIEs from authoritative local/source data. Leave
+  a field absent or explicitly uncertain rather than guessing.
+- Do not overwrite correct curated membership, environment, GTDB grounding, or
+  experimental design with broader report language.
+- If the literature supports only a related community or condition, reject the
+  claim or model the distinction allowed by the current schema; never blur it.
+
+Create the required append-only history record with `just new-history` following
+`history/README.md`. Mark the work as LLM-assisted and reference both the target
+and Claude Code raw report. Never revise old history records.
+
+## 4. Validate
+
+Run:
+
+```bash
+just validate <target-yaml-path>
+just validate-strict <target-yaml-path>
+just validate-references-explained <target-yaml-path>
+just validate-gtdb <target-yaml-path>
+just validate-gtdb-domain <target-yaml-path>
+just validate-history <new-history-path>
+```
+
+Run `just audit-snippets` as an additional corpus-aware check when evidence was
+added. Fix data or the new history entry, not validation rules or baselines. Do
+not call deep research again. Finish with `git diff --check` and review the
+focused diff.
+
+## Completion report
+
+Return the chosen question/rationale, provider check, single research command,
+raw report/citations paths, canonical YAML and history paths, accepted/rejected
+claims, validation outcomes, and any taxonomic or mechanistic uncertainty.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",
-    "deep-research-client[cyberian]>=0.2.4; python_version >= '3.12'",
+    "deep-research-client[cyberian]>=0.2.10; python_version >= '3.12'",
     # Used by scripts/research_community_edison.py — drives the Edison
     # Scientific SDK directly (PaperQA is not a registered DRC provider).
     "edison-client>=0.11.0; python_version >= '3.12'",

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -309,6 +309,12 @@ def load_config(path: Path) -> dict[str, Any]:
                         f"provider {raw_name!r} (resolved to {name!r}); "
                         f"known providers: {', '.join(sorted(PROVIDERS))}"
                     )
+                if name in canonical:
+                    raise ValueError(
+                        f"Focus {focus_name!r}.provider_adjustments has multiple "
+                        f"keys resolving to provider {name!r} (e.g. {raw_name!r}); "
+                        f"use a single canonical key per provider"
+                    )
                 canonical[name] = value
             focus["provider_adjustments"] = canonical
     return data

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Triage deep-research providers for a Mech-specific research focus.
+
+The provider facts mirror deep-research-client/DisMech, while the YAML profile
+keeps each Mech's evidence target, sources, and stage weights local to that KB.
+No provider is called and no credential value is read or printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import shutil
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Provider:
+    name: str
+    label: str
+    source_scope: str
+    synthesis: str
+    cost: str
+    time: str
+    capabilities: frozenset[str]
+    best_for: str
+    limitation: str
+
+
+PROVIDERS: dict[str, Provider] = {
+    "asta": Provider(
+        "asta",
+        "Asta",
+        "scientific corpus",
+        "none",
+        "low",
+        "fast",
+        frozenset(
+            {
+                "academic_search",
+                "scientific_literature",
+                "citation_tracking",
+                "snippets",
+            }
+        ),
+        "fast paper and passage discovery",
+        "retrieval packet only; no narrative synthesis",
+    ),
+    "falcon": Provider(
+        "falcon",
+        "Edison / Falcon",
+        "scientific literature",
+        "deep",
+        "high",
+        "slow",
+        frozenset(
+            {
+                "academic_search",
+                "scientific_literature",
+                "citation_tracking",
+                "synthesis",
+            }
+        ),
+        "scientific evidence synthesis",
+        "academic sources only; paid and slower",
+    ),
+    "openscientist": Provider(
+        "openscientist",
+        "OpenScientist",
+        "PubMed and scientific literature",
+        "agentic",
+        "high",
+        "very_slow",
+        frozenset(
+            {
+                "academic_search",
+                "scientific_literature",
+                "citation_tracking",
+                "synthesis",
+                "code_interpretation",
+                "hypothesis_tracking",
+            }
+        ),
+        "iterative mechanism and hypothesis research",
+        "long-running and PubMed-focused",
+    ),
+    "claude_code": Provider(
+        "claude_code",
+        "Claude Code",
+        "open web",
+        "agentic",
+        "medium",
+        "slow",
+        frozenset(
+            {
+                "web_search",
+                "citation_tracking",
+                "synthesis",
+                "code_interpretation",
+                "structured_databases",
+            }
+        ),
+        "broad web/database source coverage",
+        "quality depends on web access and local CLI authentication",
+    ),
+    "openai": Provider(
+        "openai",
+        "OpenAI Deep Research",
+        "open web",
+        "deep",
+        "very_high",
+        "very_slow",
+        frozenset(
+            {
+                "web_search",
+                "citation_tracking",
+                "synthesis",
+                "code_interpretation",
+                "real_time_data",
+                "structured_databases",
+            }
+        ),
+        "comprehensive multi-source synthesis",
+        "highest cost and long response times",
+    ),
+    "perplexity": Provider(
+        "perplexity",
+        "Perplexity",
+        "open web",
+        "deep",
+        "high",
+        "slow",
+        frozenset(
+            {
+                "web_search",
+                "citation_tracking",
+                "synthesis",
+                "real_time_data",
+                "multi_language",
+                "structured_databases",
+            }
+        ),
+        "current web research with source links",
+        "less specialized for primary scientific evidence",
+    ),
+    "consensus": Provider(
+        "consensus",
+        "Consensus",
+        "peer-reviewed literature",
+        "summary",
+        "low",
+        "fast",
+        frozenset({"academic_search", "citation_tracking", "scientific_literature"}),
+        "quick peer-reviewed evidence checks",
+        "limited depth and no general web/database search",
+    ),
+    "cyberian": Provider(
+        "cyberian",
+        "Cyberian",
+        "agent-selected web and literature",
+        "agentic",
+        "high",
+        "very_slow",
+        frozenset(
+            {
+                "web_search",
+                "academic_search",
+                "citation_tracking",
+                "synthesis",
+                "code_interpretation",
+                "structured_databases",
+            }
+        ),
+        "custom iterative research workflows",
+        "requires local agent tooling and careful authority limits",
+    ),
+    "cborg": Provider(
+        "cborg",
+        "CBORG proxy",
+        "model-dependent open web",
+        "deep",
+        "medium",
+        "slow",
+        frozenset({"web_search", "citation_tracking", "synthesis", "code_interpretation"}),
+        "OpenAI-compatible research through the LBL proxy",
+        "capabilities depend on the selected proxy model",
+    ),
+    "mock": Provider(
+        "mock",
+        "Mock",
+        "fixtures",
+        "none",
+        "low",
+        "fast",
+        frozenset(),
+        "tests and dry runs",
+        "never supplies real evidence",
+    ),
+    "deeper_med": Provider(
+        "deeper_med",
+        "DeepER-Med",
+        "biomedical databases",
+        "agentic",
+        "high",
+        "slow",
+        frozenset(
+            {
+                "academic_search",
+                "scientific_literature",
+                "citation_tracking",
+                "synthesis",
+                "structured_databases",
+            }
+        ),
+        "future biomedical evidence workflows",
+        "stub: no public API is available",
+    ),
+}
+
+ALIASES = {"edison": "falcon", "futurehouse": "falcon", "claude-code": "claude_code"}
+COST_VALUE = {"low": 1, "medium": 2, "high": 3, "very_high": 4}
+TIME_VALUE = {"fast": 1, "medium": 2, "slow": 3, "very_slow": 4}
+SYNTHESIS_VALUE = {"none": 0, "summary": 1, "deep": 2, "agentic": 3}
+
+
+def canonical_provider(name: str) -> str:
+    key = name.strip().casefold().replace(" ", "_")
+    return ALIASES.get(key, key)
+
+
+def provider_status(provider: str, environ: Mapping[str, str] | None = None) -> tuple[str, str]:
+    """Return status and a safe explanation without exposing credential values."""
+    env = os.environ if environ is None else environ
+    if provider == "deeper_med":
+        return "stub", "no public API"
+    if provider == "mock":
+        enabled = env.get("ENABLE_MOCK_PROVIDER", "").casefold() in {"1", "true", "yes"}
+        return (
+            ("available", "enabled")
+            if enabled
+            else ("unavailable", "set ENABLE_MOCK_PROVIDER=true")
+        )
+    if provider == "claude_code":
+        return (
+            ("available", "local CLI")
+            if shutil.which("claude")
+            else ("unavailable", "claude CLI not found")
+        )
+    if provider == "cyberian":
+        installed = importlib.util.find_spec("cyberian") is not None
+        return (
+            ("available", "local package")
+            if installed
+            else ("unavailable", "install the cyberian extra")
+        )
+
+    credentials = {
+        "asta": ("ASTA_API_KEY",),
+        "falcon": ("EDISON_API_KEY", "EDISON_PLATFORM_API_KEY", "FUTUREHOUSE_API_KEY"),
+        "openscientist": ("OPENSCIENTIST_API_KEY",),
+        "openai": ("OPENAI_API_KEY",),
+        "perplexity": ("PERPLEXITY_API_KEY",),
+        "consensus": ("CONSENSUS_API_KEY",),
+        "cborg": ("CBORG_API_KEY",),
+    }
+    keys = credentials.get(provider, ())
+    if any(env.get(key) for key in keys):
+        return "available", "credential configured"
+    return "unavailable", f"set {' or '.join(keys)}"
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Provider profile must be a YAML mapping: {path}")
+    focuses = data.get("focuses")
+    if not isinstance(focuses, dict) or not focuses:
+        raise ValueError("Provider profile requires a non-empty 'focuses' mapping")
+    default_focus = data.get("default_focus")
+    if default_focus not in focuses:
+        raise ValueError(f"default_focus {default_focus!r} is not defined under focuses")
+    for focus_name, focus in focuses.items():
+        if not isinstance(focus, dict) or not isinstance(focus.get("stages"), dict):
+            raise ValueError(f"Focus {focus_name!r} requires a 'stages' mapping")
+        for stage_name, stage in focus["stages"].items():
+            if not isinstance(stage, dict):
+                raise ValueError(f"Stage {focus_name}.{stage_name} must be a mapping")
+            capabilities = stage.get("capabilities", {})
+            if not isinstance(capabilities, dict):
+                raise ValueError(f"Stage {focus_name}.{stage_name}.capabilities must be a mapping")
+        adjustments = focus.get("provider_adjustments")
+        if adjustments is not None:
+            if not isinstance(adjustments, dict):
+                raise ValueError(f"Focus {focus_name!r}.provider_adjustments must be a mapping")
+            canonical = {}
+            for raw_name, value in adjustments.items():
+                name = canonical_provider(str(raw_name))
+                if name not in PROVIDERS:
+                    raise ValueError(
+                        f"Focus {focus_name!r}.provider_adjustments names unknown "
+                        f"provider {raw_name!r} (resolved to {name!r}); "
+                        f"known providers: {', '.join(sorted(PROVIDERS))}"
+                    )
+                canonical[name] = value
+            focus["provider_adjustments"] = canonical
+    return data
+
+
+def _score(provider: Provider, stage: Mapping[str, Any], adjustments: Mapping[str, Any]) -> float:
+    capabilities = stage.get("capabilities", {})
+    score = sum(
+        float(weight)
+        for capability, weight in capabilities.items()
+        if capability in provider.capabilities
+    )
+    score += float(stage.get("synthesis_weight", 0)) * SYNTHESIS_VALUE[provider.synthesis]
+    score += float(stage.get("speed_weight", 0)) * (5 - TIME_VALUE[provider.time])
+    score += float(stage.get("cost_weight", 0)) * (5 - COST_VALUE[provider.cost])
+    score += float(adjustments.get(provider.name, 0))
+    return score
+
+
+def rank_stage(config: Mapping[str, Any], focus_name: str, stage_name: str) -> list[dict[str, Any]]:
+    focus = config["focuses"][focus_name]
+    stage = focus["stages"][stage_name]
+    adjustments = focus.get("provider_adjustments", {})
+    raw = {name: _score(provider, stage, adjustments) for name, provider in PROVIDERS.items()}
+    high = max(raw.values()) or 1.0
+    rows = []
+    for name, provider in PROVIDERS.items():
+        status, reason = provider_status(name)
+        rows.append(
+            {
+                "provider": name,
+                "label": provider.label,
+                "status": status,
+                "status_reason": reason,
+                "fit": round(100 * max(0.0, raw[name]) / high),
+                "cost": provider.cost,
+                "time": provider.time,
+                "synthesis": provider.synthesis,
+                "source_scope": provider.source_scope,
+                "best_for": provider.best_for,
+                "limitation": provider.limitation,
+            }
+        )
+    return sorted(rows, key=lambda row: (-row["fit"], row["provider"]))
+
+
+def build_report(config: Mapping[str, Any], focus_name: str) -> dict[str, Any]:
+    focus = config["focuses"][focus_name]
+    stages = []
+    for stage_name, stage in focus["stages"].items():
+        ranking = rank_stage(config, focus_name, stage_name)
+        available = [
+            row for row in ranking if row["status"] == "available" and row["provider"] != "mock"
+        ]
+        stages.append(
+            {
+                "name": stage_name,
+                "objective": stage.get("objective", ""),
+                "ranking": ranking,
+                "recommended_available": available[0] if available else None,
+                "fallback_available": available[1] if len(available) > 1 else None,
+            }
+        )
+    return {
+        "mech": config.get("mech", "Mech"),
+        "target": config.get("target", ""),
+        "focus": focus_name,
+        "focus_label": focus.get("label", focus_name),
+        "objective": focus.get("objective", ""),
+        "evidence_policy": config.get("evidence_policy", ""),
+        "source_priorities": focus.get("source_priorities", []),
+        "stages": stages,
+    }
+
+
+def _table(rows: list[dict[str, Any]]) -> str:
+    headers = ("Provider", "Status", "Fit", "Cost", "Time", "Synthesis", "Source scope")
+    values = [headers]
+    for row in rows:
+        values.append(
+            (
+                row["provider"],
+                row["status"],
+                str(row["fit"]),
+                row["cost"],
+                row["time"],
+                row["synthesis"],
+                row["source_scope"],
+            )
+        )
+    widths = [max(len(str(row[index])) for row in values) for index in range(len(headers))]
+    lines = ["  ".join(str(value).ljust(widths[index]) for index, value in enumerate(values[0]))]
+    lines.append("  ".join("-" * width for width in widths))
+    lines.extend(
+        "  ".join(str(value).ljust(widths[index]) for index, value in enumerate(row))
+        for row in values[1:]
+    )
+    return "\n".join(lines)
+
+
+def print_report(report: Mapping[str, Any], provider_name: str | None = None) -> None:
+    print(f"{report['mech']} deep-research provider triage")
+    print(f"Target: {report['target']}")
+    print(f"Focus: {report['focus']} — {report['focus_label']}")
+    print(f"Objective: {report['objective']}")
+    print(f"Evidence gate: {report['evidence_policy']}")
+    if report["source_priorities"]:
+        print("Source priorities: " + "; ".join(report["source_priorities"]))
+
+    for stage in report["stages"]:
+        print(f"\n[{stage['name']}] {stage['objective']}")
+        rows = stage["ranking"]
+        if provider_name:
+            rows = [row for row in rows if row["provider"] == provider_name]
+        print(_table(rows))
+        if provider_name and rows:
+            row = rows[0]
+            print(f"Best for: {row['best_for']}")
+            print(f"Limitation: {row['limitation']}")
+            print(f"Availability: {row['status_reason']}")
+        elif stage["recommended_available"]:
+            primary = stage["recommended_available"]
+            fallback = stage["fallback_available"]
+            message = f"Route now: {primary['provider']} ({primary['best_for']})"
+            if fallback:
+                message += f"; cross-check/fallback: {fallback['provider']}"
+            print(message)
+        else:
+            print(
+                "Route now: no real provider is currently available; configure a listed credential or CLI."
+            )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Mech provider profile YAML")
+    parser.add_argument(
+        "--focus", help="Research focus from the profile (default: profile default)"
+    )
+    parser.add_argument(
+        "--provider", help="Show one provider (aliases such as edison are accepted)"
+    )
+    parser.add_argument("--list-focuses", action="store_true", help="List domain-specific focuses")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable triage JSON")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    config = load_config(args.config)
+    if args.list_focuses:
+        for name, focus in config["focuses"].items():
+            marker = " (default)" if name == config["default_focus"] else ""
+            print(f"{name}{marker}: {focus.get('label', name)}")
+        return 0
+    focus_name = args.focus or config["default_focus"]
+    if focus_name not in config["focuses"]:
+        choices = ", ".join(config["focuses"])
+        raise ValueError(f"Unknown focus {focus_name!r}; choose one of: {choices}")
+    provider_name = canonical_provider(args.provider) if args.provider else None
+    if provider_name and provider_name not in PROVIDERS:
+        raise ValueError(
+            f"Unknown provider {args.provider!r}; choose one of: {', '.join(PROVIDERS)}"
+        )
+    report = build_report(config, focus_name)
+    if args.json:
+        if provider_name:
+            for stage in report["stages"]:
+                stage["ranking"] = [
+                    row for row in stage["ranking"] if row["provider"] == provider_name
+                ]
+                # recommended_available/fallback_available were computed by
+                # build_report() from the *unfiltered* ranking, so they can
+                # name a provider no longer present in the filtered ranking
+                # above — recompute both from the filtered set the same way
+                # build_report() does, instead of leaving stale, internally-
+                # inconsistent values in the JSON.
+                available = [
+                    row
+                    for row in stage["ranking"]
+                    if row["status"] == "available" and row["provider"] != "mock"
+                ]
+                stage["recommended_available"] = available[0] if available else None
+                stage["fallback_available"] = available[1] if len(available) > 1 else None
+        print(json.dumps(report, indent=2))
+    else:
+        print_report(report, provider_name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -226,6 +226,9 @@ PROVIDERS: dict[str, Provider] = {
 }
 
 ALIASES = {"edison": "falcon", "futurehouse": "falcon", "claude-code": "claude_code"}
+_ALL_CAPABILITIES = frozenset(
+    cap for provider in PROVIDERS.values() for cap in provider.capabilities
+)
 COST_VALUE = {"low": 1, "medium": 2, "high": 3, "very_high": 4}
 TIME_VALUE = {"fast": 1, "medium": 2, "slow": 3, "very_slow": 4}
 SYNTHESIS_VALUE = {"none": 0, "summary": 1, "deep": 2, "agentic": 3}
@@ -296,6 +299,13 @@ def load_config(path: Path) -> dict[str, Any]:
             capabilities = stage.get("capabilities", {})
             if not isinstance(capabilities, dict):
                 raise ValueError(f"Stage {focus_name}.{stage_name}.capabilities must be a mapping")
+            unknown_caps = set(capabilities) - _ALL_CAPABILITIES
+            if unknown_caps:
+                raise ValueError(
+                    f"Stage {focus_name}.{stage_name}.capabilities names unknown "
+                    f"capability/ies {sorted(unknown_caps)}; no provider declares "
+                    f"them, so they would silently score 0"
+                )
         adjustments = focus.get("provider_adjustments")
         if adjustments is not None:
             if not isinstance(adjustments, dict):
@@ -339,7 +349,14 @@ def rank_stage(config: Mapping[str, Any], focus_name: str, stage_name: str) -> l
     stage = focus["stages"][stage_name]
     adjustments = focus.get("provider_adjustments", {})
     raw = {name: _score(provider, stage, adjustments) for name, provider in PROVIDERS.items()}
-    high = max(raw.values()) or 1.0
+    # `or 1.0` only guards an exact-zero max; a large negative
+    # provider_adjustments value can push every score negative, leaving
+    # `high` negative too. Every fit then clamps to 0 (max(0.0, raw[name])
+    # below), collapsing the ranking to alphabetical order instead of the
+    # intended relative comparison. Guard the sign, not just falsiness.
+    high = max(raw.values())
+    if high <= 0:
+        high = 1.0
     rows = []
     for name, provider in PROVIDERS.items():
         status, reason = provider_status(name)

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "deep_research_provider.py"
+CONFIG_PATH = REPO_ROOT / "conf" / "deep_research_provider.yaml"
+SPEC = importlib.util.spec_from_file_location("deep_research_provider", MODULE_PATH)
+assert SPEC and SPEC.loader
+drp = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = drp
+SPEC.loader.exec_module(drp)
+
+
+def test_profile_has_domain_specific_default_and_three_stage_triage():
+    config = drp.load_config(CONFIG_PATH)
+    focus = config["focuses"][config["default_focus"]]
+
+    assert config["mech"].endswith("Mech")
+    assert config["target"]
+    assert set(focus["stages"]) == {"discovery", "synthesis", "verification"}
+    assert focus["source_priorities"]
+
+
+@pytest.mark.parametrize("alias", ["edison", "futurehouse", "Falcon"])
+def test_edison_aliases_resolve_to_falcon(alias):
+    assert drp.canonical_provider(alias) == "falcon"
+
+
+def test_falcon_platform_key_is_recognized_without_exposing_it():
+    status, reason = drp.provider_status("falcon", {"EDISON_PLATFORM_API_KEY": "secret"})
+    assert status == "available"
+    assert reason == "credential configured"
+    assert "secret" not in reason
+
+
+def test_explicit_empty_environment_does_not_fall_back_to_process_credentials():
+    status, reason = drp.provider_status("asta", {})
+    assert status == "unavailable"
+    assert reason == "set ASTA_API_KEY"
+
+
+def test_every_focus_ranks_all_real_and_stub_providers(monkeypatch):
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+
+    for focus_name in config["focuses"]:
+        report = drp.build_report(config, focus_name)
+        for stage in report["stages"]:
+            names = {row["provider"] for row in stage["ranking"]}
+            assert names == set(drp.PROVIDERS)
+            assert stage["recommended_available"] is not None
+            assert stage["recommended_available"]["status"] == "available"
+
+
+def test_unknown_default_focus_is_rejected(tmp_path):
+    profile = tmp_path / "bad.yaml"
+    profile.write_text("default_focus: absent\nfocuses:\n  present:\n    stages: {}\n")
+    with pytest.raises(ValueError, match="default_focus"):
+        drp.load_config(profile)
+
+
+def test_provider_adjustments_alias_key_is_canonicalized(tmp_path):
+    profile = tmp_path / "aliased.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      edison: 3\n"
+        "      Claude Code: 2\n"
+    )
+    config = drp.load_config(profile)
+    adjustments = config["focuses"]["f"]["provider_adjustments"]
+    assert adjustments == {"falcon": 3, "claude_code": 2}
+
+
+def test_provider_adjustments_unknown_key_is_rejected(tmp_path):
+    profile = tmp_path / "typo.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      flacon: 3\n"  # typo of "falcon"
+    )
+    with pytest.raises(ValueError, match="unknown provider"):
+        drp.load_config(profile)
+
+
+def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
+    """The canonicalization test above only checks the config-loading side;
+    this proves the bonus actually reaches the score — the exact silent-no-op
+    failure mode #487's review found."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    monkeypatch.setenv("CONSENSUS_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+
+    baseline = drp.rank_stage(config, focus_name, stage_name)
+    # Boost whichever provider ranks last, not a hardcoded name — a provider
+    # already at fit=100 (the ceiling) can't visibly increase, so the choice
+    # has to guarantee headroom regardless of this repo's specific weights.
+    target = min(baseline, key=lambda row: row["fit"])["provider"]
+    baseline_fit = {row["provider"]: row["fit"] for row in baseline}
+
+    config["focuses"][focus_name]["provider_adjustments"] = {target: 1000}
+    boosted = drp.rank_stage(config, focus_name, stage_name)
+    boosted_fit = {row["provider"]: row["fit"] for row in boosted}
+
+    assert boosted_fit[target] > baseline_fit[target]
+    assert boosted[0]["provider"] == target
+
+
+def test_json_provider_filter_keeps_recommended_and_fallback_consistent(capsys, monkeypatch):
+    """--json --provider must not leave recommended_available/fallback_available
+    naming a provider that isn't in the filtered ranking (#412 review)."""
+    monkeypatch.setenv("CONSENSUS_API_KEY", "test-only")
+    rc = drp.main(
+        [
+            "--config",
+            str(CONFIG_PATH),
+            "--focus",
+            next(iter(drp.load_config(CONFIG_PATH)["focuses"])),
+            "--provider",
+            "consensus",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    for stage in payload["stages"]:
+        ranking_providers = {row["provider"] for row in stage["ranking"]}
+        assert ranking_providers <= {"consensus"}
+        for key in ("recommended_available", "fallback_available"):
+            entry = stage[key]
+            if entry is not None:
+                assert entry["provider"] in ranking_providers

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -130,7 +130,7 @@ def test_main_rejects_unknown_focus_argument():
 def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
     """The canonicalization test above only checks the config-loading side;
     this proves the bonus actually reaches the score — the exact silent-no-op
-    failure mode #487's review found."""
+    failure mode proteintraitsmech#487's review found."""
     monkeypatch.setenv("ASTA_API_KEY", "test-only")
     monkeypatch.setenv("CONSENSUS_API_KEY", "test-only")
     config = drp.load_config(CONFIG_PATH)
@@ -154,7 +154,7 @@ def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
 
 def test_json_provider_filter_keeps_recommended_and_fallback_consistent(capsys, monkeypatch):
     """--json --provider must not leave recommended_available/fallback_available
-    naming a provider that isn't in the filtered ranking (#412 review)."""
+    naming a provider that isn't in the filtered ranking (mediaingredientmech#412 review)."""
     monkeypatch.setenv("CONSENSUS_API_KEY", "test-only")
     rc = drp.main(
         [

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -96,6 +96,37 @@ def test_provider_adjustments_unknown_key_is_rejected(tmp_path):
         drp.load_config(profile)
 
 
+def test_provider_adjustments_colliding_aliases_are_rejected(tmp_path):
+    """Two raw keys that canonicalize to the same provider (edison/falcon)
+    must not silently let the second overwrite the first."""
+    profile = tmp_path / "collision.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      edison: 3\n"
+        "      falcon: 5\n"
+    )
+    with pytest.raises(ValueError, match="multiple"):
+        drp.load_config(profile)
+
+
+def test_main_rejects_unknown_provider_argument():
+    focus = next(iter(drp.load_config(CONFIG_PATH)["focuses"]))
+    with pytest.raises(ValueError, match="Unknown provider"):
+        drp.main(
+            ["--config", str(CONFIG_PATH), "--focus", focus, "--provider", "not-a-real-provider"]
+        )
+
+
+def test_main_rejects_unknown_focus_argument():
+    with pytest.raises(ValueError, match="Unknown focus"):
+        drp.main(["--config", str(CONFIG_PATH), "--focus", "not-a-real-focus"])
+
+
 def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
     """The canonicalization test above only checks the config-loading side;
     this proves the bonus actually reaches the score — the exact silent-no-op

--- a/tests/test_scripts_import.py
+++ b/tests/test_scripts_import.py
@@ -57,11 +57,24 @@ _KNOWN_BROKEN: set[str] = set()
 # imports between these files resolve (`from scout_communities import ...`).
 # Loading the file without that made four scripts look broken when they are not —
 # the probe has to match how the thing is actually invoked.
+#
+# The probe module must also be registered in sys.modules before exec_module
+# runs, not just constructed via module_from_spec. Without it, a script that
+# defines a `from __future__ import annotations` dataclass (postponed string
+# annotations) crashes here: dataclasses._is_type does
+# `sys.modules.get(cls.__module__).__dict__` while checking for ClassVar/
+# InitVar, and cls.__module__ is '_probe' — a module that exists as an object
+# but was never actually stored in sys.modules, so .get() returns None and
+# .__dict__ raises. `python scripts/foo.py` (the real invocation path) doesn't
+# hit this: running as __main__ registers sys.modules['__main__'] for free.
+# Reproduced directly: deep_research_provider.py's frozen Provider dataclass
+# fails this probe without the registration and imports cleanly with it.
 _PROBE = (
     "import sys, importlib.util; "
     "sys.path.insert(0, {scripts!r}); "
     "spec = importlib.util.spec_from_file_location('_probe', {path!r}); "
     "mod = importlib.util.module_from_spec(spec); "
+    "sys.modules['_probe'] = mod; "
     "spec.loader.exec_module(mod)"
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ requires-dist = [
     { name = "biolink-model", marker = "extra == 'koza'", specifier = ">=3.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "deep-research-client", extras = ["cyberian"], marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.2.4" },
+    { name = "deep-research-client", extras = ["cyberian"], marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.2.10" },
     { name = "edison-client", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.11.0" },
     { name = "jinja2", specifier = ">=3.0.0" },
     { name = "koza", marker = "extra == 'koza'", specifier = ">=0.5.0" },
@@ -1086,7 +1086,7 @@ wheels = [
 
 [[package]]
 name = "deep-research-client"
-version = "0.2.4"
+version = "0.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles", marker = "python_full_version >= '3.12'" },
@@ -1101,9 +1101,9 @@ dependencies = [
     { name = "pyyaml", marker = "python_full_version >= '3.12'" },
     { name = "typer", marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/56c518effed8816846f1142ea8f255b8dd820cad49e784bdde8fb56f747d/deep_research_client-0.2.4.tar.gz", hash = "sha256:346b02199d55150fabf4ad4e5e50130402feeea53ae1f0fa8a3fa06fa7c937df", size = 2841153 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/12/4b3a45ed457fd425790548fa45fee646d55a3056050609ea6f0842c2b0d2/deep_research_client-0.2.10.tar.gz", hash = "sha256:8ff9acdb00e5d62a4d32ec2c0ca2321c5f322533feb0b7048a3e9f5872aea313", size = 2981327 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/f1/886c64cb54be55e0b675751b61fff0e9109ee538609c88aa8d02f34f179e/deep_research_client-0.2.4-py3-none-any.whl", hash = "sha256:70d9fd064a3306850a0a0209bb3a6953ac1b0c6edb655e4a07cf4a97cf001264", size = 116422 },
+    { url = "https://files.pythonhosted.org/packages/fa/2a/5b400831514c8e4c624c88696f715c3733a3b08c925292b46f4a845beae2/deep_research_client-0.2.10-py3-none-any.whl", hash = "sha256:79e4c721bf8aeb6e1aec81e210700c2107efa3f4cf12b62432f6170e3b484f0a", size = 186934 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Ports the fleet's generic deep-research provider-scoring implementation (`scripts/deep_research_provider.py`), completing work the `justfile` already assumed: `deep-research-providers`/`deep-research-provider` recipes referenced this script and `conf/deep_research_provider.yaml`, but neither was ever committed — **both recipes are currently broken on `main`**.
- `research_community.py` (the entity runner, plus `research-community-edison`/`research-community-causal`) was already in place and committed; this PR doesn't touch it.
- Two domain-specific focuses in `conf/deep_research_provider.yaml`:
  - `ecological_mechanism` — exact composition, directional interaction evidence between community members.
  - `datasets_environment` — repository-native accessions, ENVO context, cultivation and perturbation metadata.
- Bumps `deep-research-client` to `0.2.10`, matching the version pinned across CultureMech/TraitMech/MediaIngredientMech/ProteinTraitsMech.
- Carries two fixes from review rounds on the sibling ports (proteintraitsmech#487, MediaIngredientMech#412):
  - `provider_adjustments` keys are canonicalized and validated against known providers at config-load time.
  - `--json --provider X` recomputes `recommended_available`/`fallback_available` from the filtered ranking instead of leaving stale values from the unfiltered one.
- **Also fixes a latent, pre-existing bug** in `tests/test_scripts_import.py` (#410's import sweep — unrelated to deep-research otherwise): its subprocess probe built a module via `importlib.util.module_from_spec()` but never registered it in `sys.modules` before `exec_module()`. Any script defining a `from __future__ import annotations` frozen dataclass crashes there (`dataclasses._is_type` does `sys.modules.get(cls.__module__).__dict__` while checking for `ClassVar`/`InitVar`, and `cls.__module__` — `'_probe'` — was never actually stored in `sys.modules`). The real invocation path (`python scripts/foo.py`) doesn't hit this, since running as `__main__` registers `sys.modules['__main__']` for free. One-line fix; reproduced in isolation and mutation-tested.

## Test plan
- [x] Full `uv run pytest tests/` — 2523 passed, 89 skipped, 8 deselected (0 failed)
- [x] `black --check src/ tests/ scripts/`, `ruff check src/ tests/ scripts/`, `mypy src/` — all clean, matching `.github/workflows/lint.yaml` exactly
- [x] `uv sync --frozen --all-extras` — consistent
- [x] `scripts/check_vendored_sync.sh` — OK, unaffected
- [x] Mutation-tested the `provider_adjustments` fix, the `--json` filtering fix, and the `test_scripts_import.py` probe fix independently — each turns its corresponding test red when reverted
- [x] No provider was called; no research credits were spent

🤖 Generated with [Claude Code](https://claude.com/claude-code)