### PR TITLE
Three GTDB gates could not see kb/taxa, and pointing them at it was not enough (#656)

### DIFF
--- a/src/communitymech/paths.py
+++ b/src/communitymech/paths.py
@@ -36,6 +36,7 @@ REPORTS = REPO_ROOT / "reports"
 DOCS = REPO_ROOT / "docs"
 KB_COMMUNITIES = REPO_ROOT / "kb" / "communities"
 DATA_ISOLATES = REPO_ROOT / "data" / "isolates"
+KB_TAXA = REPO_ROOT / "kb" / "taxa"
 
 
 def default_record_roots() -> list[Path]:
@@ -53,6 +54,33 @@ def default_record_roots() -> list[Path]:
     copies that made the drift invisible.
     """
     return [KB_COMMUNITIES, DATA_ISOLATES]
+
+
+def taxon_descriptor_roots() -> list[Path]:
+    """Every directory whose records can carry a `TaxonDescriptor` (#656).
+
+    A superset of `default_record_roots()`, and a different question. That list
+    answers "where do `MicrobialCommunity` records live"; this one answers "where
+    can a `gtdb_classification` be", which the schema decides:
+
+        MicrobialCommunity.taxonomy[].taxon_term -> TaxonDescriptor
+        CommonTaxon.taxon_term                   -> TaxonDescriptor
+
+    and `TaxonDescriptor` carries `gtdb_grounding_status`, `gtdb_candidates` and
+    `gtdb_classification`. `CommonTaxon` records live in `kb/taxa`, so a GTDB
+    gate that sweeps only the community roots cannot see a grounding there.
+
+    Three such gates did exactly that, each with its own
+    `RECORD_DIRS = ("kb/communities", "data/isolates")`. It was harmless only by
+    accident: `kb/taxa` holds 2 records with 0 `gtdb_classification` blocks
+    today, so there was nothing to miss. The first taxon record to gain one would
+    have been skipped by all three, silently and with a clean report.
+
+    Kept separate from `default_record_roots()` rather than widening it: callers
+    that mean "community records" — the network auditor, `validate_strict` — must
+    not start sweeping a different root class by side effect.
+    """
+    return [KB_COMMUNITIES, DATA_ISOLATES, KB_TAXA]
 
 
 def looks_like_a_checkout() -> bool:

--- a/src/communitymech/taxon_blocks.py
+++ b/src/communitymech/taxon_blocks.py
@@ -1,0 +1,58 @@
+"""Every `TaxonDescriptor` in a record, whatever root class the record has (#656).
+
+The GTDB slots — `gtdb_grounding_status`, `gtdb_candidates`,
+`gtdb_classification` — live on `TaxonDescriptor`, and the schema hangs that
+class off two different roots:
+
+    MicrobialCommunity.taxonomy[].taxon_term   -> TaxonDescriptor
+    CommonTaxon.taxon_term                     -> TaxonDescriptor
+
+`CommonTaxon` records live in `kb/taxa` and carry `taxon_term` at the **top
+level**, with no `taxonomy` key at all.
+
+That difference made a directory fix insufficient in a way worth recording.
+Three GTDB gates each carried `RECORD_DIRS = ("kb/communities",
+"data/isolates")`; adding `kb/taxa` to that list looked like the whole fix and
+was not, because their walkers iterate `document["taxonomy"]` and a
+`CommonTaxon` has none. Planting a `NOT_ATTEMPTED` grounding in `kb/taxa` still
+produced a green run. A gate can be pointed at a directory and still be blind to
+everything in it.
+
+Interaction endpoints are included because `source_taxon`/`target_taxon` share
+`taxon_term`'s range, so the schema permits a grounding there too — the same
+reasoning `gtdb_lineage_tree._descriptors` documents. None exist today.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+
+def iter_taxon_descriptors(document: object) -> Iterator[dict]:
+    """Yield each `TaxonDescriptor` block in a parsed record.
+
+    Malformed nodes are skipped rather than raising: callers include gates that
+    sweep the whole corpus, where one bad record must not discard every other
+    record's findings (the #429 rule).
+    """
+    if not isinstance(document, dict):
+        return
+
+    # CommonTaxon: the descriptor is the record's own subject.
+    top_level = document.get("taxon_term")
+    if isinstance(top_level, dict):
+        yield top_level
+
+    # MicrobialCommunity: one descriptor per member.
+    for entry in document.get("taxonomy") or []:
+        if isinstance(entry, dict) and isinstance(entry.get("taxon_term"), dict):
+            yield entry["taxon_term"]
+
+    # Interaction endpoints share TaxonDescriptor's range.
+    for interaction in document.get("ecological_interactions") or []:
+        if not isinstance(interaction, dict):
+            continue
+        for role in ("source_taxon", "target_taxon"):
+            block = interaction.get(role)
+            if isinstance(block, dict):
+                yield block

--- a/tests/test_gtdb_grounding_freshness.py
+++ b/tests/test_gtdb_grounding_freshness.py
@@ -30,11 +30,19 @@ from pathlib import Path
 import pytest
 import yaml
 
+from communitymech.paths import taxon_descriptor_roots
+from communitymech.taxon_blocks import iter_taxon_descriptors
+
 REPO = Path(__file__).parent.parent
 # `data/isolates/` uses the same `taxonomy[].taxon_term` shape and carries no
 # grounding today, but a grounded isolate would otherwise slip past unseen — the
 # directory has been outside a gate's scope once already (#310).
-RECORD_DIRS = ("kb/communities", "data/isolates")
+# Where a gtdb_classification can be, taken from the schema rather than habit:
+# TaxonDescriptor carries the GTDB slots and hangs off BOTH
+# MicrobialCommunity.taxonomy[].taxon_term and CommonTaxon.taxon_term. CommonTaxon
+# records live in kb/taxa, which this list omitted -- harmlessly, but only because
+# kb/taxa holds 0 gtdb_classification blocks today (#656).
+RECORD_DIRS = tuple(str(p.relative_to(REPO)) for p in taxon_descriptor_roots())
 
 
 def _grounded_taxa():
@@ -43,10 +51,7 @@ def _grounded_taxa():
     paths = [p for d in RECORD_DIRS for p in sorted((REPO / d).glob("*.yaml"))]
     for path in paths:
         data = yaml.safe_load(path.read_text()) or {}
-        for taxon in data.get("taxonomy") or []:
-            if not isinstance(taxon, dict):
-                continue
-            term_block = taxon.get("taxon_term") or {}
+        for term_block in iter_taxon_descriptors(data):
             grounding = term_block.get("gtdb_classification")
             if not grounding:
                 continue

--- a/tests/test_gtdb_not_attempted.py
+++ b/tests/test_gtdb_not_attempted.py
@@ -55,8 +55,16 @@ import pathlib
 import pytest
 import yaml
 
+from communitymech.paths import taxon_descriptor_roots
+from communitymech.taxon_blocks import iter_taxon_descriptors
+
 REPO = pathlib.Path(__file__).parent.parent
-RECORD_DIRS = ("kb/communities", "data/isolates")
+# Where a gtdb_classification can be, taken from the schema rather than habit:
+# TaxonDescriptor carries the GTDB slots and hangs off BOTH
+# MicrobialCommunity.taxonomy[].taxon_term and CommonTaxon.taxon_term. CommonTaxon
+# records live in kb/taxa, which this list omitted -- harmlessly, but only because
+# kb/taxa holds 0 gtdb_classification blocks today (#656).
+RECORD_DIRS = tuple(str(p.relative_to(REPO)) for p in taxon_descriptor_roots())
 
 # (record, preferred_term) -> why it stays ungrounded.
 HELD = {
@@ -98,8 +106,7 @@ def _entry(record: str, preferred: str) -> dict:
         if not path.exists():
             continue
         document = yaml.safe_load(path.read_text()) or {}
-        for item in document.get("taxonomy") or []:
-            block = (item or {}).get("taxon_term") or {}
+        for block in iter_taxon_descriptors(document):
             if block.get("preferred_term") == preferred:
                 return block
     raise AssertionError(f"{preferred!r} is gone from {record}")
@@ -149,8 +156,7 @@ def test_no_taxon_is_silently_outstanding():
     for directory in RECORD_DIRS:
         for path in sorted((REPO / directory).glob("*.yaml")):
             document = yaml.safe_load(path.read_text()) or {}
-            for item in document.get("taxonomy") or []:
-                block = (item or {}).get("taxon_term") or {}
+            for block in iter_taxon_descriptors(document):
                 if block.get("gtdb_grounding_status") != "NOT_ATTEMPTED":
                     continue
                 key = (path.name, block.get("preferred_term"))

--- a/tests/test_gtdb_uncurated_blocks_match_the_tool.py
+++ b/tests/test_gtdb_uncurated_blocks_match_the_tool.py
@@ -34,8 +34,16 @@ import pathlib
 import pytest
 import yaml
 
+from communitymech.paths import taxon_descriptor_roots
+from communitymech.taxon_blocks import iter_taxon_descriptors
+
 REPO = pathlib.Path(__file__).parent.parent
-RECORD_DIRS = ("kb/communities", "data/isolates")
+# Where a gtdb_classification can be, taken from the schema rather than habit:
+# TaxonDescriptor carries the GTDB slots and hangs off BOTH
+# MicrobialCommunity.taxonomy[].taxon_term and CommonTaxon.taxon_term. CommonTaxon
+# records live in kb/taxa, which this list omitted -- harmlessly, but only because
+# kb/taxa holds 0 gtdb_classification blocks today (#656).
+RECORD_DIRS = tuple(str(p.relative_to(REPO)) for p in taxon_descriptor_roots())
 
 
 @pytest.fixture(scope="module")
@@ -63,8 +71,7 @@ def _grounded_taxa():
     for directory in RECORD_DIRS:
         for path in sorted((REPO / directory).glob("*.yaml")):
             document = yaml.safe_load(path.read_text()) or {}
-            for entry in document.get("taxonomy") or []:
-                block = (entry or {}).get("taxon_term") or {}
+            for block in iter_taxon_descriptors(document):
                 grounding = block.get("gtdb_classification")
                 term = block.get("term")
                 if not isinstance(grounding, dict) or not isinstance(term, dict):
@@ -142,8 +149,7 @@ def test_every_curated_block_says_why():
     for directory in RECORD_DIRS:
         for path in sorted((REPO / directory).glob("*.yaml")):
             document = yaml.safe_load(path.read_text()) or {}
-            for entry in document.get("taxonomy") or []:
-                block = (entry or {}).get("taxon_term") or {}
+            for block in iter_taxon_descriptors(document):
                 grounding = block.get("gtdb_classification")
                 if not isinstance(grounding, dict):
                     continue

--- a/tests/test_record_roots_are_shared.py
+++ b/tests/test_record_roots_are_shared.py
@@ -33,7 +33,7 @@ import pathlib
 import pytest
 import yaml
 
-from communitymech.paths import default_record_roots
+from communitymech.paths import default_record_roots, taxon_descriptor_roots
 
 REPO = pathlib.Path(__file__).parent.parent
 WORKFLOW = REPO / ".github/workflows/network-quality.yml"
@@ -190,3 +190,58 @@ def test_no_constructor_hardcodes_the_old_root():
         "`default_record_roots()` at the call site and silently narrows what "
         "gets audited (#350, #521):\n" + "\n".join(offenders)
     )
+
+
+def test_the_gtdb_gates_sweep_every_root_a_grounding_can_live_in():
+    """A GTDB gate that skips a root reports clean on what it never read (#656).
+
+    Three gates carried their own `RECORD_DIRS = ("kb/communities",
+    "data/isolates")`. The schema does not agree: `gtdb_classification` lives on
+    `TaxonDescriptor`, which hangs off `CommonTaxon.taxon_term` as well as
+    `MicrobialCommunity.taxonomy[].taxon_term`, and `CommonTaxon` records live in
+    `kb/taxa`. The omission was invisible because `kb/taxa` holds no groundings
+    yet — so the gates found nothing either way.
+
+    Asserted positively, on the value each module computes, rather than by
+    grepping for the old literal: a file that stopped defining `RECORD_DIRS`
+    entirely would pass a negative check.
+    """
+    import importlib.util
+
+    expected = tuple(str(p.relative_to(REPO)) for p in taxon_descriptor_roots())
+    modules = (
+        "test_gtdb_grounding_freshness",
+        "test_gtdb_not_attempted",
+        "test_gtdb_uncurated_blocks_match_the_tool",
+    )
+    wrong = {}
+    for name in modules:
+        spec = importlib.util.spec_from_file_location(name, REPO / f"tests/{name}.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        actual = tuple(getattr(module, "RECORD_DIRS", ()))
+        if actual != expected:
+            wrong[name] = actual
+
+    assert not wrong, (
+        f"these GTDB gates do not sweep every root a grounding can live in. "
+        f"Expected {expected}, got {wrong}. Use `taxon_descriptor_roots()` (#656)."
+    )
+
+
+def test_the_two_root_lists_stay_distinct():
+    """Widening `default_record_roots()` would be the wrong fix (#656).
+
+    `kb/taxa` holds `CommonTaxon`, not `MicrobialCommunity`. Callers that mean
+    community records — the network auditor, `validate_strict` — must not begin
+    sweeping a different root class because a GTDB gate needed a wider list.
+    """
+    community = default_record_roots()
+    descriptor = taxon_descriptor_roots()
+
+    assert (REPO / "kb/taxa") not in community, (
+        "`default_record_roots()` now includes kb/taxa, which holds CommonTaxon "
+        "records; the network auditor and validate_strict would sweep a root "
+        "class they do not model"
+    )
+    assert set(community) < set(descriptor), "the descriptor roots must be a strict superset"


### PR DESCRIPTION
Closes #656

## The decision, settled on the schema

#656 asked whether the GTDB tests should include `kb/taxa`. The schema answers it: `gtdb_classification` lives on `TaxonDescriptor`, and that class hangs off **both** roots —

```
MicrobialCommunity.taxonomy[].taxon_term  -> TaxonDescriptor
CommonTaxon.taxon_term                    -> TaxonDescriptor
```

`CommonTaxon` records live in `kb/taxa`. So a GTDB gate must sweep it, and the three carrying `RECORD_DIRS = ("kb/communities", "data/isolates")` were wrong — harmlessly, because `kb/taxa` holds 2 records with **0** groundings today. The first taxon record to gain one would have been skipped by all three, silently, with a clean report.

## Two lists, not one widened list

`taxon_descriptor_roots()` is added **alongside** `default_record_roots()`, not in place of it. They answer different questions — *"where do `MicrobialCommunity` records live"* versus *"where can a grounding be"* — and the network auditor and `validate_strict` must not start sweeping a different root class by side effect. A test pins that they stay distinct and that one is a strict superset.

## The part worth reading

**Widening the directory list looked like the whole fix and was not.**

Those walkers iterate `document["taxonomy"]`, and a `CommonTaxon` has no such key — its `taxon_term` sits at the top level. With `RECORD_DIRS` already widened, I planted a `NOT_ATTEMPTED` grounding in `kb/taxa` and the gate **still passed**:

```
=== M3: does a planted GTDB block in kb/taxa now get seen? ===
 planted NOT_ATTEMPTED in kb/taxa
9 passed
```

A gate can be pointed at a directory and remain blind to everything in it. Had I stopped at `RECORD_DIRS`, the consolidation test would have passed, the PR would have looked complete, and the gap would have been exactly as open as before — with a test now asserting it was closed.

`iter_taxon_descriptors()` handles both roots plus interaction endpoints (which share `TaxonDescriptor`'s range, the same reasoning `gtdb_lineage_tree._descriptors` already documents). Rewired, the planted grounding fails:

```
FAILED tests/test_gtdb_not_attempted.py::test_no_taxon_is_silently_outstanding
```

That failure is what demonstrates the fix — not the `RECORD_DIRS` value being right.

## Scope

Five other GTDB test modules walk `taxonomy` directly but sweep only `kb/communities`, so they are internally consistent and untouched. The validators' own `_descriptors` helpers likewise run under `default_record_roots()`. Converging those is a larger change than #656 asked for.

## Verification

Mutation-checked three ways, each failing its own test and not the others:
- reverting one gate to the literal → consolidation test fails
- widening `default_record_roots()` → distinctness and workflow-trigger tests fail
- planting a `kb/taxa` grounding → the gate it was blind to fails

lint 0 · validate-all 0 · validate-strict 0 · check-docs-current 0 · **2589 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
