### PR TITLE
Fix repository safety, test, documentation, and CI contracts

### DIFF
--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -43,7 +43,8 @@ jobs:
           fetch-depth: 0   # need the merge base to diff against
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
 

--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -43,10 +43,12 @@ jobs:
           fetch-depth: 0   # need the merge base to diff against
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.5"
 
       - name: Install deps
-        run: uv sync
+        run: uv sync --frozen
 
       - name: Validate history records (blocking)
         run: |

--- a/.github/workflows/docs-current.yaml
+++ b/.github/workflows/docs-current.yaml
@@ -59,9 +59,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs-current.yaml
+++ b/.github/workflows/docs-current.yaml
@@ -59,7 +59,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
           enable-cache: true

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -73,7 +73,8 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
           enable-cache: true

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -73,9 +73,9 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
           enable-cache: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,9 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/network-quality.yml
+++ b/.github/workflows/network-quality.yml
@@ -69,12 +69,12 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.5"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --all-extras
 
       # `--report` writes the detailed report *and* signals the outcome through
       # its exit code, so one invocation gives us both the artifact and the
@@ -305,12 +305,12 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.5"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --frozen --all-extras
 
       - name: Fail early if the API key is missing
         if: env.HAS_ANTHROPIC_KEY != 'true'

--- a/.github/workflows/network-quality.yml
+++ b/.github/workflows/network-quality.yml
@@ -69,7 +69,8 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
 
@@ -305,7 +306,8 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
 

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -51,7 +51,8 @@ jobs:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
           enable-cache: true
@@ -96,7 +97,8 @@ jobs:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        # setup-uv v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           version: "0.12.5"
           enable-cache: true

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -8,6 +8,9 @@ on:
       # budget, and it matched no workflow filter — so the guard added in #358
       # would not have run on it. Same shape as the data/isolates gap below.
       - "prompts/**"
+      # Provider ranking is executable configuration covered by pytest. A
+      # config-only PR must run the same tests as its Python implementation.
+      - "conf/deep_research_provider.yaml"
       # data/isolates carries CommunityMech ids too. It was outside every
       # workflow's paths filter, which is half of why four ids ended up used
       # twice (#310) — editing an isolate has to re-run the uniqueness gate.
@@ -48,9 +51,9 @@ jobs:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
 
       - name: Install dependencies
@@ -78,3 +81,28 @@ jobs:
             reports/instance_validation_failures.tsv
             reports/pipeline_writers_audit.tsv
           if-no-files-found: warn
+
+  # The primary gate above stays on the minimum supported Python because it also
+  # runs the expensive corpus validators. This lane runs the complete test suite
+  # on a modern interpreter without doubling those sweeps (#667).
+  python-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.5"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run tests
+        run: uv run pytest tests/ -q --no-cov

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -91,6 +91,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The full suite includes repository-contract tests that inspect recipes
+      # through `just --show`; keep this lane equivalent to validate-strict.
+      - uses: extractions/setup-just@v3
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,88 +1,207 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Operational guidance for Claude Code and other coding agents working in this
+repository.
 
-## Project Overview
+## Project model
 
-CommunityMech is a LinkML-based knowledge base for modeling microbial community structure, function, and ecological interactions. Community data lives as curated YAML files in `kb/communities/` (312 files), each validated against a LinkML schema. Every claim is evidence-backed with PMID/DOI references and snippet validation against abstracts.
+CommunityMech is a LinkML knowledge base for microbial community composition,
+ecological interactions, cultivation, environments, and evidence. Curated YAML
+is the canonical record format. Validators, Python models, HTML, and KGX files
+are derived products.
 
-Adapted from Monarch Initiative's dismech: YAML is the source of truth, with lossy Koza transforms planned for KG export.
+The repository currently runs as a source checkout. `communitymech.paths`
+anchors the KB, reference cache, reports, and generated site to the checkout.
+Do not assume an installed wheel has those repository data paths; the long-term
+packaging decision is tracked in issue #668.
 
-## Commands
+Before changing anything:
+
+- Read any applicable `AGENTS.md` plus this file.
+- Inspect `git status` and preserve unrelated or uncommitted user work.
+- Work in a dedicated branch/worktree for multi-file changes.
+- Never read, print, modify, or commit `.env` or credential values.
+- Do not make network calls, spend provider credits, or apply generated curation
+  unless the task authorizes it.
+
+## Canonical and generated files
+
+| Path | Role | Editing rule |
+|---|---|---|
+| `src/communitymech/schema/communitymech.yaml` | Main LinkML schema | Edit first for model changes |
+| `src/communitymech/schema/mech_shared.yaml` | Shared discussion types | Keep synchronized with its canonical source |
+| `src/communitymech/schema/history.yaml` | Vendored history schema | Do not diverge casually from shared tooling |
+| `src/communitymech/datamodel/communitymech.py` | Generated Python model | Never hand-edit; run `just gen-python` |
+| `kb/communities/` | Canonical community records | Root class `MicrobialCommunity` |
+| `data/isolates/` | Additional community records | Root class `MicrobialCommunity` |
+| `kb/taxa/` | Reusable taxon/gene records | Root class `CommonTaxon` |
+| `references_cache/` | Committed evidence source text | Preserve source/provenance boundaries |
+| `history/` | Append-only curation provenance | Never revise old history entries |
+| `src/communitymech/templates/` | HTML templates | Regenerate committed HTML after edits |
+| `docs/` | Published GitHub Pages tree and guides | Do not hand-edit generated community pages |
+| `scripts/` | Repository curation utilities | Not part of the public package API |
+
+The generated datamodel and published HTML are tracked. `just clean` must never
+delete them.
+
+## Environment
+
+- Core package and validation: Python 3.10+.
+- Deep research and Edison: Python 3.12+.
+- Package/environment manager: `uv`; do not add `requirements.txt`.
+- Task runner: `just`.
+- Style: Black and Ruff, line length 100.
+- Static typing: mypy over `src/`.
+
+Install development dependencies with:
 
 ```bash
-just install              # Install deps (uv sync --extra dev)
-just test                 # Run pytest
-just validate FILE        # Validate one YAML against schema
-just validate-all         # Validate all community YAMLs
-just validate-references FILE  # Check evidence references (PubMed snippets)
-just qc                   # Full QC: lint + test + every offline validator
-just qc-references        # qc + the literature sweep (network; fails on main, #417)
-just gen-python           # Regenerate datamodel from schema
-just format               # black + ruff --fix
-just lint                 # black --check + ruff + mypy
+just install
 ```
 
-`validate-references` is not a CI gate and does not pass on `main` — most cited
-DOIs resolve to no fetchable content (#259) and some snippets paraphrase rather
-than quote (#347). It is out of `qc` on purpose: `just` stops at the first
-failing dependency, so having it there meant `lint` and `test` never ran (#417).
+Several optional repository commands use modules from a sibling
+`culturebotai-claw` checkout. They resolve `CLAW_SRC`, defaulting to
+`../../culturebotai-claw/src`, and fail loudly when it is absent. These include
+`just gen-qc-dashboard`, `just knowledge-gap-scan`,
+`just gen-discussions-data`, and `just new-history`.
 
-Single test: `uv run pytest tests/test_datamodel.py::test_name -v`
+## Schema and ontology invariants
 
-## Architecture
+- Change `src/communitymech/schema/communitymech.yaml`, then run
+  `just gen-python`. Never patch the generated datamodel directly.
+- Taxa use NCBITaxon; environments use ENVO; chemicals/metabolites use CHEBI;
+  biological processes use GO; anatomy uses UBERON; cells use CL; experimental
+  concepts may use OBI.
+- Ontology values use `{id, label}` pairs. The `label` is the canonical ontology
+  label; curator wording belongs in `preferred_term` or notes.
+- A pairwise ecological interaction normally names source and target taxa from
+  the record taxonomy. Community-level interactions use `scope` and optionally
+  `participating_taxa`.
+- `kb/taxa` has a different root class and therefore needs the dedicated taxon
+  validation recipes.
 
+## Evidence policy
+
+Every curated claim should have evidence at the assertion it supports. This is
+a curation policy, not a blanket schema guarantee: taxonomy, interaction, and
+environment evidence lists are optional in LinkML. Schema validity alone does
+not prove evidence completeness.
+
+An `EvidenceItem` requires:
+
+- a stable `PMID:`, `doi:`, or supported dataset reference;
+- `supports`;
+- `evidence_source`;
+- an exact supporting `snippet`.
+
+Reference validation can match against committed abstracts, cached open-access
+full text, and separately cached supplementary text. Do not paraphrase a
+snippet, combine non-contiguous text, remove meaningful bracketed text, or move
+supplement text into the article cache. If support is absent, omit the claim or
+record uncertainty instead of weakening the validator.
+
+`just qc-references` is separate from `just qc`: it can use the network and the
+corpus has a known evidence-repair backlog. It is not a CI gate.
+
+## Editing a community or taxon record
+
+1. Read the target, schema, and strong neighboring records.
+2. Check whether the same taxon should reference a reusable record in `kb/taxa`.
+3. Make the smallest source-supported change; preserve experimental context and
+   do not generalize strain-pair evidence to a natural community.
+4. Verify CURIEs and canonical labels from authoritative local/source data.
+5. Add evidence at each changed assertion.
+6. Create a new append-only history record following `history/README.md`.
+   `just new-history` requires the shared claw checkout.
+7. Run focused validators, review the diff, then run the proportional wider
+   checks.
+8. If a community record or renderer changed, regenerate/check `docs/`.
+
+Never change the schema, validator, exception list, threshold, or baseline merely
+to make generated prose pass.
+
+## Validation commands
+
+```bash
+just test
+just lint
+just validate FILE
+just validate-strict FILE
+just validate-gtdb FILE
+just validate-gtdb-domain FILE
+just validate-terms FILE
+just validate-references-explained FILE
+just validate-history PATH
 ```
-src/communitymech/
-├── schema/communitymech.yaml    # LinkML schema (source of truth for datamodel)
-├── datamodel/communitymech.py   # AUTO-GENERATED from schema (just gen-python)
-├── literature.py                # PubMed/CrossRef/Unpaywall fetcher + snippet validation
-├── validators/                  # cross-field checks the LinkML schema cannot express.
-│                                #   scripts/validate_strict.py (the CI gate) runs
-│                                #   gtdb_coherence, gtdb_lineage_tree, prokaryotic_lineage
-│                                #   (which pulls in ncbi_domain), shared_taxon_ids and
-│                                #   yaml_scalars. cross_repo_ids is separate:
-│                                #   `just validate-cross-repo-ids`. Evidence/reference
-│                                #   checking is NOT here — `just validate-references` runs
-│                                #   the official linkml-reference-validator against
-│                                #   conf/reference_validator.yaml (the custom one was
-│                                #   replaced in 4dd299a)
-└── cli.py                       # Entry point (not yet implemented)
 
-kb/communities/                  # curated community YAML files (root class MicrobialCommunity)
-kb/taxa/                          # reusable per-taxon gene records (root class CommonTaxon);
-                                  #   referenced from taxonomy[].common_taxon; `just validate-taxa`
-vocab/                            # controlled-vocabulary staging files (e.g. cultivation_terms.yaml):
-                                  #   definitions/synonyms/ontology-mapping for METPO proposals;
-                                  #   kept in sync with the schema enums by tests/
-conf/oak_config.yaml             # OAK ontology adapter config (NCBITaxon, ENVO, CHEBI, GO)
-references_cache/                # Cached PubMed abstracts (committed for reproducibility)
-scripts/                         # Utility scripts for curation (not part of package)
-NEXT_TASKS.md                    # The deferred-work backlog (source of truth)
-NEXT_TASKS_LOOP.md               # Which of those suit an autonomous /goal run
-                                 #   (and which need a human decision first)
-prompts/                         # Reusable agent prompts, pasted whole (e.g. `/goal`);
-                                 #   backlog-loop.goal.md drives the issue->PR->review->
-                                 #   merge cycle. Kept under 4000 *characters* for /goal,
-                                 #   measured on the trimmed string: Claude Code rejects a
-                                 #   longer condition outright rather than truncating it
-                                 #   (Ydr=4000 in 2.1.220; see tests/ for how to re-derive).
+Corpus-level validation:
+
+```bash
+just validate-all
+just validate-taxa
+just validate-terms-all
+just validate-terms-taxa
+just qc
+just qc-references
 ```
 
-## Key Patterns
+Use a focused test during development:
 
-- **Schema-first**: Edit `schema/communitymech.yaml`, then `just gen-python` to regenerate the datamodel. Never hand-edit `datamodel/communitymech.py`.
-- **Ontology-grounded terms**: All taxa use NCBITaxon, environments use ENVO, metabolites use CHEBI, processes use GO. Terms are `{id, label}` pairs.
-- **Evidence on everything**: `EvidenceItem` requires a `reference` (PMID/DOI), `supports` enum, `evidence_source` enum, and a `snippet` that must fuzzy-match the cited abstract.
-- **Community YAML structure**: Root class is `MicrobialCommunity` with `taxonomy` (list of `TaxonomicComposition`), `ecological_interactions`, and `environmental_factors`.
-- **Validation layers**: Schema validation (linkml-validate), reference validation (snippet matching), and term validation (OAK).
+```bash
+uv run pytest tests/test_datamodel.py::test_name -v
+```
 
-## Ontology Prefixes
+`just qc` runs lint, pytest, schema validation, closed-schema/cross-field checks,
+GTDB checks, scalar checks, and ontology-term checks. Evidence/reference checking
+is deliberately outside it.
 
-NCBITaxon (taxonomy), ENVO (environments), CHEBI (chemicals/metabolites), GO (biological processes), UBERON (anatomy), CL (cell types). References use PMID and doi prefixes.
+## Generated outputs
 
-## Style
+```bash
+just gen-python
+just gen-html
+just check-docs-current
+just gen-browser
+just kgx-export
+just kgx-validate
+```
 
-- Line length: 100 (black + ruff)
-- Python 3.10+ target
-- Uses `uv` for package management (never requirements.txt)
+- `just gen-html` renders the committed `docs/` site.
+- `just check-docs-current` is the drift gate after community or template edits.
+- `just gen-umap` needs a large local embedding artifact that is absent in CI.
+- `just kgx-export` uses the custom Python emitter under
+  `src/communitymech/export/`; it is not a Koza transform.
+
+## Deep research
+
+Provider ranking is read-only and does not call a provider:
+
+```bash
+just deep-research-providers
+just deep-research-provider claude_code ecological_mechanism
+```
+
+Commands that invoke `deep-research-client` or Edison require Python 3.12+, an
+available provider, and appropriate authorization. They can incur cost. Use a
+dry run before an authorized call:
+
+```bash
+just research-community claude_code CommunityMech:000164 --dry-run
+```
+
+Raw reports under `research/` are not schema-compliant deliverables. Verify each
+accepted taxon, strain, metabolite, condition, causal direction, accession,
+citation, and snippet before curating it into YAML. Record LLM assistance in the
+new history entry.
+
+## Code changes
+
+- Keep reusable runtime code under `src/communitymech/`; keep one-off curation
+  workflows under `scripts/`.
+- Add regression tests for the failure being fixed, including command/CI wiring
+  when relevant.
+- The console entry point is implemented in `src/communitymech/cli.py` and
+  currently exposes network audit/repair and UMAP generation commands.
+- Preserve vendored byte-identical files and their synchronization guards.
+- Finish with focused tests, `just lint`, `git diff --check`, and the widest
+  validation justified by the change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ Several optional repository commands use modules from a sibling
 `just gen-qc-dashboard`, `just knowledge-gap-scan`,
 `just gen-discussions-data`, and `just new-history`.
 
+The reusable backlog condition is in `prompts/backlog-loop.goal.md`.
+Kept under 4000 characters for /goal, it is measured on the trimmed string. Claude Code
+rejects an over-long condition rather than truncating it.
+
 ## Schema and ontology invariants
 
 - Change `src/communitymech/schema/communitymech.yaml`, then run
@@ -101,7 +105,7 @@ supplement text into the article cache. If support is absent, omit the claim or
 record uncertainty instead of weakening the validator.
 
 `just qc-references` is separate from `just qc`: it can use the network and the
-corpus has a known evidence-repair backlog. It is not a CI gate.
+corpus has a known evidence-repair backlog (#417). It is not a CI gate.
 
 ## Editing a community or taxon record
 

--- a/README.md
+++ b/README.md
@@ -1,391 +1,271 @@
 # CommunityMech
 
-**Microbial Community Mechanisms Knowledge Base**
+CommunityMech is a LinkML knowledge base for microbial community composition,
+ecological interactions, cultivation conditions, environments, and supporting
+evidence. Curated YAML is the canonical record format; validation, static HTML,
+and KGX exports are derived from it.
 
-A LinkML-based knowledge base for modeling microbial community structure, function, and ecological interactions with evidence-based validation.
+The project is adapted from the
+[Monarch Initiative dismech project](https://github.com/monarch-initiative/dismech).
 
----
+## What is in this repository
 
-## 🎯 Project Vision
+- `kb/communities/` — canonical `MicrobialCommunity` records.
+- `data/isolates/` — additional `MicrobialCommunity` records kept separate from
+  the main community collection.
+- `kb/taxa/` — reusable `CommonTaxon` genome and gene records.
+- `src/communitymech/schema/` — LinkML schemas.
+- `src/communitymech/datamodel/communitymech.py` — generated Python datamodel;
+  never edit it by hand.
+- `src/communitymech/validators/` — cross-field checks LinkML cannot express.
+- `references_cache/` — committed source text used for reproducible evidence
+  checks.
+- `history/` — append-only curation provenance.
+- `docs/` — the committed GitHub Pages site and maintainer guides.
+- `scripts/` — repository-oriented curation and validation utilities.
 
-Model specific microbial communities as individual YAML files, combining:
-- Rich, expressive YAML for agent consumption
-- Validated evidence chains (anti-hallucination)
-- Ontology-grounded terms (NCBITaxon, ENVO, CHEBI, GO)
-- Causal graphs for ecological interactions
-- Faceted browser for scientists
-- KG export for integration (via Koza)
+CommunityMech currently operates from a source checkout. Some commands resolve
+the KB, caches, reports, and generated site relative to the repository root. The
+long-term installed-package contract is being decided in
+[#668](https://github.com/CultureBotAI/CommunityMech/issues/668).
 
-**Adapted from**: [Monarch Initiative's dismech](https://github.com/monarch-initiative/dismech)
+## Architecture
 
----
-
-## 🏗️ Architecture
-
+```text
+community YAML + taxon YAML
+            |
+            +--> LinkML schema validation
+            +--> strict cross-field validators
+            +--> ontology id/label validation
+            +--> cached/network evidence validation
+            |
+            +--> deterministic custom Python KGX emitter
+            +--> static browser and per-community HTML
 ```
-Rich YAML Source
-  kb/communities/Human_Gut_Healthy_Adult.yaml
-       ↓
-  Validation Stack
-  ├── Schema validation (linkml-validate)
-  ├── Term validation (linkml-term-validator + OAK)
-  └── Reference validation (snippets vs PubMed)
-       ↓
-  Dual Output
-  ├── Koza Transform → KGX Edges (for KG stacks)
-  └── Browser Export → Faceted Search (for scientists)
-```
 
----
+The KGX path is a custom Python emitter, not a Koza transform. YAML retains the
+full curation context and remains the source of truth.
 
-## 🚀 Quick Start
+## Requirements and installation
 
-### Installation
+Core development supports Python 3.10 and newer. Deep-research and Edison
+commands require Python 3.12 or newer because their optional dependencies do.
+
+Install [uv](https://docs.astral.sh/uv/) and
+[just](https://github.com/casey/just), then run:
 
 ```bash
-# Clone repository
 git clone https://github.com/CultureBotAI/CommunityMech.git
 cd CommunityMech
-
-# Install dependencies
 just install
-
-# Or with uv directly
-uv sync --extra dev
+just test
 ```
 
-### Validate a Community
+`just install` installs the `dev` extra from `pyproject.toml`. CI uses the frozen
+`uv.lock`; commit `pyproject.toml` and `uv.lock` together when dependencies
+change.
+
+## Validate records
+
+For one community record:
 
 ```bash
-# Schema validation
-just validate kb/communities/Human_Gut_Healthy_Adult.yaml
-
-# Reference validation (prevent hallucination)
-just validate-references kb/communities/Human_Gut_Healthy_Adult.yaml
-
-# Term validation (check ontology terms)
-just validate-terms
+FILE=kb/communities/Yogurt_TwoSpecies_Starter_Culture.yaml
+just validate "$FILE"
+just validate-strict "$FILE"
+just validate-gtdb "$FILE"
+just validate-gtdb-domain "$FILE"
+just validate-terms "$FILE"
 ```
 
-### Generate Outputs
+Evidence validation is separate because it may use the committed cache and the
+network:
 
 ```bash
-# Export to KG (Koza transform)
-just kgx-export
-
-# Generate faceted browser
-just gen-browser
-
-# Generate HTML pages
-just gen-html-all
+just validate-references-explained "$FILE"
 ```
 
-> **Note**: Commands above are planned for implementation. See [COMMUNITY_MECH_PLAN.md](COMMUNITY_MECH_PLAN.md) for development roadmap.
-
----
-
-## 📁 Repository Structure
-
-```
-CommunityMech/
-├── src/
-│   └── communitymech/
-│       ├── schema/
-│       │   └── communitymech.yaml      # LinkML schema
-│       ├── datamodel/                   # Generated Python models
-│       ├── export/
-│       │   ├── kgx_export.py           # Koza transform to KG
-│       │   └── browser_export.py       # Faceted browser export
-│       ├── render.py                    # HTML page generator
-│       └── templates/                   # Jinja2 templates
-├── kb/
-│   └── communities/
-│       ├── Human_Gut_Healthy_Adult.yaml
-│       ├── Human_Gut_IBD_UC.yaml
-│       ├── Soil_Grassland_Temperate.yaml
-│       └── ...
-├── conf/
-│   ├── oak_config.yaml                  # OAK ontology adapters
-│   └── qc_config.yaml                   # QC configuration
-├── app/                                  # Faceted browser
-│   ├── index.html
-│   ├── data.js
-│   └── schema.js
-├── pages/
-│   └── communities/                     # Rendered HTML pages
-├── tests/
-│   └── test_communities.py
-├── .claude/
-│   └── skills/                          # Claude Code curation skills
-├── justfile                             # Task runner
-├── pyproject.toml
-├── COMMUNITY_MECH_PLAN.md              # Full implementation plan
-├── QUICK_START.md                       # Quick reference
-└── README.md
-```
-
----
-
-## 📖 Documentation
-
-- **[Implementation Plan](COMMUNITY_MECH_PLAN.md)** - Complete 11-phase plan
-- **[Quick Start Guide](QUICK_START.md)** - Quick reference
-- **[Schema Documentation](docs/)** - LinkML schema reference
-- **[Cross-Repo Linking](docs/cross_repo_linking.md)** - Environmental linking to CultureMech and MediaIngredientMech
-- **[Growth Media Linking](docs/media_linking.md)** - Cultivation-based media linking
-
----
-
-## 📦 KGX export (downstream consumer contract)
-
-CommunityMech publishes its community knowledge graph as KGX TSV on
-every release. The artifact has stable column shapes, deterministic
-edge IDs, and propagates literature evidence directly into edge
-metadata so downstream graphs preserve provenance.
-
-### Where to find it
-
-- **Latest release:** GitHub Releases page → `nodes.tsv.gz`,
-  `edges.tsv.gz`, and `manifest.json` attached to each release.
-- **CI artifacts:** every push and release run uploads the same
-  files to the workflow's Artifacts panel
-  (`.github/workflows/kgx-release.yaml`, ~90-day retention).
-- **Local build:** `just kgx-export` writes them to
-  `output/kgx/`. `just kgx-validate` runs structural checks.
-
-### File schemas
-
-`nodes.tsv` columns: `id, category, name, description, provided_by`
-
-`edges.tsv` columns: `id, subject, predicate, object, category, publications, supporting_text, knowledge_level, agent_type, primary_knowledge_source`
-
-Edge `id` values are deterministic UUID5 derived from `(subject,
-predicate, object, qualifier)` — re-running the export with the
-same input produces byte-identical IDs.
-
-### Edge types
-
-| Predicate | Subject category | Object category | Edge category |
-|---|---|---|---|
-| `biolink:located_in` | `biolink:OrganismalEntity` (community) | `biolink:EnvironmentalFeature` (ENVO) | `biolink:OrganismToEnvironmentAssociation` |
-| `biolink:has_part` | `biolink:OrganismalEntity` (community) | `biolink:OrganismTaxon` (NCBITaxon) | `biolink:OrganismToOrganismAssociation` |
-| `biolink:related_to` | `biolink:OrganismalEntity` (community) | `biolink:ChemicalEntity` (CHEBI metals/REE) | `biolink:ChemicalEntityToOrganismalEntityAssociation` |
-| `biolink:occurs_in` | `biolink:OrganismalEntity` (community) | growth medium | `biolink:Association` |
-
-### Provenance & evidence
-
-Every edge derived from a community evidence claim carries:
-
-- `publications`: pipe-separated CURIEs (e.g.
-  `PMID:18936492|DOI:10.1099/00207713-50-4-1539`)
-- `supporting_text`: pipe-separated verbatim snippets (the same
-  ones that pass MIM's anti-hallucination Phase 1 validator)
-- `knowledge_level`: `knowledge_assertion` (curator-asserted)
-- `agent_type`: `manual_agent`
-- `primary_knowledge_source`: `infores:communitymech`
-
-### Stability commitments
-
-- Column order in both TSVs is fixed; new columns will only be
-  appended at the right.
-- Edge IDs are stable across runs unless the underlying
-  `(subject, predicate, object, qualifier)` tuple changes.
-- `infores:communitymech` is the canonical knowledge-source id.
-- Bare element names in `metals_present` / `rare_earth_elements_present`
-  are auto-resolved to verified CHEBI atom CURIEs (26 elements
-  covered as of 2026-05); see `_ELEMENT_CHEBI` in
-  `src/communitymech/export/kgx_export.py` for the full table.
-
-### Upstream details
-
-The export is implemented as a custom Python emitter (no Koza
-dependency for a 78-record / ~580-edge scale). Schema, evidence
-slots, and edge selection are documented in:
-[`../../culturebotai-claw/docs/proposals/phase3_communitymech_kgx_export_with_publications.md`](../../culturebotai-claw/docs/proposals/phase3_communitymech_kgx_export_with_publications.md).
-
----
-
-## 🧬 Example Community File
-
-```yaml
-name: Human Gut Healthy Adult
-ecological_state: HEALTHY
-
-environment_term:
-  preferred_term: human gut
-  term:
-    id: ENVO:0001998
-    label: human gut environment
-
-taxonomy:
-  - taxon_term:
-      preferred_term: Faecalibacterium prausnitzii
-      term:
-        id: NCBITaxon:853
-        label: Faecalibacterium prausnitzii
-    abundance_level: ABUNDANT
-    functional_role: [KEYSTONE, CORE]
-    evidence:
-      - reference: PMID:18936492
-        supports: SUPPORT
-        snippet: "F. prausnitzii represents more than 5%..."
-
-ecological_interactions:
-  - name: Butyrate Production
-    source_taxon:
-      preferred_term: Faecalibacterium prausnitzii
-      term:
-        id: NCBITaxon:853
-    metabolites:
-      - preferred_term: butyrate
-        term:
-          id: CHEBI:30089
-    downstream:
-      - target: Host Colonocyte Energy
-    evidence:
-      - reference: PMID:18936492
-```
-
----
-
-## 🔬 Key Features
-
-### 1. Evidence-Based
-- Every claim backed by PMID references
-- Snippets validated against PubMed abstracts
-- Prevents AI hallucination
-
-### 2. Ontology-Grounded
-- **NCBITaxon** - Microbial taxa
-- **ENVO** - Environments
-- **CHEBI** - Chemical entities/metabolites
-- **GO** - Biological processes
-- **UBERON** - Host anatomy
-
-### 3. Causal Graphs
-- Model ecological interactions as directed graphs
-- Represent cross-feeding, competition, mutualism
-- Visualize with D3.js/Cytoscape
-
-### 4. Dual Output
-- **Rich YAML** - For agent consumption (full context)
-- **Simple KG** - For graph algorithms (Biolink edges)
-
-### 5. Cross-Repository Linking
-- **Environmental linking** to CultureMech media and MediaIngredientMech ingredients
-- Environment-based discovery via shared ENVO terms
-- `related_media` for environmentally relevant media (complements `growth_media`)
-- `related_ingredients` for environmentally significant compounds
-- SPARQL query patterns for cross-repo joins
-
-### 6. Scientist-Friendly
-- Faceted browser (no coding required)
-- Click-through to evidence
-- Interactive visualizations
-
----
-
-## 🛠️ Development Status
-
-**Current Phase**: Foundation (Sprint 1)
-
-- [x] Repository created
-- [x] Implementation plan documented
-- [x] Reference implementation analyzed (Monarch dismech)
-- [x] Seed data added (35 communities)
-- [x] Schema design (LinkML schema with full validation)
-- [x] First example community YAML
-- [x] Cross-repo environmental linking (CultureMech + MediaIngredientMech)
-- [ ] Validation stack setup
-- [ ] Koza transform implementation
-- [ ] Faceted browser adaptation
-- [ ] HTML rendering
-
-See [COMMUNITY_MECH_PLAN.md](COMMUNITY_MECH_PLAN.md) for the complete roadmap.
-
----
-
-## 🤝 Contributing
-
-This is a private repository during initial development. Once the core infrastructure is in place, we'll open it up for community contributions.
-
-### Development Workflow
-
-1. Create a new branch for your feature/community
-2. Add/modify community YAML files
-3. Run validation: `just qc`
-4. Commit with evidence validation
-5. Create PR for review
-
----
-
-## 📊 Validation Stack
+Repository-wide checks:
 
 ```bash
-# Schema validation
-just validate kb/communities/YourCommunity.yaml
-
-# Reference validation (anti-hallucination)
-just validate-references kb/communities/YourCommunity.yaml
-
-# Term validation (ontology checking)
-just validate-terms-file kb/communities/YourCommunity.yaml
-
-# Full QC
-just qc
+just qc                 # lint, tests, schema, strict, GTDB, scalar, and term gates
+just qc-references      # qc plus the corpus-wide literature sweep
 ```
 
----
+The corpus-wide reference sweep has a known evidence-repair backlog and is not a
+CI gate. A red reference result is not permission to weaken the validator; fix
+the evidence or record the unresolved curation work.
 
-## Deep Research Provider Triage
+Validation layers serve different purposes:
 
-CommunityMech uses a community-specific version of DisMech's multi-provider
-workflow. `ecological_mechanism` prioritizes exact composition and directional
-interaction evidence; `datasets_environment` prioritizes repository-native
-accessions, ENVO context, cultivation, and perturbation metadata.
+| Layer | Command | What it checks |
+|---|---|---|
+| LinkML | `just validate FILE` | Schema shape, required fields, enums, patterns |
+| Strict | `just validate-strict FILE` | Closed-schema and cross-field invariants |
+| Taxonomy | `just validate-gtdb FILE` | GTDB grounding coherence |
+| Domain | `just validate-gtdb-domain FILE` | Prokaryotic NCBI-domain expectations |
+| Terms | `just validate-terms FILE` | Ontology identifier/label correspondence |
+| Evidence | `just validate-references-explained FILE` | Snippets against cached or fetched source text |
+| History | `just validate-history PATH` | Append-only history record shape |
+
+## Curation workflow
+
+1. Read the schema and a strong neighboring record before editing.
+2. Make the smallest source-supported YAML change.
+3. Use canonical ontology identifiers and labels; never invent CURIEs.
+4. Add `EvidenceItem` entries at the assertions they support.
+5. Add an append-only history record as described in
+   [history/README.md](history/README.md).
+6. Run focused validation, then `just qc` when the change is ready.
+7. Regenerate committed HTML when a community record or renderer changes.
+
+Evidence is a curation policy as well as a data structure. The schema permits
+some assertions without an `evidence` list, so schema validity alone does not
+prove that every claim has support. Curators should leave unsupported claims
+absent or explicitly uncertain rather than infer them from co-occurrence.
+
+## Generate outputs
+
+```bash
+just gen-html             # render docs/ from community YAML and templates
+just check-docs-current   # fail if committed docs disagree with the KB
+just gen-browser          # regenerate faceted-browser data
+just kgx-export           # write output/kgx/{nodes.tsv,edges.tsv,manifest.json}
+just kgx-validate         # validate the generated KGX files
+```
+
+`just gen-umap` additionally requires the local embedding artifact documented in
+the [UMAP guide](docs/UMAP_VISUALIZATION.md). `just gen-all` combines HTML and
+UMAP generation.
+
+GitHub Pages serves the committed `docs/` tree. Do not hand-edit generated
+community pages; update their YAML or templates and regenerate them.
+
+## KGX downstream contract
+
+Release builds publish `nodes.tsv.gz`, `edges.tsv.gz`, and `manifest.json`.
+Local output is written under `output/kgx/`.
+
+`nodes.tsv` columns:
+
+```text
+id, category, name, description, provided_by
+```
+
+`edges.tsv` columns:
+
+```text
+id, subject, predicate, object, category, publications, supporting_text,
+knowledge_level, agent_type, primary_knowledge_source
+```
+
+Edge identifiers are deterministic UUID5 values derived from the edge tuple.
+Evidence-bearing edges propagate publication CURIEs and supporting snippets.
+See the implementation in
+[`src/communitymech/export/kgx_export.py`](src/communitymech/export/kgx_export.py)
+and the release workflow in
+[`kgx-release.yaml`](.github/workflows/kgx-release.yaml).
+
+## Deep research
+
+Provider triage does not run a provider or spend credits:
 
 ```bash
 just deep-research-providers
 just deep-research-providers datasets_environment
-just deep-research-provider asta ecological_mechanism
-just research-community falcon <community-id-or-path> --dry-run
+just deep-research-provider claude_code ecological_mechanism
 ```
 
-Triage ranks discovery, synthesis, and verification independently. Provider
-reports seed curation; taxa, strains, metabolites, conditions, causal claims,
-and dataset accessions must still resolve to the cited source.
+An actual research run requires Python 3.12+, provider authentication, and may
+incur cost:
 
----
+```bash
+just research-community claude_code CommunityMech:000164 --dry-run
+```
 
-## 🎓 Citation
+Research reports under `research/` are raw artifacts, not canonical data.
+Accepted findings must be curated into community YAML with exact source support,
+ontology grounding, validation, and history. Never read, print, or commit `.env`
+credentials.
 
-(TBD once published)
+## Schema-valid example
 
-Based on the dismech framework:
-- Monarch Initiative. (2024). dismech: Disorder Mechanisms Knowledge Base. https://github.com/monarch-initiative/dismech
+This minimal record is derived from the curated yogurt community. A regression
+test extracts this fenced block and validates it against the current LinkML
+schema.
 
----
+```yaml
+id: CommunityMech:000164
+name: Yogurt Two-Species Starter Culture
+ecological_state: ENGINEERED
+community_origin: SYNTHETIC
+environment_term:
+  preferred_term: laboratory yogurt fermentation culture
+  term:
+    id: ENVO:01001405
+    label: laboratory environment
+taxonomy:
+  - taxon_term:
+      preferred_term: Streptococcus thermophilus
+      term:
+        id: NCBITaxon:1308
+        label: Streptococcus thermophilus
+    functional_role: [CROSS_FEEDER]
+    evidence:
+      - reference: PMID:30594386
+        supports: SUPPORT
+        evidence_source: IN_VITRO
+        snippet: Streptococcus thermophilus and Lactobacillus delbrueckii ssp. bulgaricus
+  - taxon_term:
+      preferred_term: Lactobacillus delbrueckii subsp. bulgaricus
+      term:
+        id: NCBITaxon:1585
+        label: Lactobacillus delbrueckii subsp. bulgaricus
+    functional_role: [CROSS_FEEDER]
+    evidence:
+      - reference: PMID:30594386
+        supports: SUPPORT
+        evidence_source: IN_VITRO
+        snippet: Lactobacillus delbrueckii ssp. bulgaricus
+ecological_interactions:
+  - name: Streptococcus Formate Support
+    interaction_type: CROSS_FEEDING
+    source_taxon:
+      preferred_term: Streptococcus thermophilus
+      term:
+        id: NCBITaxon:1308
+        label: Streptococcus thermophilus
+    target_taxon:
+      preferred_term: Lactobacillus delbrueckii subsp. bulgaricus
+      term:
+        id: NCBITaxon:1585
+        label: Lactobacillus delbrueckii subsp. bulgaricus
+    metabolites:
+      - preferred_term: formate
+        term:
+          id: CHEBI:15740
+          label: formate
+    evidence:
+      - reference: PMID:20889781
+        supports: SUPPORT
+        evidence_source: IN_VITRO
+        snippet: S. thermophilus is suggested to provide L. bulgaricus with formic acid
+```
 
-## 📝 License
+## Documentation
 
-BSD-3-Clause (matching the dismech framework)
+- [Quick-start guide](docs/QUICK_START.md)
+- [Automation tools](docs/AUTOMATION_TOOLS.md)
+- [Network quality guide](docs/NETWORK_QUALITY_GUIDE.md)
+- [Cross-repository linking](docs/cross_repo_linking.md)
+- [Growth-media linking](docs/media_linking.md)
+- [Curation history](history/README.md)
+- [Historical implementation notes](notes/README.md)
 
----
+## Contributing
 
-## 🔗 Related Projects
+Keep changes focused and preserve unrelated work in dirty checkouts. Do not
+hand-edit generated models or generated community pages. Pull requests should
+include the relevant validation results and any required regenerated artifacts.
 
-- [dismech](https://github.com/monarch-initiative/dismech) - Disease mechanisms KB (inspiration)
-- [LinkML](https://linkml.io/) - Modeling framework
-- [Koza](https://github.com/monarch-initiative/koza) - KG transformation tool
-- [BugSigDB](https://bugsigdb.org/) - Microbial signatures database
-- [OAK](https://github.com/INCATools/ontology-access-kit) - Ontology access toolkit
-
----
-
-## 📧 Contact
-
-For questions or collaboration inquiries, please open an issue.
-
----
-
-**Status**: 🚧 Under active development
+CommunityMech is licensed under the [BSD 3-Clause License](LICENSE).

--- a/justfile
+++ b/justfile
@@ -27,6 +27,12 @@ _require-claw module:
       exit 1
     fi
 
+# deep-research-client and edison-client are deliberately marked Python 3.12+
+# in pyproject.toml. Fail before uv reports a missing executable/module on the
+# core-supported Python 3.10/3.11 interpreters (#667).
+_require-research-python:
+    @uv run python -c 'import sys; sys.exit("error: deep-research commands require Python 3.12 or newer") if sys.version_info < (3, 12) else None'
+
 # List all commands
 default:
     @just --list
@@ -506,7 +512,7 @@ templates_dir := "templates"
 # Examples:
 #   just research-community falcon Yogurt_TwoSpecies_Starter_Culture --dry-run
 #   just research-community falcon CommunityMech:000164
-research-community provider target *args="":
+research-community provider target *args="": _require-research-python
     uv run --extra dev python scripts/research_community.py \
       --provider {{provider}} \
       --target {{target}} \
@@ -522,7 +528,7 @@ research-entity provider target *args="": (research-community provider target ar
 # Examples:
 #   just research-community-edison Yogurt_TwoSpecies_Starter_Culture --dry-run
 #   just research-community-edison CommunityMech:000164 --job literature-high
-research-community-edison target *args="":
+research-community-edison target *args="": _require-research-python
     uv run --extra dev python scripts/research_community_edison.py \
       --target {{target}} \
       --template {{templates_dir}}/community_mechanism_research.md \
@@ -534,7 +540,7 @@ research-community-edison target *args="":
 # + InteractionDownstream). Same Edison plumbing as research-community-edison, with
 # the causal template + a `causal` label so it does NOT overwrite the mechanism run.
 #   just research-community-causal Cellulose_Methane_Quad_Culture_SynCom --dry-run
-research-community-causal target *args="":
+research-community-causal target *args="": _require-research-python
     uv run --extra dev python scripts/research_community_edison.py \
       --target {{target}} \
       --template {{templates_dir}}/community_causal_graph_research.md \
@@ -543,7 +549,7 @@ research-community-causal target *args="":
       {{args}}
 
 # Edison deep research for a batch of communities (JSON list of stems/ids/paths).
-research-community-edison-batch batch *args="":
+research-community-edison-batch batch *args="": _require-research-python
     uv run --extra dev python scripts/research_community_edison.py \
       --batch {{batch}} \
       --template {{templates_dir}}/community_mechanism_research.md \
@@ -551,7 +557,7 @@ research-community-edison-batch batch *args="":
       {{args}}
 
 # Retroactively backfill Edison provenance sidecars (no re-billing).
-enrich-edison-response *args="":
+enrich-edison-response *args="": _require-research-python
     uv run --extra dev python scripts/enrich_edison_response.py {{args}}
 
 # Scout recent literature for NEW communities (Europe PMC, free; dedups vs kb/communities).
@@ -572,7 +578,7 @@ ground-taxa-gtdb *args="":
     uv run python scripts/gtdb_ground.py {{args}}
 
 # List available deep-research-client providers.
-research-providers:
+research-providers: _require-research-python
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ -z "${EDISON_API_KEY:-}" && -n "${FUTUREHOUSE_API_KEY:-}" ]]; then
@@ -582,7 +588,7 @@ research-providers:
     fi
 
 # Show detailed availability and parameters for one provider.
-research-provider provider:
+research-provider provider: _require-research-python
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ -z "${EDISON_API_KEY:-}" && -n "${FUTUREHOUSE_API_KEY:-}" ]]; then

--- a/justfile
+++ b/justfile
@@ -411,11 +411,13 @@ knowledge-gap-scan *args: (_require-claw "kg_microbe_kgscan")
 gen-all: gen-html gen-umap
     @echo "✅ All HTML pages regenerated"
 
-# Clean generated files
+# Clean disposable build artifacts only. Generated source and published docs are
+# tracked inputs/outputs and must never be removed here; regenerate them explicitly
+# with `just gen-python` / `just gen-html` when needed.
 clean:
-    rm -rf src/communitymech/datamodel/*.py
-    rm -rf docs/*.md
     rm -rf .linkml-cache
+    rm -rf build dist src/communitymech.egg-info
+    rm -rf output/kgx
 
 # Format code
 format:

--- a/tests/test_ci_runtime_contracts.py
+++ b/tests/test_ci_runtime_contracts.py
@@ -1,0 +1,96 @@
+"""CI and research-runtime contracts must be explicit and reproducible (#667)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO / ".github" / "workflows"
+JUSTFILE = REPO / "justfile"
+
+SETUP_UV_ACTION = "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9"
+UV_VERSION = "0.12.5"
+
+
+def _workflow_documents() -> list[tuple[Path, dict]]:
+    paths = sorted([*WORKFLOWS.glob("*.yaml"), *WORKFLOWS.glob("*.yml")])
+    return [(path, yaml.safe_load(path.read_text(encoding="utf-8"))) for path in paths]
+
+
+def _steps(document: dict):
+    for job in document.get("jobs", {}).values():
+        yield from job.get("steps", [])
+
+
+def test_every_setup_uv_step_pins_the_same_action_and_binary_version():
+    found = []
+    for path, document in _workflow_documents():
+        for step in _steps(document):
+            uses = str(step.get("uses", ""))
+            if not uses.startswith("astral-sh/setup-uv@"):
+                continue
+            found.append(path.name)
+            assert uses == SETUP_UV_ACTION, f"{path.name} uses an unpinned/different setup-uv"
+            assert (
+                step.get("with", {}).get("version") == UV_VERSION
+            ), f"{path.name} does not pin uv {UV_VERSION}"
+
+    assert found, "no workflow installs uv; this test checked nothing"
+
+
+def test_every_workflow_sync_is_frozen():
+    sync_commands = []
+    for path, document in _workflow_documents():
+        for step in _steps(document):
+            for line in str(step.get("run", "")).splitlines():
+                command = line.strip()
+                if not command.startswith("uv sync"):
+                    continue
+                sync_commands.append((path.name, command))
+                assert "--frozen" in command, f"{path.name} re-resolves dependencies: {command}"
+
+    assert sync_commands, "no workflow runs uv sync; this test checked nothing"
+
+
+def test_provider_profile_alone_triggers_its_test_workflow():
+    workflow = (WORKFLOWS / "validate-strict.yaml").read_text(encoding="utf-8")
+    assert '"conf/deep_research_provider.yaml"' in workflow
+
+
+def test_ci_exercises_minimum_and_modern_supported_python():
+    document = yaml.safe_load((WORKFLOWS / "validate-strict.yaml").read_text())
+
+    def python_version(job: str) -> str | None:
+        for step in document["jobs"][job]["steps"]:
+            if str(step.get("uses", "")).startswith("actions/setup-python@"):
+                return step.get("with", {}).get("python-version")
+        return None
+
+    assert python_version("validate-strict") == "3.10"
+    assert python_version("python-compatibility") == "3.13"
+
+
+def test_commands_that_invoke_research_dependencies_have_a_python_preflight():
+    text = JUSTFILE.read_text(encoding="utf-8")
+    guard = re.search(r"^_require-research-python:\n(?P<body>(?:[ \t]+.*\n)+)", text, re.MULTILINE)
+    assert guard, "the research Python preflight recipe is missing"
+    assert "sys.version_info < (3, 12)" in guard.group("body")
+
+    guarded = {
+        "research-community",
+        "research-community-edison",
+        "research-community-causal",
+        "research-community-edison-batch",
+        "enrich-edison-response",
+        "research-providers",
+        "research-provider",
+    }
+    for recipe in guarded:
+        header = re.search(rf"^{re.escape(recipe)}(?: [^:]*)?:[^\n]*$", text, re.MULTILINE)
+        assert header, f"missing recipe: {recipe}"
+        assert (
+            "_require-research-python" in header.group()
+        ), f"{recipe} can reach a Python 3.12-only dependency without the preflight"

--- a/tests/test_ci_runtime_contracts.py
+++ b/tests/test_ci_runtime_contracts.py
@@ -73,6 +73,13 @@ def test_ci_exercises_minimum_and_modern_supported_python():
     assert python_version("python-compatibility") == "3.13"
 
 
+def test_modern_python_lane_installs_just_for_repository_contract_tests():
+    document = yaml.safe_load((WORKFLOWS / "validate-strict.yaml").read_text())
+    uses = {str(step.get("uses", "")) for step in document["jobs"]["python-compatibility"]["steps"]}
+
+    assert "extractions/setup-just@v3" in uses
+
+
 def test_commands_that_invoke_research_dependencies_have_a_python_preflight():
     text = JUSTFILE.read_text(encoding="utf-8")
     guard = re.search(r"^_require-research-python:\n(?P<body>(?:[ \t]+.*\n)+)", text, re.MULTILINE)

--- a/tests/test_claude_guide_contract.py
+++ b/tests/test_claude_guide_contract.py
@@ -1,0 +1,71 @@
+"""Agent guidance must track the repository contract it describes (#666)."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GUIDE = REPO / "CLAUDE.md"
+
+
+def _text() -> str:
+    return GUIDE.read_text(encoding="utf-8")
+
+
+def test_every_documented_just_recipe_exists():
+    documented = set(re.findall(r"\bjust ([a-z][a-z0-9-]*)", _text()))
+    result = subprocess.run(
+        ["just", "--summary"], cwd=REPO, check=True, capture_output=True, text=True
+    )
+    available = set(result.stdout.split())
+
+    assert documented
+    assert (
+        documented <= available
+    ), f"CLAUDE.md names missing recipes: {sorted(documented - available)}"
+
+
+def test_canonical_paths_named_by_the_guide_exist():
+    required = {
+        "src/communitymech/schema/communitymech.yaml",
+        "src/communitymech/schema/mech_shared.yaml",
+        "src/communitymech/schema/history.yaml",
+        "src/communitymech/datamodel/communitymech.py",
+        "src/communitymech/cli.py",
+        "kb/communities",
+        "data/isolates",
+        "kb/taxa",
+        "references_cache",
+        "history",
+        "src/communitymech/templates",
+        "docs",
+        "scripts",
+    }
+    assert all(f"`{path}" in _text() for path in required)
+    assert not [path for path in required if not (REPO / path).exists()]
+
+
+def test_stale_architecture_claims_do_not_return():
+    text = _text()
+    assert "cli.py                       # Entry point (not yet implemented)" not in text
+    assert "lossy Koza transforms planned" not in text
+    assert "`schema/communitymech.yaml`" not in text
+    assert not re.search(r"kb/communities/` \(\d+ files\)", text)
+
+
+def test_guide_distinguishes_policy_from_enforcement_and_names_safety_boundaries():
+    text = _text()
+    for phrase in (
+        "a curation policy, not a blanket schema guarantee",
+        "full text",
+        "supplementary text",
+        "append-only history",
+        "CLAW_SRC",
+        "Python 3.12+",
+        "Never read, print, modify, or commit `.env`",
+        "preserve unrelated or uncommitted user work",
+        "not a Koza transform",
+    ):
+        assert phrase in text

--- a/tests/test_claude_md_is_accurate.py
+++ b/tests/test_claude_md_is_accurate.py
@@ -1,23 +1,8 @@
-"""CLAUDE.md is loaded as authoritative context, and nothing checked it (#460).
+"""Mechanically check the repository facts declared in CLAUDE.md (#460, #666).
 
-Every session starts with this file in context, described as instructions that
-override default behaviour. It had drifted in two ways at once, both found by
-accident while working #410:
-
-* its architecture tree named `validators/reference_validator.py` as the sole
-  occupant of that directory. That file was deleted in **4dd299a**, "Replace
-  custom validators with official LinkML validators" — only an untracked
-  `.pyc` survives, so a naive `find` appears to succeed. Meanwhile the seven
-  validators that *are* there, and that the CI gate runs, went undocumented.
-* it said `kb/communities/` holds **60** files. It holds 312.
-
-Neither is exotic: a doc nobody executes drifts from a tree that changes weekly.
-The fix is to execute it. This parses the tree — tracking parents, since it is
-nested and a bare `cli.py` means `src/communitymech/cli.py` — and asserts every
-path is real, then checks the counts the prose quotes.
-
-Kept deliberately narrow. It checks facts that are mechanically checkable and
-says nothing about whether the prose is *good*, which no test can.
+The guide is authoritative agent context, so paths and version claims should be
+executable facts. Volatile corpus counts are deliberately forbidden rather than
+continuously updated.
 """
 
 from __future__ import annotations
@@ -27,130 +12,47 @@ from pathlib import Path
 
 import pytest
 
-REPO = Path(__file__).parent.parent
+REPO = Path(__file__).resolve().parent.parent
 CLAUDE_MD = REPO / "CLAUDE.md"
 
-# Three line shapes carry a path. A nested child (`├── name`) hangs off the
-# most recent bare directory; a bare directory (`src/communitymech/`) is both a
-# path and a parent; and a top-level entry (`NEXT_TASKS.md`, `conf/oak_config.yaml`)
-# is neither. Missing that third shape is how the first version of this test
-# checked 12 of 15 paths and stayed green while CLAUDE.md named two files that
-# did not exist — including NEXT_TASKS.md, which the same doc calls the backlog
-# source of truth.
-_CHILD = re.compile(r"^[│\s]*[├└]──\s+(\S+)")
-_ROOT = re.compile(r"^([A-Za-z][A-Za-z0-9_./-]*/)\s*(?:#.*)?$")
-_TOP_FILE = re.compile(r"^([A-Za-z][A-Za-z0-9_./-]*\.[A-Za-z0-9]+)\s*(?:#.*)?$")
-# A continuation of the previous entry's comment, carrying no path of its own.
-_COMMENT_ONLY = re.compile(r"^[│\s]*#")
+
+def _text() -> str:
+    return CLAUDE_MD.read_text(encoding="utf-8")
 
 
-def _tree_block() -> str:
-    text = CLAUDE_MD.read_text()
-    start = text.index("## Architecture")
-    fence = text.index("```", start)
-    return text[fence + 3 : text.index("```", fence + 3)]
+def _canonical_table_paths() -> list[str]:
+    text = _text()
+    start = text.index("## Canonical and generated files")
+    end = text.index("\n## ", start + 3)
+    section = text[start:end]
+    paths = re.findall(r"^\| `([^`]+)` \|", section, re.MULTILINE)
+    assert paths, "the canonical-files table moved or became unparsable"
+    return paths
 
 
-def _parse_tree() -> tuple[list[str], list[str]]:
-    """(paths declared, lines the parser could not account for).
-
-    Returning the leftovers is the point: a lower bound on the path count
-    cannot tell "the tree shrank" from "the parser went blind", but a line it
-    failed to classify can.
-    """
-    paths: list[str] = []
-    unconsumed: list[str] = []
-    parent = ""
-    for line in _tree_block().split("\n"):
-        if not line.strip() or _COMMENT_ONLY.match(line):
-            continue
-        root = _ROOT.match(line.strip())
-        if root:
-            parent = root.group(1)
-            paths.append(parent)
-            continue
-        top = _TOP_FILE.match(line.strip())
-        if top:
-            paths.append(top.group(1))
-            continue
-        child = _CHILD.match(line)
-        if child:
-            name = child.group(1)
-            # A parenthetical aside rather than a filename.
-            if name.startswith("("):
-                continue
-            # A child is relative to its parent — that is what the tree means.
-            # An earlier version had a ternary trying to special-case rooted
-            # names; it hardcoded two directory prefixes, was unreachable for
-            # the current tree, and got these wrong when it did fire.
-            paths.append(parent + name)
-            continue
-        unconsumed.append(line)
-    return paths, unconsumed
+@pytest.mark.parametrize("declared", _canonical_table_paths())
+def test_every_path_in_the_canonical_files_table_exists(declared: str):
+    assert (
+        REPO / declared
+    ).exists(), f"CLAUDE.md names {declared!r}, which does not exist in the repository"
 
 
-def _declared_paths() -> list[str]:
-    return _parse_tree()[0]
+def test_the_core_python_target_matches_pyproject():
+    claimed = re.search(r"Core package and validation: Python (\d+\.\d+)\+", _text())
+    assert claimed, "the core Python support statement moved or disappeared"
 
-
-def test_the_parser_reads_every_line_of_the_tree():
-    """The guard that matters: no line goes unclassified.
-
-    A floor on the path count cannot distinguish a tree that shrank from a
-    parser that went blind — the first version asserted `>= 10` and reported
-    healthy at 12 while three entries were never checked at all.
-    """
-    declared, unconsumed = _parse_tree()
-    assert unconsumed == [], (
-        "these lines of the architecture tree were not recognised as a path, a "
-        "directory, or a comment, so nothing checked them:\n" + "\n".join(unconsumed)
-    )
-    assert any(p.endswith(".py") for p in declared)
-    assert any(p.endswith("/") for p in declared)
-    assert any(
-        p.endswith(".md") for p in declared
-    ), "the top-level file entries are the shape the first parser missed"
-
-
-@pytest.mark.parametrize("declared", _declared_paths())
-def test_every_path_named_in_the_architecture_tree_exists(declared: str):
-    assert (REPO / declared).exists(), (
-        f"CLAUDE.md's architecture tree names {declared!r}, which is not in the "
-        f"repo. This file is loaded as authoritative context every session, so a "
-        f"stale entry misdirects every reader — `validators/reference_validator.py` "
-        f"outlived its deletion in 4dd299a by many months this way (#460)."
-    )
-
-
-def test_the_community_record_count_is_current():
-    """The prose quotes a count, and counts rot faster than paths."""
-    text = CLAUDE_MD.read_text()
-    match = re.search(r"kb/communities/[^.]*?\((\d+) files\)", text)
-    assert match, "the 'kb/communities/ (N files)' claim has moved; update this test"
-
-    claimed = int(match.group(1))
-    actual = len(list((REPO / "kb/communities").glob("*.yaml")))
-    assert claimed == actual, (
-        f"CLAUDE.md says kb/communities/ holds {claimed} files; it holds {actual}. "
-        f"It said 60 for long enough to be off by a factor of five (#460)."
-    )
-
-
-def test_the_python_target_matches_pyproject():
-    """Another checkable number that had drifted.
-
-    CLAUDE.md said "Python 3.9+ target" while pyproject requires >=3.10, and
-    black/ruff/mypy are all configured for 3.10. A PR premised on executing this
-    file's checkable facts should not leave one wrong.
-    """
-    claimed = re.search(r"Python (\d+\.\d+)\+ target", CLAUDE_MD.read_text())
-    assert claimed, "the 'Python N.N+ target' line has moved; update this test"
-
-    pyproject = (REPO / "pyproject.toml").read_text()
+    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
     required = re.search(r'requires-python\s*=\s*">=(\d+\.\d+)"', pyproject)
     assert required, "could not read requires-python from pyproject.toml"
+    assert claimed.group(1) == required.group(1)
 
-    assert claimed.group(1) == required.group(1), (
-        f"CLAUDE.md targets Python {claimed.group(1)}+, pyproject requires "
-        f">={required.group(1)}"
-    )
+
+def test_the_guide_does_not_publish_a_volatile_community_count():
+    assert not re.search(r"kb/communities/[^.]*?\(\d+ files\)", _text())
+
+
+def test_generated_datamodel_is_named_and_protected():
+    text = _text()
+    assert "`src/communitymech/datamodel/communitymech.py`" in text
+    assert "Never hand-edit" in text
+    assert "`just gen-python`" in text

--- a/tests/test_clean_recipe.py
+++ b/tests/test_clean_recipe.py
@@ -1,0 +1,67 @@
+"""The cleanup recipe must never target a tracked repository file (#663)."""
+
+from __future__ import annotations
+
+import glob
+import shlex
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _tracked_paths() -> set[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+    )
+    return {
+        (REPO / path.decode()).resolve()
+        for path in result.stdout.split(b"\0")
+        if path
+    }
+
+
+def _clean_commands() -> list[list[str]]:
+    result = subprocess.run(
+        ["just", "--dry-run", "clean"],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [shlex.split(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def test_clean_targets_no_tracked_files():
+    """Expand every cleanup target and compare it with the Git index.
+
+    This catches both an explicit tracked path and a broad glob such as
+    ``docs/*.md``. New cleanup commands must stay simple enough for this audit;
+    dynamic shell expressions would make a destructive recipe harder to review.
+    """
+    tracked = _tracked_paths()
+    offenders: set[Path] = set()
+
+    for command in _clean_commands():
+        assert command[:2] == ["rm", "-rf"], f"unaudited clean command: {command}"
+        for target in command[2:]:
+            assert not any(token in target for token in ("$", "`", "$(")), (
+                f"clean target must be an explicit path or glob: {target}"
+            )
+            matches = glob.glob(str(REPO / target), recursive=True)
+            offenders.update(Path(match).resolve() for match in matches if Path(match).is_file())
+
+    assert not offenders & tracked, (
+        "clean would delete tracked files:\n"
+        + "\n".join(str(path.relative_to(REPO)) for path in sorted(offenders & tracked))
+    )
+
+
+def test_clean_keeps_tracked_datamodel_and_documentation_out_of_its_commands():
+    rendered = "\n".join(" ".join(command) for command in _clean_commands())
+
+    assert "src/communitymech/datamodel" not in rendered
+    assert "docs/" not in rendered

--- a/tests/test_clean_recipe.py
+++ b/tests/test_clean_recipe.py
@@ -17,11 +17,7 @@ def _tracked_paths() -> set[Path]:
         check=True,
         capture_output=True,
     )
-    return {
-        (REPO / path.decode()).resolve()
-        for path in result.stdout.split(b"\0")
-        if path
-    }
+    return {(REPO / path.decode()).resolve() for path in result.stdout.split(b"\0") if path}
 
 
 def _clean_commands() -> list[list[str]]:
@@ -48,15 +44,14 @@ def test_clean_targets_no_tracked_files():
     for command in _clean_commands():
         assert command[:2] == ["rm", "-rf"], f"unaudited clean command: {command}"
         for target in command[2:]:
-            assert not any(token in target for token in ("$", "`", "$(")), (
-                f"clean target must be an explicit path or glob: {target}"
-            )
+            assert not any(
+                token in target for token in ("$", "`", "$(")
+            ), f"clean target must be an explicit path or glob: {target}"
             matches = glob.glob(str(REPO / target), recursive=True)
             offenders.update(Path(match).resolve() for match in matches if Path(match).is_file())
 
-    assert not offenders & tracked, (
-        "clean would delete tracked files:\n"
-        + "\n".join(str(path.relative_to(REPO)) for path in sorted(offenders & tracked))
+    assert not offenders & tracked, "clean would delete tracked files:\n" + "\n".join(
+        str(path.relative_to(REPO)) for path in sorted(offenders & tracked)
     )
 
 

--- a/tests/test_gtdb_coherence_validator.py
+++ b/tests/test_gtdb_coherence_validator.py
@@ -22,6 +22,7 @@ the constraint should move into the schema.
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -711,9 +712,7 @@ def test_nothing_else_writes_relative_to_the_working_directory(tmp_path):
 
     result = subprocess.run(
         [
-            "uv",
-            "run",
-            "python",
+            sys.executable,
             str(REPO / "scripts/validate_strict.py"),
             str(fixture),
             "--out",

--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -1,0 +1,76 @@
+"""README commands, links, and sample data must stay executable (#665)."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+README = REPO / "README.md"
+SCHEMA = REPO / "src/communitymech/schema/communitymech.yaml"
+
+
+def _readme_text() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def test_every_documented_just_recipe_exists():
+    documented = set(re.findall(r"\bjust ([a-z][a-z0-9-]*)", _readme_text()))
+    result = subprocess.run(
+        ["just", "--summary"], cwd=REPO, check=True, capture_output=True, text=True
+    )
+    available = set(result.stdout.split())
+
+    assert documented, "README contains no just commands; this test checked nothing"
+    assert (
+        documented <= available
+    ), f"README names missing recipes: {sorted(documented - available)}"
+
+
+def test_every_repository_relative_link_resolves():
+    destinations = re.findall(r"\[[^]]*\]\(([^)]+)\)", _readme_text())
+    missing = []
+    for destination in destinations:
+        if re.match(r"^[a-z][a-z0-9+.-]*://", destination, re.IGNORECASE):
+            continue
+        path_text = unquote(destination.split("#", 1)[0])
+        if path_text and not (REPO / path_text).exists():
+            missing.append(destination)
+
+    assert not missing, f"README contains broken relative links: {missing}"
+
+
+def test_schema_example_is_valid_yaml_and_linkml(tmp_path):
+    match = re.search(
+        r"^## Schema-valid example\b.*?^```yaml\n(?P<yaml>.*?)^```$",
+        _readme_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "README has no YAML block under the schema-valid example heading"
+
+    document = yaml.safe_load(match.group("yaml"))
+    assert document["id"].startswith("CommunityMech:")
+    assert document.get("taxonomy")
+    assert document.get("ecological_interactions")
+
+    example = tmp_path / "readme-example.yaml"
+    example.write_text(match.group("yaml"), encoding="utf-8")
+    validator = Path(sys.executable).with_name("linkml-validate")
+    result = subprocess.run(
+        [str(validator), "-s", str(SCHEMA), str(example)],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_readme_describes_the_implemented_export_consistently():
+    text = _readme_text()
+    assert "custom Python KGX emitter" in text
+    assert "commands above are planned" not in text.casefold()


### PR DESCRIPTION
## Summary

- make `just clean` remove only disposable outputs and guard against tracked-file deletion
- restore normal import and out-of-root subprocess behavior for the provider changes
- make provider CI deterministic with pinned uv tooling, frozen installs, path coverage, and Python 3.13 compatibility testing
- rebuild README commands, links, and YAML examples from executable repository behavior
- rewrite CLAUDE.md as a stable operational guide with contract tests

## Validation

- full suite before the final rebase: 2,563 passed, 89 skipped, 8 deselected
- affected contracts after rebasing onto the current #662 head: 243 passed, 6 skipped
- Black, Ruff, mypy, and `git diff --check` pass

## Stacking

This PR is stacked on #662 so it contains only the remediation commits. #668 remains open for the human packaging/runtime decision; the documentation describes the current checkout-dependent behavior without selecting the long-term architecture.

Closes #663
Closes #664
Closes #665
Closes #666
Closes #667
Refs #668
Refs #669