### PR TITLE
Harden check_vendored_sync.sh curl calls against transient failures

### DIFF
--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -44,7 +44,7 @@ checked=0
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || { echo "MISSING: $f not present locally"; fail=1; continue; }
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${f}"
-  if ! curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "$url" -o "$tmp"; then
+  if ! curl -fsSL --max-time 10 --retry 2 --retry-delay 1 --retry-max-time 15 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $f from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
   # byte-exact comparison (temp file preserves the trailing newline that $() would strip)
@@ -61,7 +61,7 @@ for entry in "${MAPPED[@]}"; do
   for cand in $glob; do [ -f "$cand" ] && local="$cand" && break; done
   if [ -z "$local" ]; then echo "MISSING: no local file matching $glob"; fail=1; continue; fi
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${hubf}"
-  if ! curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "$url" -o "$tmp"; then
+  if ! curl -fsSL --max-time 10 --retry 2 --retry-delay 1 --retry-max-time 15 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $hubf from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
   if ! cmp -s "$tmp" "$local"; then

--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -44,7 +44,7 @@ checked=0
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || { echo "MISSING: $f not present locally"; fail=1; continue; }
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${f}"
-  if ! curl -fsSL "$url" -o "$tmp"; then
+  if ! curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $f from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
   # byte-exact comparison (temp file preserves the trailing newline that $() would strip)
@@ -61,7 +61,7 @@ for entry in "${MAPPED[@]}"; do
   for cand in $glob; do [ -f "$cand" ] && local="$cand" && break; done
   if [ -z "$local" ]; then echo "MISSING: no local file matching $glob"; fail=1; continue; fi
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${hubf}"
-  if ! curl -fsSL "$url" -o "$tmp"; then
+  if ! curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $hubf from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
   if ! cmp -s "$tmp" "$local"; then

--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -44,6 +44,12 @@ checked=0
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || { echo "MISSING: $f not present locally"; fail=1; continue; }
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${f}"
+  # --max-time bounds each fetch (curl has no default timeout and would hang
+  # indefinitely on a stalled connection). Deliberately NOT using curl's own
+  # --retry/--retry-max-time here: --retry-max-time only gates starting a new
+  # attempt, not an in-flight one, so combined with the calling workflow's own
+  # outer retry loop the worst case could exceed the job's timeout. Retries
+  # live in the outer loop only.
   if ! curl -fsSL --max-time 10 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $f from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
@@ -61,6 +67,12 @@ for entry in "${MAPPED[@]}"; do
   for cand in $glob; do [ -f "$cand" ] && local="$cand" && break; done
   if [ -z "$local" ]; then echo "MISSING: no local file matching $glob"; fail=1; continue; fi
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${hubf}"
+  # --max-time bounds each fetch (curl has no default timeout and would hang
+  # indefinitely on a stalled connection). Deliberately NOT using curl's own
+  # --retry/--retry-max-time here: --retry-max-time only gates starting a new
+  # attempt, not an in-flight one, so combined with the calling workflow's own
+  # outer retry loop the worst case could exceed the job's timeout. Retries
+  # live in the outer loop only.
   if ! curl -fsSL --max-time 10 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $hubf from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi

--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -44,7 +44,7 @@ checked=0
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || { echo "MISSING: $f not present locally"; fail=1; continue; }
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${f}"
-  if ! curl -fsSL --max-time 10 --retry 2 --retry-delay 1 --retry-max-time 15 "$url" -o "$tmp"; then
+  if ! curl -fsSL --max-time 10 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $f from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
   # byte-exact comparison (temp file preserves the trailing newline that $() would strip)
@@ -61,7 +61,7 @@ for entry in "${MAPPED[@]}"; do
   for cand in $glob; do [ -f "$cand" ] && local="$cand" && break; done
   if [ -z "$local" ]; then echo "MISSING: no local file matching $glob"; fail=1; continue; fi
   url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${hubf}"
-  if ! curl -fsSL --max-time 10 --retry 2 --retry-delay 1 --retry-max-time 15 "$url" -o "$tmp"; then
+  if ! curl -fsSL --max-time 10 "$url" -o "$tmp"; then
     echo "ERROR: could not fetch $hubf from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
   fi
   if ! cmp -s "$tmp" "$local"; then


### PR DESCRIPTION
## Summary
Propagates culturebotai-claw#88's hardening of the canonical \`check_vendored_sync.sh\` (CultureMech#298): adds \`--max-time 10\` to both \`curl\` calls, bounding each fetch instead of letting it hang indefinitely.

**Retry history**: an earlier revision of this PR (and the canonical claw source) also added \`--retry\`/\`--retry-delay\`/\`--retry-max-time\` flags. dynamic-review caught that curl's \`--retry-max-time\` only gates the *decision* to start a new retry, not an in-flight attempt — so the worst case still exceeded this workflow's 5-minute job timeout once combined with \`vendored-sync.yaml\`'s own outer 3-attempt/5s-backoff retry loop (which already exists to handle transient failures across whole script invocations). Final fix drops \`--retry\` entirely: \`--max-time 10\` alone, relying on the outer loop for retries.

Does **not** add the \`history.yaml\` MAPPED entry the canonical copy now carries — \`scripts/.vendored_canon_ref\` here still pins a hub commit (\`6be694f3\`) that predates \`history.yaml\` existing in the hub, so the entry would 404 rather than catch real drift. This repo's local \`history.yaml\` is currently byte-identical to the hub's current copy regardless. Tracked separately: #670.

## Test plan
- [x] \`bash scripts/check_vendored_sync.sh\` — "OK: all 6 vendored files match"