### PR TITLE
Fix Edison sidecar provenance, drop malformed citation sidecar, KNOWN_BLOCKED provider

### DIFF
--- a/scripts/_edison_capture.py
+++ b/scripts/_edison_capture.py
@@ -166,7 +166,6 @@ def _safe_model_dump(obj: Any) -> Any:
             try:
                 return obj.model_dump()
             except Exception:
-                # Best-effort serialisation: fall through to __dict__ below.
                 pass
     if hasattr(obj, "__dict__"):
         return {k: _safe_model_dump(v) for k, v in obj.__dict__.items() if not k.startswith("_")}
@@ -399,14 +398,19 @@ def capture_full_response(
     answer_reasoning = _get_attr(response, "answer_reasoning")
     body = formatted_answer or answer or "(no answer field on this job's response type)"
     md_path.write_text(body)
+    # Track what THIS invocation wrote, so the meta reports its own provenance
+    # rather than whatever a previous run of the same stem left on disk.
+    written: set[str] = {"answer_md"}
 
     # Full raw response dump (every SDK field, future-proof)
     response_dump = _safe_model_dump(response)
     response_json_path.write_text(json.dumps(response_dump, indent=2, default=str))
+    written.add("response_json")
 
     # Citations sidecar
     citations = parse_citations(formatted_answer or answer)
     citations_md_path.write_text(render_citations_md(citations, query=query))
+    written.add("citations_md")
 
     # Verbose + files via secondary fetches (no extra billing)
     task_id = str(_get_attr(response, "task_id") or "")
@@ -428,11 +432,13 @@ def capture_full_response(
                     default=str,
                 )
             )
+            written.add("agent_state_json")
 
     files_listing = _try_list_files(client, task_id) if task_id else None
     artifacts_manifest: list[dict[str, Any]] = []
     if files_listing is not None:
         files_path.write_text(json.dumps(_safe_model_dump(files_listing), indent=2, default=str))
+        written.add("files_json")
         # Pull the actual content of named curation artifacts (small,
         # not internal PaperQA pickles) into a sibling artifacts/ dir.
         artifacts_manifest = fetch_named_artifacts(
@@ -466,7 +472,7 @@ def capture_full_response(
             "answer_reasoning_chars": len(answer_reasoning or ""),
             "citations_parsed": len(citations),
             "query_sha256": query_sha256(query),
-            "sidecar_files": _existing_sidecars(out_dir, stem),
+            "sidecar_files": _existing_sidecars(out_dir, stem, written),
             "artifacts_fetched": [a for a in artifacts_manifest if a.get("status") == "fetched"],
             "artifacts_skipped": [a for a in artifacts_manifest if a.get("status") != "fetched"],
         }
@@ -499,15 +505,34 @@ def capture_dry_run(
     return meta
 
 
-def _existing_sidecars(out_dir: Path, stem: str) -> dict[str, bool]:
-    """Snapshot which sidecar files exist for this stem — for the meta."""
-    return {
+def _existing_sidecars(
+    out_dir: Path, stem: str, written: set[str] | None = None
+) -> dict[str, bool]:
+    """Which sidecars this invocation produced for this stem.
+
+    The stem is deterministic (``{slug}-edison-{job}``), so a re-run of the same
+    record and job finds the previous run's files already on disk. Reporting a
+    plain ``.exists()`` snapshot therefore attributed a prior task's trace to the
+    new ``task_id`` whenever the new run failed to fetch it — for a feature whose
+    whole point is provenance, an auditor following the meta would read the wrong
+    trajectory.
+
+    Pass ``written`` (the keys this run actually wrote) to report truthfully. It
+    is optional so the call sites that genuinely want a disk snapshot keep
+    working — ``enrich_edison_response`` backfills sidecars for the *same*
+    ``task_id`` already recorded in the meta, so for it "what is on disk now" is
+    the honest answer.
+    """
+    on_disk = {
         "answer_md": (out_dir / f"{stem}.md").exists(),
         "response_json": (out_dir / f"{stem}-response.json").exists(),
         "citations_md": (out_dir / f"{stem}-citations.md").exists(),
         "agent_state_json": (out_dir / f"{stem}-agent-state.json").exists(),
         "files_json": (out_dir / f"{stem}-files.json").exists(),
     }
+    if written is None:
+        return on_disk
+    return {key: (key in written and value) for key, value in on_disk.items()}
 
 
 def _to_iso(dt: Any) -> str | None:

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -346,10 +346,16 @@ def load_config(path: Path) -> dict[str, Any]:
                     f"them, so they would silently score 0. Known capabilities: "
                     f"{', '.join(sorted(_ALL_CAPABILITIES))}"
                 )
-        adjustments = focus.get("provider_adjustments")
-        if adjustments is not None:
-            if not isinstance(adjustments, dict):
-                raise ValueError(f"Focus {focus_name!r}.provider_adjustments must be a mapping")
+        # .get(key, {}) only supplies the default when the key is ABSENT — an
+        # explicit YAML `provider_adjustments: null` still returns None here,
+        # so this isinstance check (unconditional, like the sibling
+        # `capabilities` check above) must run either way, not be skipped by
+        # an `is not None` guard (which let a null block crash later in
+        # rank_stage/_score with AttributeError instead of this ValueError).
+        adjustments = focus.get("provider_adjustments", {})
+        if not isinstance(adjustments, dict):
+            raise ValueError(f"Focus {focus_name!r}.provider_adjustments must be a mapping")
+        if adjustments:
             canonical: dict[str, Any] = {}
             for raw_name, value in adjustments.items():
                 name = canonical_provider(str(raw_name))

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -239,8 +239,47 @@ def canonical_provider(name: str) -> str:
     return ALIASES.get(key, key)
 
 
+# Providers whose credential is configurable but which do not actually work, with
+# what happened when each was called (#284). A credential check cannot discover
+# this: "Available" in `deep-research-client providers` means an env var is set,
+# nothing more. Without this table the triage tool recommended `falcon` as the
+# primary route for every stage while the justfile beside it recorded that falcon
+# returns HTTP 402 — the tool contradicting its own documentation (#290).
+#
+# Remove an entry when the provider is verified working again, rather than
+# editing the reason.
+KNOWN_BLOCKED: dict[str, str] = {
+    "falcon": "HTTP 402 Payment Required (measured #284)",
+    "cyberian": "HTTP 500; wraps an agentapi service that is not running (#284)",
+}
+
+# Costs that count as "paid" for --no-paid. `medium` is deliberately NOT here:
+# claude_code is the medium-cost provider, and keeping it is usually the point of
+# asking for no paid providers in the first place.
+PAID_COSTS = frozenset({"high", "very_high"})
+
+
 def provider_status(provider: str, environ: Mapping[str, str] | None = None) -> tuple[str, str]:
-    """Return status and a safe explanation without exposing credential values."""
+    """Whether this provider can actually be routed to, and why.
+
+    A measured-dead provider reports `blocked` however well its credential is
+    configured — that is the whole point, since a configured credential is what
+    made `falcon` look routable while returning HTTP 402. Credential recognition
+    is still a separate, testable question: see `credential_status`.
+    """
+    if provider in KNOWN_BLOCKED:
+        return "blocked", KNOWN_BLOCKED[provider]
+    return credential_status(provider, environ)
+
+
+def credential_status(provider: str, environ: Mapping[str, str] | None = None) -> tuple[str, str]:
+    """Status from local configuration alone, ignoring whether the provider works.
+
+    Kept separate from `provider_status` so "do we recognise this env var name"
+    stays covered for providers that are currently blocked — otherwise adding a
+    provider to KNOWN_BLOCKED would silently drop the test that its credential
+    aliases are spelled right.
+    """
     env = os.environ if environ is None else environ
     if provider == "deeper_med":
         return "stub", "no public API"
@@ -304,13 +343,14 @@ def load_config(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"Stage {focus_name}.{stage_name}.capabilities names unknown "
                     f"capability/ies {sorted(unknown_caps)}; no provider declares "
-                    f"them, so they would silently score 0"
+                    f"them, so they would silently score 0. Known capabilities: "
+                    f"{', '.join(sorted(_ALL_CAPABILITIES))}"
                 )
         adjustments = focus.get("provider_adjustments")
         if adjustments is not None:
             if not isinstance(adjustments, dict):
                 raise ValueError(f"Focus {focus_name!r}.provider_adjustments must be a mapping")
-            canonical = {}
+            canonical: dict[str, Any] = {}
             for raw_name, value in adjustments.items():
                 name = canonical_provider(str(raw_name))
                 if name not in PROVIDERS:
@@ -349,11 +389,15 @@ def rank_stage(config: Mapping[str, Any], focus_name: str, stage_name: str) -> l
     stage = focus["stages"][stage_name]
     adjustments = focus.get("provider_adjustments", {})
     raw = {name: _score(provider, stage, adjustments) for name, provider in PROVIDERS.items()}
-    # `or 1.0` only guards an exact-zero max; a large negative
-    # provider_adjustments value can push every score negative, leaving
-    # `high` negative too. Every fit then clamps to 0 (max(0.0, raw[name])
-    # below), collapsing the ranking to alphabetical order instead of the
-    # intended relative comparison. Guard the sign, not just falsiness.
+    # `or 1.0` only replaces an exact-zero max (e.g. every raw score landing
+    # at precisely 0 through cancelling adjustments) — a real, if rare, case
+    # this guards. It does NOT fix the harder case where every score is
+    # negative: fit is 0/high either way there (0.0 divided by any nonzero
+    # number is 0.0), so the ranking still collapses to alphabetical order
+    # once every candidate is "actively bad" rather than merely "not the
+    # best." That needs a different normalization (e.g. min-max instead of
+    # max-only) and is a real design decision, not a one-line fix — see
+    # CultureMech#315.
     high = max(raw.values())
     if high <= 0:
         high = 1.0
@@ -378,14 +422,36 @@ def rank_stage(config: Mapping[str, Any], focus_name: str, stage_name: str) -> l
     return sorted(rows, key=lambda row: (-row["fit"], row["provider"]))
 
 
-def build_report(config: Mapping[str, Any], focus_name: str) -> dict[str, Any]:
+def recommendable(
+    rows: list[dict[str, Any]], *, allow: frozenset[str] | None = None, no_paid: bool = False
+) -> list[dict[str, Any]]:
+    """The rows a recommendation may be drawn from, in ranked order.
+
+    One place, so the text and JSON paths cannot disagree — the JSON filter used
+    to narrow `ranking` while leaving `recommended_available` untouched, so
+    `--provider asta --json` recommended `claude_code` out of a document whose
+    only ranked provider was asta (#290).
+    """
+    out = [row for row in rows if row["status"] == "available" and row["provider"] != "mock"]
+    if allow is not None:
+        out = [row for row in out if row["provider"] in allow]
+    if no_paid:
+        out = [row for row in out if row["cost"] not in PAID_COSTS]
+    return out
+
+
+def build_report(
+    config: Mapping[str, Any],
+    focus_name: str,
+    *,
+    allow: frozenset[str] | None = None,
+    no_paid: bool = False,
+) -> dict[str, Any]:
     focus = config["focuses"][focus_name]
     stages = []
     for stage_name, stage in focus["stages"].items():
         ranking = rank_stage(config, focus_name, stage_name)
-        available = [
-            row for row in ranking if row["status"] == "available" and row["provider"] != "mock"
-        ]
+        available = recommendable(ranking, allow=allow, no_paid=no_paid)
         stages.append(
             {
                 "name": stage_name,
@@ -476,6 +542,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--list-focuses", action="store_true", help="List domain-specific focuses")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable triage JSON")
+    parser.add_argument(
+        "--allow",
+        help="Comma-separated allowlist; only these providers may be recommended",
+    )
+    parser.add_argument(
+        "--no-paid",
+        action="store_true",
+        help=f"Never recommend a provider whose cost is {' or '.join(sorted(PAID_COSTS))}",
+    )
     return parser.parse_args(argv)
 
 
@@ -496,26 +571,27 @@ def main(argv: list[str] | None = None) -> int:
         raise ValueError(
             f"Unknown provider {args.provider!r}; choose one of: {', '.join(PROVIDERS)}"
         )
-    report = build_report(config, focus_name)
+    allow = (
+        frozenset(canonical_provider(p) for p in args.allow.split(",") if p.strip())
+        if args.allow
+        else None
+    )
+    if allow is not None:
+        unknown = allow - set(PROVIDERS)
+        if unknown:
+            raise ValueError(f"Unknown provider(s) in --allow: {', '.join(sorted(unknown))}")
+    report = build_report(config, focus_name, allow=allow, no_paid=args.no_paid)
     if args.json:
         if provider_name:
             for stage in report["stages"]:
                 stage["ranking"] = [
                     row for row in stage["ranking"] if row["provider"] == provider_name
                 ]
-                # recommended_available/fallback_available were computed by
-                # build_report() from the *unfiltered* ranking, so they can
-                # name a provider no longer present in the filtered ranking
-                # above — recompute both from the filtered set the same way
-                # build_report() does, instead of leaving stale, internally-
-                # inconsistent values in the JSON.
-                available = [
-                    row
-                    for row in stage["ranking"]
-                    if row["status"] == "available" and row["provider"] != "mock"
-                ]
-                stage["recommended_available"] = available[0] if available else None
-                stage["fallback_available"] = available[1] if len(available) > 1 else None
+                # Recompute from what survived, so the document cannot recommend a
+                # provider absent from its own ranking (#290).
+                kept = recommendable(stage["ranking"], allow=allow, no_paid=args.no_paid)
+                stage["recommended_available"] = kept[0] if kept else None
+                stage["fallback_available"] = kept[1] if len(kept) > 1 else None
         print(json.dumps(report, indent=2))
     else:
         print_report(report, provider_name)

--- a/scripts/research_community.py
+++ b/scripts/research_community.py
@@ -214,7 +214,6 @@ def build_command(
     provider: str,
     template: Path,
     output_file: Path,
-    citations_file: Path,
     variables: dict[str, str],
     passthrough_args: list[str],
     client_command: str = "deep-research-client",
@@ -230,10 +229,17 @@ def build_command(
     command.extend(provider_args(provider))
     command.extend(
         [
+            # NO --separate-citations. The client builds that sidecar with a
+            # regex over the report prose, and it is malformed: TraitMech's
+            # #249 found 353 sidecars with 194 broken markdown-link tails,
+            # 2,770 stray trailing commas, and 332 of 353 duplicating a
+            # reference two or three times; CultureMech's own single sample
+            # re-emitted the ~55-line rendered prompt as "Query" and listed
+            # one DOI three times over. The report's own References section
+            # is the trustworthy artifact — see CultureMech's
+            # docs/RESEARCH_ARTIFACT_CONTRACT.md.
             "--output",
             str(output_file),
-            "--separate-citations",
-            str(citations_file),
         ]
     )
     command.extend(passthrough_args)
@@ -267,13 +273,11 @@ def main(argv: list[str] | None = None) -> int:
 
     output_dir = args.research_dir / "communities"
     output_file = output_dir / f"{community_file.stem}-deep-research-{args.provider}.md"
-    citations_file = output_file.with_suffix(output_file.suffix + ".citations.md")
     variables = template_vars(doc, community_file)
     command = build_command(
         provider=args.provider,
         template=args.template,
         output_file=output_file,
-        citations_file=citations_file,
         variables=variables,
         passthrough_args=args.passthrough_args,
         client_command=args.client_command,

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -103,6 +103,26 @@ def test_provider_adjustments_alias_key_is_canonicalized(tmp_path):
     assert adjustments == {"falcon": 3, "claude_code": 2}
 
 
+def test_provider_adjustments_explicit_null_is_rejected(tmp_path):
+    """focus.get("provider_adjustments", {}) only supplies the {} default
+    when the key is absent — an explicit YAML `provider_adjustments: null`
+    still returns None, which used to skip validation entirely (guarded
+    behind `if adjustments is not None:`) and crash later in
+    rank_stage/_score with AttributeError instead of this clean
+    ValueError."""
+    profile = tmp_path / "nulladj.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments: null\n"
+    )
+    with pytest.raises(ValueError, match="provider_adjustments must be a mapping"):
+        drp.load_config(profile)
+
+
 def test_provider_adjustments_unknown_key_is_rejected(tmp_path):
     profile = tmp_path / "typo.yaml"
     profile.write_text(

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -219,7 +219,7 @@ def test_exact_zero_max_score_does_not_divide_by_zero(monkeypatch):
 # --- policy and machine-readable consistency (#290) ------------------------
 
 
-def test_a_measured_dead_provider_is_not_recommended():
+def test_a_measured_dead_provider_is_not_recommended(monkeypatch):
     """The tool used to contradict the justfile beside it.
 
     #284 measured falcon returning HTTP 402 and cyberian HTTP 500, and recorded
@@ -231,11 +231,23 @@ def test_a_measured_dead_provider_is_not_recommended():
     assert "402" in reason
     assert "secret" not in reason
 
+    # Exercise the override end-to-end through rank_stage/build_report, not
+    # just the direct provider_status() call above. With no credentials set
+    # at all every provider is "unavailable" and recommended_available is
+    # None for an unrelated reason, making an assertion against
+    # build_report() vacuous unless falcon is actually made
+    # "available"-but-blocked here.
+    monkeypatch.setenv("EDISON_API_KEY", "test-only")
     config = drp.load_config(CONFIG_PATH)
     report = drp.build_report(config, config["default_focus"])
     for stage in report["stages"]:
-        recommended = stage["recommended_available"]
-        assert recommended is None or recommended["provider"] not in drp.KNOWN_BLOCKED
+        falcon_row = next(row for row in stage["ranking"] if row["provider"] == "falcon")
+        assert falcon_row["status"] == "blocked"
+        # Checking recommended_available's None-or-not-blocked would still
+        # pass vacuously if nothing else happens to be available either —
+        # assert against recommendable() directly instead, which has no
+        # None-branch escape hatch.
+        assert "falcon" not in {row["provider"] for row in drp.recommendable(stage["ranking"])}
 
 
 def test_provider_filtered_json_never_recommends_a_provider_it_did_not_rank(monkeypatch):

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -306,6 +306,22 @@ def test_an_allowlist_confines_the_recommendation(monkeypatch):
         assert len(stage["ranking"]) == len(drp.PROVIDERS)
 
 
+def test_recommendable_allow_actually_excludes_a_disallowed_row():
+    """test_an_allowlist_confines_the_recommendation above can pass even with
+    --allow filtering fully removed, if the ambient environment never makes
+    a genuinely disallowed provider available. This exercises
+    recommendable() directly against a hand-built row set that guarantees a
+    disallowed candidate is in contention."""
+    rows = [
+        {"provider": "in_scope", "status": "available", "cost": "low"},
+        {"provider": "out_of_scope", "status": "available", "cost": "low"},
+    ]
+    unfiltered = drp.recommendable(rows)
+    filtered = drp.recommendable(rows, allow=frozenset({"in_scope"}))
+    assert {r["provider"] for r in unfiltered} == {"in_scope", "out_of_scope"}
+    assert {r["provider"] for r in filtered} == {"in_scope"}
+
+
 def test_an_unknown_provider_in_the_allowlist_is_rejected():
     with pytest.raises(ValueError, match="Unknown provider"):
         drp.main(["--config", str(CONFIG_PATH), "--allow", "not_a_provider"])

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -16,6 +16,18 @@ sys.modules[SPEC.name] = drp
 SPEC.loader.exec_module(drp)
 
 
+def _run_json(extra):
+    """Run main() with --json and return the parsed document."""
+    import contextlib
+    import io
+    import json
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        drp.main(["--config", str(CONFIG_PATH), "--json", *extra])
+    return json.loads(buf.getvalue())
+
+
 def test_profile_has_domain_specific_default_and_three_stage_triage():
     config = drp.load_config(CONFIG_PATH)
     focus = config["focuses"][config["default_focus"]]
@@ -32,7 +44,14 @@ def test_edison_aliases_resolve_to_falcon(alias):
 
 
 def test_falcon_platform_key_is_recognized_without_exposing_it():
-    status, reason = drp.provider_status("falcon", {"EDISON_PLATFORM_API_KEY": "secret"})
+    """Credential RECOGNITION, asked of `credential_status`.
+
+    `provider_status` now reports falcon as blocked whatever the credential says
+    (#290), so this has to ask the lower-level question or adding a provider to
+    KNOWN_BLOCKED would silently drop the check that its env-var aliases are
+    spelled right.
+    """
+    status, reason = drp.credential_status("falcon", {"EDISON_PLATFORM_API_KEY": "secret"})
     assert status == "available"
     assert reason == "credential configured"
     assert "secret" not in reason
@@ -62,6 +81,9 @@ def test_unknown_default_focus_is_rejected(tmp_path):
     profile.write_text("default_focus: absent\nfocuses:\n  present:\n    stages: {}\n")
     with pytest.raises(ValueError, match="default_focus"):
         drp.load_config(profile)
+
+
+# --- provider_adjustments / capabilities validation -------------------------
 
 
 def test_provider_adjustments_alias_key_is_canonicalized(tmp_path):
@@ -114,33 +136,30 @@ def test_provider_adjustments_colliding_aliases_are_rejected(tmp_path):
         drp.load_config(profile)
 
 
-def test_main_rejects_unknown_provider_argument():
-    focus = next(iter(drp.load_config(CONFIG_PATH)["focuses"]))
-    with pytest.raises(ValueError, match="Unknown provider"):
-        drp.main(
-            ["--config", str(CONFIG_PATH), "--focus", focus, "--provider", "not-a-real-provider"]
-        )
-
-
-def test_main_rejects_unknown_focus_argument():
-    with pytest.raises(ValueError, match="Unknown focus"):
-        drp.main(["--config", str(CONFIG_PATH), "--focus", "not-a-real-focus"])
+def test_stage_capabilities_unknown_key_is_rejected(tmp_path):
+    profile = tmp_path / "badcap.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        capabilities:\n"
+        "          acadmic_search: 5\n"  # typo of "academic_search"
+    )
+    with pytest.raises(ValueError, match="unknown capability"):
+        drp.load_config(profile)
 
 
 def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
-    """The canonicalization test above only checks the config-loading side;
-    this proves the bonus actually reaches the score — the exact silent-no-op
-    failure mode proteintraitsmech#487's review found."""
+    """Config-loading validation alone doesn't prove the bonus reaches the
+    ranking — this proves it does."""
     monkeypatch.setenv("ASTA_API_KEY", "test-only")
-    monkeypatch.setenv("CONSENSUS_API_KEY", "test-only")
     config = drp.load_config(CONFIG_PATH)
     focus_name = config["default_focus"]
     stage_name = next(iter(config["focuses"][focus_name]["stages"]))
 
     baseline = drp.rank_stage(config, focus_name, stage_name)
-    # Boost whichever provider ranks last, not a hardcoded name — a provider
-    # already at fit=100 (the ceiling) can't visibly increase, so the choice
-    # has to guarantee headroom regardless of this repo's specific weights.
     target = min(baseline, key=lambda row: row["fit"])["provider"]
     baseline_fit = {row["provider"]: row["fit"] for row in baseline}
 
@@ -152,29 +171,92 @@ def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
     assert boosted[0]["provider"] == target
 
 
-def test_json_provider_filter_keeps_recommended_and_fallback_consistent(capsys, monkeypatch):
-    """--json --provider must not leave recommended_available/fallback_available
-    naming a provider that isn't in the filtered ranking (mediaingredientmech#412 review)."""
-    monkeypatch.setenv("CONSENSUS_API_KEY", "test-only")
-    rc = drp.main(
-        [
-            "--config",
-            str(CONFIG_PATH),
-            "--focus",
-            next(iter(drp.load_config(CONFIG_PATH)["focuses"])),
-            "--provider",
-            "consensus",
-            "--json",
-        ]
-    )
-    assert rc == 0
-    import json
+def test_exact_zero_max_score_does_not_divide_by_zero(monkeypatch):
+    """`high = max(raw.values()); if high <= 0: high = 1.0` exists to guard
+    an exact-zero max (every raw score landing at 0, e.g. through cancelling
+    adjustments) from a ZeroDivisionError. It does NOT make the ranking
+    meaningful when every score is negative — that's CultureMech#315, a
+    separate, harder problem (0.0 divided by any nonzero number, positive or
+    negative, is still 0.0, so this guard is a no-op for the negative case).
+    This test covers only what the guard actually does."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    # Zero out every capability weight and adjustment so every raw score is
+    # exactly 0.0 — the precise edge case `or 1.0` was written for.
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+    config["focuses"][focus_name]["provider_adjustments"] = {}
 
-    payload = json.loads(capsys.readouterr().out)
-    for stage in payload["stages"]:
-        ranking_providers = {row["provider"] for row in stage["ranking"]}
-        assert ranking_providers <= {"consensus"}
-        for key in ("recommended_available", "fallback_available"):
-            entry = stage[key]
-            if entry is not None:
-                assert entry["provider"] in ranking_providers
+    rows = drp.rank_stage(config, focus_name, stage_name)  # must not raise ZeroDivisionError
+    assert all(row["fit"] == 0 for row in rows)
+
+
+# --- policy and machine-readable consistency (#290) ------------------------
+
+
+def test_a_measured_dead_provider_is_not_recommended():
+    """The tool used to contradict the justfile beside it.
+
+    #284 measured falcon returning HTTP 402 and cyberian HTTP 500, and recorded
+    both in the provider table. The triage tool still routed every stage to
+    falcon, because "available" only ever meant "an env var is set".
+    """
+    status, reason = drp.provider_status("falcon", {"EDISON_API_KEY": "secret"})
+    assert status == "blocked"
+    assert "402" in reason
+    assert "secret" not in reason
+
+    config = drp.load_config(CONFIG_PATH)
+    report = drp.build_report(config, config["default_focus"])
+    for stage in report["stages"]:
+        recommended = stage["recommended_available"]
+        assert recommended is None or recommended["provider"] not in drp.KNOWN_BLOCKED
+
+
+def test_provider_filtered_json_never_recommends_a_provider_it_did_not_rank(monkeypatch):
+    """`--provider asta --json` recommended claude_code out of a document whose
+    only ranked provider was asta. The human path took a different branch, so
+    only machine consumers saw it."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    out = _run_json(["--provider", "asta"])
+    for stage in out["stages"]:
+        ranked = {row["provider"] for row in stage["ranking"]}
+        assert ranked == {"asta"}
+        recommended = stage["recommended_available"]
+        assert recommended is None or recommended["provider"] in ranked
+        fallback = stage["fallback_available"]
+        assert fallback is None or fallback["provider"] in ranked
+
+
+def test_no_paid_keeps_the_medium_cost_provider(monkeypatch):
+    """`medium` is not "paid" here: claude_code is the medium-cost provider and
+    keeping it is the point of asking."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    report = drp.build_report(config, config["default_focus"], no_paid=True)
+    for stage in report["stages"]:
+        recommended = stage["recommended_available"]
+        if recommended:
+            assert recommended["cost"] not in drp.PAID_COSTS
+
+
+def test_an_allowlist_confines_the_recommendation(monkeypatch):
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    report = drp.build_report(config, config["default_focus"], allow=frozenset({"asta"}))
+    for stage in report["stages"]:
+        recommended = stage["recommended_available"]
+        assert recommended is None or recommended["provider"] == "asta"
+        # The full ranking is still reported — the allowlist bounds the
+        # RECOMMENDATION, it does not hide what else exists.
+        assert len(stage["ranking"]) == len(drp.PROVIDERS)
+
+
+def test_an_unknown_provider_in_the_allowlist_is_rejected():
+    with pytest.raises(ValueError, match="Unknown provider"):
+        drp.main(["--config", str(CONFIG_PATH), "--allow", "not_a_provider"])

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -260,3 +260,13 @@ def test_an_allowlist_confines_the_recommendation(monkeypatch):
 def test_an_unknown_provider_in_the_allowlist_is_rejected():
     with pytest.raises(ValueError, match="Unknown provider"):
         drp.main(["--config", str(CONFIG_PATH), "--allow", "not_a_provider"])
+
+
+def test_main_rejects_unknown_provider_argument():
+    with pytest.raises(ValueError, match="Unknown provider"):
+        drp.main(["--config", str(CONFIG_PATH), "--provider", "not-a-real-provider"])
+
+
+def test_main_rejects_unknown_focus_argument():
+    with pytest.raises(ValueError, match="Unknown focus"):
+        drp.main(["--config", str(CONFIG_PATH), "--focus", "not-a-real-focus"])

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -277,6 +277,23 @@ def test_no_paid_keeps_the_medium_cost_provider(monkeypatch):
             assert recommended["cost"] not in drp.PAID_COSTS
 
 
+def test_recommendable_no_paid_actually_excludes_a_high_cost_row():
+    """The test above can pass even with no_paid filtering fully removed, if
+    the ambient environment never makes a genuinely paid provider available.
+    This exercises recommendable() directly against a hand-built row set that
+    guarantees a high-cost candidate is in contention, so the filter has
+    something real to exclude."""
+    rows = [
+        {"provider": "cheap", "status": "available", "cost": "low"},
+        {"provider": "midpriced", "status": "available", "cost": "medium"},
+        {"provider": "pricey", "status": "available", "cost": "very_high"},
+    ]
+    with_paid = drp.recommendable(rows, no_paid=False)
+    without_paid = drp.recommendable(rows, no_paid=True)
+    assert {r["provider"] for r in with_paid} == {"cheap", "midpriced", "pricey"}
+    assert {r["provider"] for r in without_paid} == {"cheap", "midpriced"}
+
+
 def test_an_allowlist_confines_the_recommendation(monkeypatch):
     monkeypatch.setenv("ASTA_API_KEY", "test-only")
     config = drp.load_config(CONFIG_PATH)

--- a/tests/test_edison_capture_sidecar_provenance.py
+++ b/tests/test_edison_capture_sidecar_provenance.py
@@ -1,0 +1,214 @@
+"""Tests that ``sidecar_files`` describes THIS Edison run, not the directory.
+
+Edison output stems are deterministic — ``{slug}-edison-{job}`` — so re-running
+the same medium and job writes into a directory that already holds the previous
+run's sidecars. ``capture_full_response`` used to report ``sidecar_files`` from a
+plain ``.exists()`` sweep of that directory, which meant a fresh run that failed
+to fetch the agent-state trace still reported ``agent_state_json: true`` next to
+its own new ``task_id``. An auditor following the meta would open the previous
+task's trajectory believing it belonged to the new one (#288).
+
+The fix records which keys the invocation actually wrote. These tests pin that
+behaviour, and pin the deliberate escape hatch: ``_existing_sidecars`` without a
+written-set still returns a disk snapshot, because ``enrich_edison_response``
+backfills sidecars for the *same* ``task_id`` already in the meta.
+
+No Edison client is constructed and no credits are spent — the response is a
+stub object and ``client=None`` exercises the "verbose fetch skipped" path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_module():
+    path = REPO_ROOT / "scripts" / "_edison_capture.py"
+    spec = importlib.util.spec_from_file_location("_edison_capture", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_edison_capture"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def ec():
+    return _load_module()
+
+
+class _StubResponse:
+    """Minimal stand-in for the SDK response object.
+
+    Only the attributes ``capture_full_response`` reads are defined; anything
+    else falls through ``getattr(..., default)`` as it would for a job type that
+    does not carry the field.
+    """
+
+    def __init__(self, task_id: str, answer: str = "new answer"):
+        self.task_id = task_id
+        self.answer = answer
+        self.formatted_answer = f"{answer}\n\nReferences\n\n1. doe2020paper pages 1-2\n"
+        self.status = "success"
+        self.has_successful_answer = True
+
+
+STEM = "archaeoglobus_medium_dsm_399-edison-literature"
+
+# The sidecars a *previous*, fully successful run of the same stem left behind.
+PRIOR_RUN_FILES = {
+    f"{STEM}.md": "old answer",
+    f"{STEM}-response.json": '{"task_id": "task-OLD"}',
+    f"{STEM}-citations.md": "# Citations\n",
+    f"{STEM}-agent-state.json": '{"task_id": "task-OLD", "agent_state": []}',
+    f"{STEM}-files.json": "[]",
+}
+
+
+@pytest.fixture
+def prior_run_dir(tmp_path: Path) -> Path:
+    for name, body in PRIOR_RUN_FILES.items():
+        (tmp_path / name).write_text(body)
+    return tmp_path
+
+
+def test_stale_sidecars_are_not_attributed_to_the_new_task(ec, prior_run_dir):
+    """The regression: a rerun that fetches neither trace reports neither.
+
+    ``client=None`` is how a run behaves when the verbose fetch and
+    ``list_files`` are skipped, so nothing rewrites the agent-state or files
+    sidecars — yet both are sitting on disk from ``task-OLD``.
+    """
+    meta = ec.capture_full_response(
+        response=_StubResponse("task-NEW"),
+        client=None,
+        out_dir=prior_run_dir,
+        stem=STEM,
+        query="q",
+        base_meta={"slug": "archaeoglobus_medium_dsm_399"},
+    )
+
+    assert meta["task_id"] == "task-NEW"
+    assert meta["sidecar_files"] == {
+        # written by this invocation, unconditionally
+        "answer_md": True,
+        "response_json": True,
+        "citations_md": True,
+        # left over from task-OLD — must not be claimed by task-NEW
+        "agent_state_json": False,
+        "files_json": False,
+    }
+
+    # The stale files themselves are left alone; only the claim about them
+    # changes. Deleting them would destroy the earlier run's evidence.
+    assert (prior_run_dir / f"{STEM}-agent-state.json").exists()
+    assert (
+        json.loads((prior_run_dir / f"{STEM}-agent-state.json").read_text())["task_id"]
+        == "task-OLD"
+    )
+
+
+def test_sidecars_this_run_did_write_are_reported_true(ec, prior_run_dir):
+    """The fix must not simply report False for everything it did not fetch.
+
+    A client that answers both secondary fetches makes this run the author of
+    all five sidecars, and the meta should say so even though five files of the
+    same names were already present.
+    """
+
+    class _Client:
+        def get_task(self, task_id, verbose=False):  # noqa: ARG002
+            return type(
+                "V",
+                (),
+                {"agent_state": [{"tool": "search"}], "environment_frame": None, "metadata": None},
+            )()
+
+        def list_files(self, trajectory_id):  # noqa: ARG002
+            return []
+
+    meta = ec.capture_full_response(
+        response=_StubResponse("task-NEW"),
+        client=_Client(),
+        out_dir=prior_run_dir,
+        stem=STEM,
+        query="q",
+        base_meta={},
+    )
+
+    assert meta["sidecar_files"] == dict.fromkeys(
+        ["answer_md", "response_json", "citations_md", "agent_state_json", "files_json"],
+        True,
+    )
+    # ...and the rewritten trace really is the new task's.
+    assert (
+        json.loads((prior_run_dir / f"{STEM}-agent-state.json").read_text())["task_id"]
+        == "task-NEW"
+    )
+
+
+def test_empty_output_dir_reports_only_what_was_written(ec, tmp_path):
+    """First run of a stem: no prior files, so the two unfetched keys are False
+    for the ordinary reason rather than the stale-file reason."""
+    meta = ec.capture_full_response(
+        response=_StubResponse("task-FIRST"),
+        client=None,
+        out_dir=tmp_path / "nested",
+        stem=STEM,
+        query="q",
+        base_meta={},
+    )
+    assert meta["sidecar_files"]["answer_md"] is True
+    assert meta["sidecar_files"]["agent_state_json"] is False
+
+
+def test_written_set_cannot_claim_a_file_that_is_absent(ec, tmp_path):
+    """Belt-and-braces: the report is an AND of "we wrote it" and "it is there".
+
+    A key in the written set whose file never materialised (a failed write, a
+    later unlink) must still report False, so the meta never points at a path
+    that does not exist.
+    """
+    assert ec._existing_sidecars(tmp_path, STEM, {"answer_md", "files_json"}) == {
+        "answer_md": False,
+        "response_json": False,
+        "citations_md": False,
+        "agent_state_json": False,
+        "files_json": False,
+    }
+
+
+def test_omitting_the_written_set_still_snapshots_the_disk(ec, prior_run_dir):
+    """The ``enrich_edison_response`` contract.
+
+    Backfill runs against the ``task_id`` already stored in the meta, so "what
+    is on disk for this stem" is the truthful answer there and must not regress
+    to the written-set semantics.
+    """
+    assert ec._existing_sidecars(prior_run_dir, STEM) == dict.fromkeys(
+        ["answer_md", "response_json", "citations_md", "agent_state_json", "files_json"],
+        True,
+    )
+
+
+def test_dry_run_reports_no_sidecars_at_all(ec, prior_run_dir):
+    """A dry run spends nothing and authors nothing, so it must not inherit the
+    previous run's sidecar claims — ``capture_dry_run`` omits the key entirely
+    rather than reporting a directory snapshot."""
+    meta = ec.capture_dry_run(
+        out_dir=prior_run_dir,
+        stem=STEM,
+        query="rendered prompt",
+        base_meta={"slug": "archaeoglobus_medium_dsm_399"},
+    )
+    assert meta["status"] == "dry-run"
+    assert "sidecar_files" not in meta
+    assert "task_id" not in meta
+    # and it must not have overwritten the earlier run's answer
+    assert (prior_run_dir / f"{STEM}.md").read_text() == "old answer"

--- a/tests/test_research_community.py
+++ b/tests/test_research_community.py
@@ -51,10 +51,6 @@ def test_build_command_for_falcon_research():
         output_file=Path(
             "research/communities/Yogurt_TwoSpecies_Starter_Culture-deep-research-falcon.md"
         ),
-        citations_file=Path(
-            "research/communities/"
-            "Yogurt_TwoSpecies_Starter_Culture-deep-research-falcon.md.citations.md"
-        ),
         variables={
             "community_name": "Yogurt Two-Species Starter Culture",
             "community_id": "CommunityMech:000164",
@@ -69,7 +65,11 @@ def test_build_command_for_falcon_research():
     ]
     assert "--provider" in command
     assert "falcon" in command
-    assert "--separate-citations" in command
+    # NO --separate-citations: the client's regex-based sidecar is malformed
+    # (see build_command's docstring comment / CultureMech's
+    # docs/RESEARCH_ARTIFACT_CONTRACT.md). The report's own References
+    # section is the trustworthy artifact.
+    assert "--separate-citations" not in command
     assert command[-2:] == ["--max-cost", "1"]
     assert not any("test-key" in arg for arg in command)
 


### PR DESCRIPTION
## Summary
Three fixes, closing #641 and addressing part of #658:

1. **`scripts/_edison_capture.py`**: `capture_full_response`'s `sidecar_files` provenance block used a plain `.exists()` sweep of the output directory. Edison output stems are deterministic, so a rerun of the same record/job lands in a directory already holding the previous run's sidecars — a rerun whose verbose fetch or `list_files` call fails wrote `agent_state_json: true` into a meta stamped with a **new** `task_id`, pointing at a trace belonging to the **old** one. Ported TraitMech's fix (via CultureMech#291's canonical, now-tested implementation): track which keys the invocation actually wrote, report the AND of "we wrote it" and "it is on disk". `enrich_edison_response`'s disk-snapshot call site is unchanged, and a test now pins why it's allowed to differ.
2. **`scripts/research_community.py`**: dropped `--separate-citations`. That sidecar is a regex over the report prose, not structured provider output, and it's malformed — TraitMech's #249 found 353 sidecars with 194 broken markdown-link tails, 2,770 stray trailing commas, and 332 of 353 duplicating a reference. The report's own References section is the trustworthy artifact.
3. **`scripts/deep_research_provider.py`**: brought to parity with **CultureMech#285**'s canonical copy (`KNOWN_BLOCKED` provider table, `--allow`/`--no-paid`, the `recommendable()` helper, duplicate-alias guard) — same change landing in proteintraitsmech#514 and MediaIngredientMech#418. (An earlier revision of this description cited CultureMech#317, which is a separate, unrelated open PR — corrected per review.)

This PR does **not** fully close #658: its second acceptance criterion ("either this script is in the vendored-sync contract, or a documented decision explains why it deliberately is not") is still open. That's a fleet-wide sharing-model decision (CultureMech#287 explicitly deferred it until real copies existed somewhere — they now do, across 5 repos) and is out of scope for this PR; #658 stays open to track it.

## Test plan
- [x] 6 new regression tests for the Edison fix, ported from CultureMech#291 (no Edison client constructed, no credits spent — response is a stub, `client=None` exercises the skipped-fetch path)
- [x] Mutation-tested: reverting only the `sidecar_files` source line turns `test_stale_sidecars_are_not_attributed_to_the_new_task` red
- [x] Full `uv run pytest tests/` — 2553 passed, 89 skipped, 8 deselected, 0 failed
- [x] `black --check`/`ruff check`/`mypy src/` all clean
- [x] No provider was called; no research credits were spent

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)