### PR TITLE
Close provider and Edison provenance review gaps

### DIFF
--- a/scripts/.vendored_canon_ref
+++ b/scripts/.vendored_canon_ref
@@ -1,1 +1,1 @@
-6be694f3d6308ac0f4c2e0dcf196e2ff73f6468f
+8f7a44ab2db2da80c549c4b6fa7cea6ea9a82fad

--- a/scripts/_edison_capture.py
+++ b/scripts/_edison_capture.py
@@ -17,8 +17,10 @@ Files written per task (under ``out_dir``):
                                Every SDK-exposed field, future-proof
                                against new ones.
     {stem}-citations.md        Parsed reference list from
-                               ``formatted_answer`` (PaperQA convention,
-                               matches the falcon citations.md sidecar).
+                               ``formatted_answer`` (PaperQA convention).
+                               Unrelated to falcon's removed
+                               --separate-citations sidecar; Edison's own
+                               extractor here is not affected.
     {stem}-agent-state.json    ``agent_state`` (tool-call trace) +
                                ``environment_frame`` + verbose
                                ``metadata``. Only written when verbose
@@ -517,11 +519,9 @@ def _existing_sidecars(
     whole point is provenance, an auditor following the meta would read the wrong
     trajectory.
 
-    Pass ``written`` (the keys this run actually wrote) to report truthfully. It
-    is optional so the call sites that genuinely want a disk snapshot keep
-    working — ``enrich_edison_response`` backfills sidecars for the *same*
-    ``task_id`` already recorded in the meta, so for it "what is on disk now" is
-    the honest answer.
+    Pass ``written`` (the keys this run actually wrote) to report truthfully.
+    With ``written=None``, this returns a disk snapshot only; callers must
+    separately validate that task-specific artifacts belong to their task id.
     """
     on_disk = {
         "answer_md": (out_dir / f"{stem}.md").exists(),

--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -20,6 +20,8 @@ REF_FILE="scripts/.vendored_canon_ref"
 
 # Same-path vendored files: identical relative path in the hub and here.
 FILES=(
+  scripts/check_vendored_sync.sh
+  tests/test_provider_triage_contract.py
   scripts/validate_id_label_correspondence.py
   scripts/chem_formula.py
   tests/test_id_label_empty_adapter.py
@@ -31,7 +33,24 @@ FILES=(
 # by this repo's package while the hub's is culturemech. Format "local_glob|hub".
 MAPPED=(
   "src/*/schema/mech_shared.yaml|src/culturemech/schema/mech_shared.yaml"
+  "src/*/schema/history.yaml|src/culturemech/schema/history.yaml"
 )
+
+# Edison capture is shared only by the Mechs that have an Edison runner.
+# Select it by repository identity rather than file existence: existence-based
+# selection would let deleting the local copy silently remove it from the gate.
+REPO_ID="${GITHUB_REPOSITORY:-$(git config --get remote.origin.url || true)}"
+case "$REPO_ID" in
+  *CultureMech*|*TraitMech*|*MediaIngredientMech*|*CommunityMech*)
+    FILES+=(scripts/_edison_capture.py)
+    ;;
+  *proteintraitsmech*)
+    ;;
+  *)
+    echo "ERROR: cannot identify Mech repository from: $REPO_ID" >&2
+    exit 2
+    ;;
+esac
 
 [ -f "$REF_FILE" ] || { echo "ERROR: $REF_FILE missing (pinned canonical commit)"; exit 2; }
 REF="$(tr -d '[:space:]' < "$REF_FILE")"

--- a/scripts/chem_formula.py
+++ b/scripts/chem_formula.py
@@ -29,6 +29,7 @@ __all__ = [
     "parse_formula",
     "parse_ontology_formula",
     "compare_formulas",
+    "hydration_states",
     "build_formula_lookup",
 ]
 
@@ -255,3 +256,56 @@ def compare_formulas(label: str, ontology_formula: str) -> str | None:
     if ws and set(ws) == set(gs):
         return "SUBSCRIPTS_LOST"
     return "CONFLICT"
+
+
+def _label_water_units(text: str) -> int:
+    """Waters of hydration written in a label string; 0 when none is stated.
+
+    Mirrors the tail/dot hydrate handling ``parse_formula`` applies, so it reads
+    the same count that folded into the element multiset: "NiCl2 x 6 H2O" -> 6,
+    "MnSO4 x H2O" -> 1 (the ``x`` is the separator, count implied), "MgSO4" -> 0.
+    A variable multiplier ("VOSO4·xH2O") never reaches here -- ``parse_formula``
+    returns None for it, so ``compare_formulas`` is None and the caller stops.
+    """
+    s = str(text or "").strip()
+    total = 0
+    m = _HYDRATE_TAIL_RE.search(s)
+    if m:
+        total += int(m.group(1) or 1)
+        s = s[: m.start()].strip().rstrip(".·・")
+    m = _HYDRATE_DOT_RE.match(s)
+    if m:
+        total += int(m.group(2) or 1)
+    return total
+
+
+def hydration_states(label: str, ontology_formula: str) -> tuple[int, int] | None:
+    """Waters of hydration on each side of a ``HYDRATE_RELAXED`` pair.
+
+    Returns ``(label_waters, term_waters)`` when the label and the ontology
+    formula share a non-water skeleton and differ ONLY by water of hydration;
+    None when that is not the case, so the caller keeps the old tolerant pass.
+
+    The term's molecular formula may fold its waters into the H/O totals
+    ("H14MgO11S") or spell them out ("Cl2Mn.4H2O") -- either way the folded
+    OXYGEN difference between the two multisets is the difference in waters
+    (each H2O contributes H2 O1), and the label's own stated count anchors that
+    difference to an absolute pair. A difference that is not a whole number of
+    waters (dH != 2·dO, e.g. an -OH vs -H structural change) is refused.
+    """
+    want = parse_formula(label)
+    got = parse_ontology_formula(ontology_formula)
+    if not want or not got:
+        return None
+    ws, gs = _skeleton(want), _skeleton(got)
+    if not ws or ws != gs:
+        return None
+    d_h = want.get("H", 0) - got.get("H", 0)
+    d_o = want.get("O", 0) - got.get("O", 0)
+    if d_o == 0 or d_h != 2 * d_o:
+        return None
+    label_w = _label_water_units(label)
+    term_w = label_w - d_o
+    if term_w < 0:
+        return None                       # inconsistent counts -- refuse to guess
+    return label_w, term_w

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -425,7 +425,13 @@ def rank_stage(config: Mapping[str, Any], focus_name: str, stage_name: str) -> l
                 "limitation": provider.limitation,
             }
         )
-    return sorted(rows, key=lambda row: (-row["fit"], row["provider"]))
+    # Preserve relative order when the absolute-zero fit floor collapses
+    # several (or all) negative raw scores to fit=0.  The public fit meaning
+    # stays unchanged; raw score is only a deterministic tie-breaker.
+    return sorted(
+        rows,
+        key=lambda row: (-row["fit"], -raw[row["provider"]], row["provider"]),
+    )
 
 
 def recommendable(

--- a/scripts/enrich_edison_response.py
+++ b/scripts/enrich_edison_response.py
@@ -67,14 +67,41 @@ def _strip_meta_suffix(name: str) -> str:
     return name
 
 
-def needs_enrichment(out_dir: Path, stem: str, *, force: bool) -> dict[str, bool]:
-    """Return a dict of which sidecars are missing for this stem."""
+def _agent_state_matches_task(out_dir: Path, stem: str, task_id: str) -> bool:
+    """Whether the saved trace is readable and belongs to the task."""
+    path = out_dir / f"{stem}-agent-state.json"
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and str(payload.get("task_id") or "") == task_id
+
+
+def _attributable_sidecars(out_dir: Path, stem: str, task_id: str) -> dict[str, bool]:
+    """Return on-disk sidecars this task's metadata may truthfully claim."""
+    sidecars = ec._existing_sidecars(out_dir, stem)  # pylint: disable=protected-access
+    if sidecars["agent_state_json"]:
+        sidecars["agent_state_json"] = _agent_state_matches_task(out_dir, stem, task_id)
+    return sidecars
+
+
+def needs_enrichment(
+    out_dir: Path, stem: str, *, force: bool, task_id: str | None = None
+) -> dict[str, bool]:
+    """Return which sidecars are absent or cannot be attributed to this task."""
+    task_set_unverified = bool(task_id) and not _agent_state_matches_task(out_dir, stem, task_id)
     return {
-        "response_json": force or not (out_dir / f"{stem}-response.json").exists(),
-        "citations_md": force or not (out_dir / f"{stem}-citations.md").exists(),
-        "agent_state_json": force or not (out_dir / f"{stem}-agent-state.json").exists(),
-        "files_json": force or not (out_dir / f"{stem}-files.json").exists(),
-        "answer_md": force or not (out_dir / f"{stem}.md").exists(),
+        "response_json": force
+        or task_set_unverified
+        or not (out_dir / f"{stem}-response.json").exists(),
+        "citations_md": force
+        or task_set_unverified
+        or not (out_dir / f"{stem}-citations.md").exists(),
+        "agent_state_json": force
+        or task_set_unverified
+        or not (out_dir / f"{stem}-agent-state.json").exists(),
+        "files_json": force or task_set_unverified or not (out_dir / f"{stem}-files.json").exists(),
+        "answer_md": force or task_set_unverified or not (out_dir / f"{stem}.md").exists(),
     }
 
 
@@ -91,13 +118,12 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
 
     stem = _strip_meta_suffix(meta_path.name)
     out_dir = meta_path.parent
-    missing = needs_enrichment(out_dir, stem, force=force)
+    prior_task_set_verified = _agent_state_matches_task(out_dir, stem, task_id)
+    missing = needs_enrichment(out_dir, stem, force=force, task_id=task_id)
     if not any(missing.values()):
         return {"path": str(meta_path), "status": "already-complete", "wrote": []}
 
-    print(
-        f"  + enriching {stem}  (missing: " f"{[k for k, v in missing.items() if v]})", flush=True
-    )
+    print(f"  + enriching {stem}  (missing: {[k for k, v in missing.items() if v]})", flush=True)
 
     if dry_run:
         return {
@@ -197,7 +223,11 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
     # inventory). Always attempt, even when files.json already exists,
     # so re-running picks up artifacts that were missed before.
     artifacts_manifest: list[dict[str, Any]] = []
-    if files_listing is None and (out_dir / f"{stem}-files.json").exists():
+    if (
+        files_listing is None
+        and prior_task_set_verified
+        and (out_dir / f"{stem}-files.json").exists()
+    ):
         try:
             files_listing = json.loads((out_dir / f"{stem}-files.json").read_text())
         except (OSError, json.JSONDecodeError):
@@ -213,13 +243,24 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
             wrote.append("artifacts")
 
     # Refresh the meta yaml with the now-richer field set
+    if prior_task_set_verified:
+        attributable_sidecars = _attributable_sidecars(out_dir, stem, task_id)
+    else:
+        attributable_sidecars = ec._existing_sidecars(  # pylint: disable=protected-access
+            out_dir, stem, set(wrote)
+        )
+        if attributable_sidecars["agent_state_json"]:
+            attributable_sidecars["agent_state_json"] = _agent_state_matches_task(
+                out_dir, stem, task_id
+            )
+
     updates: dict[str, Any] = {
         "answer_chars": len(answer or ""),
         "formatted_answer_chars": len(formatted_answer or ""),
         "has_answer_reasoning": bool(getattr(primary, "answer_reasoning", None)),
         "answer_reasoning_chars": len(getattr(primary, "answer_reasoning", "") or ""),
         "citations_parsed": len(ec.parse_citations(formatted_answer or answer)),
-        "sidecar_files": ec._existing_sidecars(out_dir, stem),  # pylint: disable=protected-access
+        "sidecar_files": attributable_sidecars,
         "artifacts_fetched": [a for a in artifacts_manifest if a.get("status") == "fetched"],
         "artifacts_skipped": [a for a in artifacts_manifest if a.get("status") != "fetched"],
         "enriched_at": ec._to_iso(datetime.now(timezone.utc)),

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -146,7 +146,16 @@ _ERROR_VERDICTS = {
 # Reported, actionable, but NOT fatal: the grounding is correct and only the
 # label lost its subscript glyphs upstream ("NaCO3" for Na2CO3). Repairing the
 # name is a data-cleanup task, not a mapping error, so it must not fail enforce.
-_WARN_VERDICTS = {"LABEL_SUBSCRIPTS_LOST"}
+# The label's element skeleton matches the term's but the waters of hydration
+# differ. All three are the same MAPPING_SEMANTICS.md Section 3 collapse seen
+# from different sides — reported for curation, never fatal (a hydrate grounded
+# to its anhydrous parent is a defensible interim mapping).
+_HYDRATION_VERDICTS = {
+    "HYDRATE_ON_ANHYDROUS_TERM",   # label has water, term has none
+    "ANHYDROUS_ON_HYDRATE_TERM",   # term has water, label has none
+    "HYDRATION_STATE_MISMATCH",    # both have water, different amounts
+}
+_WARN_VERDICTS = {"LABEL_SUBSCRIPTS_LOST"} | _HYDRATION_VERDICTS
 
 # Path segments under which a `term`/`chebi_term` label-waiver does NOT apply:
 # organism (NCBITaxon) and environment (ENVO) groundings must carry the canonical
@@ -406,8 +415,30 @@ def _plausibility_verdict(
 
     if formula and chem_formula.looks_like_formula(label):
         cmp = chem_formula.compare_formulas(label, formula)
-        if cmp in ("MATCH", "HYDRATE_RELAXED"):
-            return "OK_ID_ONLY", f"formula {cmp.lower()}"
+        if cmp == "MATCH":
+            return "OK_ID_ONLY", "formula match"
+        if cmp == "HYDRATE_RELAXED":
+            # Skeletons agree but the water counts differ. That is symmetric, so
+            # a single "label has extra water" verdict asserts the opposite of
+            # the facts half the time. Split it by comparing the waters on each
+            # side; when the split is not decidable, keep the tolerant pass.
+            states = chem_formula.hydration_states(label, formula)
+            if states is None:
+                return "OK_ID_ONLY", "formula hydrate_relaxed"
+            label_w, term_w = states
+            if term_w == 0:
+                return "HYDRATE_ON_ANHYDROUS_TERM", (
+                    f"label states {label_w} water(s) of hydration that "
+                    f"'{canonical or formula}' (anhydrous) lacks — ground to a "
+                    "hydrate-specific term, or mint cas:<hydrate CAS> with a "
+                    "narrowMatch to this parent (MAPPING_SEMANTICS.md Section 3)")
+            if label_w == 0:
+                return "ANHYDROUS_ON_HYDRATE_TERM", (
+                    f"term carries {term_w} water(s) of hydration the anhydrous "
+                    "label lacks — ground to the anhydrous term instead")
+            return "HYDRATION_STATE_MISMATCH", (
+                f"label states {label_w} water(s), term states {term_w} — ground "
+                "to the term whose hydration state the label actually names")
         if cmp == "SUBSCRIPTS_LOST":
             # Correct grounding, damaged label — flag for name repair, not as a
             # mapping error.
@@ -849,16 +880,20 @@ def run(config_path: Path, report_path: Path | None) -> int:
                 # residuals of exactly the kind the allow-list exists for — a
                 # correct grounding the heuristic cannot see is correct
                 # ("soy peptone" on FOODON "vegetable protein, hydrolyzed"
-                # shares no word) — so they are waivable too. Structural errors
-                # (UNKNOWN_PREFIX, ADAPTER_ERROR, MISSING_*) remain unwaivable.
+                # shares no word) — so they are waivable too. The three
+                # _HYDRATION_VERDICTS are the same kind of curator-judgeable
+                # residual (a hydrate grounded to its anhydrous parent when no
+                # hydrate term exists yet), so a curator gets the same escape
+                # hatch. Structural errors (UNKNOWN_PREFIX, ADAPTER_ERROR,
+                # MISSING_*) remain unwaivable.
                 # ID_OUT_OF_RANGE explicitly signals a foreign identifier
                 # wearing an OBO prefix (e.g. PubChem CID as CHEBI:) — that's
                 # the one class the allow-list must NOT cover; a curator who
                 # really wants to keep such an id should add its true prefix
                 # to `ignored_prefixes` instead.
                 if rec["verdict"] in (
-                    "MISMATCH", "ID_NOT_FOUND", "IMPLAUSIBLE_LABEL",
-                    "LABEL_SUBSCRIPTS_LOST",
+                    {"MISMATCH", "ID_NOT_FOUND", "IMPLAUSIBLE_LABEL",
+                     "LABEL_SUBSCRIPTS_LOST"} | _HYDRATION_VERDICTS
                 ) and (curie, normalize(label)) in exceptions:
                     rec["verdict"] = "OK_EXCEPTION"
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
@@ -889,6 +924,9 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "IMPLAUSIBLE_LABEL",
         "ID_OUT_OF_RANGE",
         "LABEL_SUBSCRIPTS_LOST",
+        "HYDRATE_ON_ANHYDROUS_TERM",
+        "ANHYDROUS_ON_HYDRATE_TERM",
+        "HYDRATION_STATE_MISMATCH",
         "SKIPPED_NO_ADAPTER",
         "SKIPPED_EMPTY_ADAPTER",
     ):

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -335,3 +335,26 @@ def test_main_rejects_unknown_provider_argument():
 def test_main_rejects_unknown_focus_argument():
     with pytest.raises(ValueError, match="Unknown focus"):
         drp.main(["--config", str(CONFIG_PATH), "--focus", "not-a-real-focus"])
+
+
+def test_all_negative_scores_keep_their_relative_order():
+    """Fit may floor at zero, but routing must still prefer the least-bad score."""
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+
+    # Deliberately make reverse-alphabetical order the raw-score order.  The
+    # old fit-only sort returned alphabetical order once every fit floored to 0.
+    expected = sorted(drp.PROVIDERS, reverse=True)
+    config["focuses"][focus_name]["provider_adjustments"] = {
+        provider: -(index + 1) for index, provider in enumerate(expected)
+    }
+
+    rows = drp.rank_stage(config, focus_name, stage_name)
+    assert all(row["fit"] == 0 for row in rows)
+    assert [row["provider"] for row in rows] == expected

--- a/tests/test_enrich_edison_response_provenance.py
+++ b/tests/test_enrich_edison_response_provenance.py
@@ -1,0 +1,123 @@
+"""Regression tests for task-aware Edison enrichment provenance."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+er = importlib.import_module("enrich_edison_response")
+
+STEM = "example-edison-literature"
+
+
+class _Response:
+    answer = "answer"
+    formatted_answer = "answer\n\nReferences\n\n1. Example\n"
+    answer_reasoning = None
+    created_at = None
+
+
+class _Client:
+    def __init__(self, *, fail_verbose: bool = False, fail_files: bool = False):
+        self.fail_verbose = fail_verbose
+        self.fail_files = fail_files
+        self.verbose_calls = 0
+
+    def get_task(self, *, task_id: str, verbose: bool):
+        if verbose:
+            self.verbose_calls += 1
+            if self.fail_verbose:
+                raise RuntimeError("fixture failure")
+            return type(
+                "Verbose",
+                (),
+                {"agent_state": [{"tool": "search"}], "environment_frame": None, "metadata": None},
+            )()
+        return _Response()
+
+    def list_files(self, *, trajectory_id: str):
+        if self.fail_files:
+            raise RuntimeError("fixture failure")
+        return []
+
+
+def _write_fixture(tmp_path: Path, *, trace_task: str = "task-OLD") -> Path:
+    meta_path = tmp_path / f"{STEM}-meta.yaml"
+    meta_path.write_text(yaml.safe_dump({"status": "success", "task_id": "task-NEW"}))
+    (tmp_path / f"{STEM}.md").write_text("answer")
+    (tmp_path / f"{STEM}-response.json").write_text("{}")
+    (tmp_path / f"{STEM}-citations.md").write_text("# Citations\n")
+    (tmp_path / f"{STEM}-agent-state.json").write_text(
+        json.dumps({"task_id": trace_task, "agent_state": []})
+    )
+    # files.json is deliberately absent so enrichment cannot early-return.
+    return meta_path
+
+
+def test_agent_state_presence_requires_the_current_task_id(tmp_path):
+    _write_fixture(tmp_path)
+    missing = er.needs_enrichment(tmp_path, STEM, force=False, task_id="task-NEW")
+    assert missing["agent_state_json"] is True
+    assert all(missing.values())
+
+    (tmp_path / f"{STEM}-agent-state.json").write_text(
+        json.dumps({"task_id": "task-NEW", "agent_state": []})
+    )
+    assert (
+        er.needs_enrichment(tmp_path, STEM, force=False, task_id="task-NEW")["agent_state_json"]
+        is False
+    )
+
+
+def test_enrichment_refetches_a_stale_trace_and_attributes_the_new_one(tmp_path):
+    meta_path = _write_fixture(tmp_path)
+    client = _Client()
+
+    result = er.enrich_one(client, meta_path, force=False, dry_run=False)
+
+    assert result["status"] == "enriched"
+    assert client.verbose_calls == 1
+    trace = json.loads((tmp_path / f"{STEM}-agent-state.json").read_text())
+    assert trace["task_id"] == "task-NEW"
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["sidecar_files"]["agent_state_json"] is True
+
+
+def test_failed_refetch_does_not_reassert_the_stale_trace(tmp_path):
+    meta_path = _write_fixture(tmp_path)
+    client = _Client(fail_verbose=True)
+
+    result = er.enrich_one(client, meta_path, force=False, dry_run=False)
+
+    assert result["status"] == "enriched"
+    trace = json.loads((tmp_path / f"{STEM}-agent-state.json").read_text())
+    assert trace["task_id"] == "task-OLD"
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["task_id"] == "task-NEW"
+    assert meta["sidecar_files"]["agent_state_json"] is False
+
+
+def test_task_mismatch_does_not_claim_any_sidecar_that_failed_to_refresh(tmp_path):
+    meta_path = _write_fixture(tmp_path)
+    (tmp_path / f"{STEM}-files.json").write_text('[{"name": "stale.yaml"}]')
+    client = _Client(fail_verbose=True, fail_files=True)
+
+    result = er.enrich_one(client, meta_path, force=False, dry_run=False)
+
+    assert result["status"] == "enriched"
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["sidecar_files"] == {
+        "answer_md": True,
+        "response_json": True,
+        "citations_md": True,
+        "agent_state_json": False,
+        "files_json": False,
+    }
+    assert meta["artifacts_fetched"] == []
+    assert meta["artifacts_skipped"] == []

--- a/tests/test_id_label_plausibility.py
+++ b/tests/test_id_label_plausibility.py
@@ -78,12 +78,33 @@ def _classify(label: str, curie: str, **kw):
 @pytest.mark.parametrize("label,curie", [
     ("Distilled water", "CHEBI:15377"),   # shares the word "water"
     ("KH2PO4", "CHEBI:63036"),            # formula matches exactly
-    ("MnCl2 x 4 H2O", "CHEBI:86368"),     # formula matches exactly
-    ("NiCl2 x 6 H2O", "CHEBI:34887"),     # hydrate → anhydrous parent, tolerated
+    ("MnCl2 x 4 H2O", "CHEBI:86368"),     # formula matches exactly (right hydrate)
     ("H2O", "CHEBI:15377"),               # matches a synonym
 ])
 def test_curator_labels_still_pass(label, curie):
     assert _classify(label, curie) == "OK_ID_ONLY"
+
+
+@pytest.mark.parametrize("label,curie,verdict", [
+    # label has waters the term lacks — the case #242 set out to surface. The
+    # remedy is a hydrate-specific term or a cas: mint, NOT accepting it silently.
+    ("NiCl2 x 6 H2O", "CHEBI:34887", "HYDRATE_ON_ANHYDROUS_TERM"),
+    # term is a hydrate, the label is anhydrous — a DIFFERENT substance, whose
+    # remedy (the anhydrous term) is the opposite of the case above.
+    ("MnCl2", "CHEBI:86368", "ANHYDROUS_ON_HYDRATE_TERM"),
+    # both are hydrates, but of different states.
+    ("MnCl2 x 6 H2O", "CHEBI:86368", "HYDRATION_STATE_MISMATCH"),
+])
+def test_hydration_state_is_split_by_which_side_carries_water(label, curie, verdict):
+    """`compare_formulas` returns HYDRATE_RELAXED symmetrically; a single
+    "label has extra water" verdict is right only a third of the time (#242)."""
+    assert _classify(label, curie) == verdict
+
+
+def test_hydration_verdicts_are_non_blocking():
+    """All three are curation signals, never enforce failures."""
+    assert mod._HYDRATION_VERDICTS <= mod._WARN_VERDICTS
+    assert not (mod._HYDRATION_VERDICTS & mod._ERROR_VERDICTS)
 
 
 @pytest.mark.parametrize("label,curie", [
@@ -141,6 +162,33 @@ def test_default_waiver_mode_is_unchanged():
 ])
 def test_formula_comparison(label, formula, expected):
     assert chem.compare_formulas(label, formula) == expected
+
+
+@pytest.mark.parametrize("label,formula,expected", [
+    # (label_waters, term_waters). Term formula folded ("Cl2Ni") or spelled
+    # out (".4H2O") — the oxygen delta plus the label's own count recover both.
+    ("NiCl2 x 6 H2O", "Cl2Ni", (6, 0)),
+    ("MnCl2", "Cl2Mn.4H2O", (0, 4)),
+    ("MnCl2 x 6 H2O", "Cl2Mn.4H2O", (6, 4)),
+    ("MnCl2 x H2O", "Cl2Mn.4H2O", (1, 4)),          # implied monohydrate
+    # not a hydration question: exact match, and an element conflict.
+    ("MnCl2 x 4 H2O", "Cl2Mn.4H2O", None),          # MATCH, no water gap
+    ("KI", "Cl2Ni", None),                          # skeletons differ
+])
+def test_hydration_states_reads_water_on_each_side(label, formula, expected):
+    assert chem.hydration_states(label, formula) == expected
+
+
+@pytest.mark.parametrize("label,expected", [
+    ("NiCl2 x 6 H2O", 6),
+    ("CuSO4·5H2O", 5),
+    ("Na2MoO4. 2H2O", 2),
+    ("MnSO4 x H2O", 1),     # x is the separator, monohydrate
+    ("MgSO4", 0),           # anhydrous
+    ("glucose", 0),
+])
+def test_label_water_units(label, expected):
+    assert chem._label_water_units(label) == expected
 
 
 def test_roman_oxidation_state_parses():

--- a/tests/test_provider_triage_contract.py
+++ b/tests/test_provider_triage_contract.py
@@ -1,0 +1,116 @@
+"""Fleet contract for shared provider-triage behavior.
+
+This suite performs only local scoring and status stubbing. It never invokes a
+research provider and cannot spend provider credits. Domain profiles and richer
+Mech-specific status models remain intentionally local.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+drp = importlib.import_module("deep_research_provider")
+CONFIG_PATH = REPO_ROOT / "conf" / "deep_research_provider.yaml"
+
+
+def _all_available(provider: str, environ=None) -> tuple[str, str]:
+    del provider, environ
+    return "available", "contract fixture; no provider call"
+
+
+def _first_stage(config):
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    return focus_name, stage_name
+
+
+def test_policy_flags_are_a_shared_cli_contract():
+    args = drp.parse_args(["--config", str(CONFIG_PATH), "--allow", "asta", "--no-paid"])
+    assert args.allow == "asta"
+    assert args.no_paid is True
+
+
+def test_allowlist_and_no_paid_constrain_every_recommendation(monkeypatch):
+    monkeypatch.setattr(drp, "provider_status", _all_available)
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+
+    allowlisted = drp.build_report(config, focus_name, allow=frozenset({"asta"}), no_paid=False)
+    for stage in allowlisted["stages"]:
+        assert stage["recommended_available"]["provider"] == "asta"
+        assert stage["fallback_available"] is None
+
+    no_paid = drp.build_report(config, focus_name, no_paid=True)
+    for stage in no_paid["stages"]:
+        for key in ("recommended_available", "fallback_available"):
+            row = stage[key]
+            if row:
+                assert row["cost"] not in drp.PAID_COSTS
+
+
+def test_all_negative_scores_keep_their_relative_order(monkeypatch):
+    monkeypatch.setattr(drp, "provider_status", _all_available)
+    config = copy.deepcopy(drp.load_config(CONFIG_PATH))
+    focus_name, stage_name = _first_stage(config)
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+
+    expected = sorted(drp.PROVIDERS, reverse=True)
+    config["focuses"][focus_name]["provider_adjustments"] = {
+        provider: -(index + 1) for index, provider in enumerate(expected)
+    }
+    rows = drp.rank_stage(config, focus_name, stage_name)
+
+    assert {row["fit"] for row in rows} == {0}
+    assert [row["provider"] for row in rows] == expected
+
+
+def test_provider_filtered_json_is_internally_consistent(monkeypatch, capsys):
+    monkeypatch.setattr(drp, "provider_status", _all_available)
+    assert (
+        drp.main(
+            [
+                "--config",
+                str(CONFIG_PATH),
+                "--provider",
+                "asta",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    report = json.loads(capsys.readouterr().out)
+    for stage in report["stages"]:
+        ranked = {row["provider"] for row in stage["ranking"]}
+        for key in ("recommended_available", "fallback_available"):
+            row = stage[key]
+            if row:
+                assert row["provider"] in ranked
+        if "selected" in stage:
+            assert stage["selected"]["provider"] == "asta"
+            assert "asta" in ranked
+        else:
+            assert ranked == {"asta"}
+
+
+def test_unknown_capability_is_rejected_before_scoring(tmp_path):
+    config = copy.deepcopy(drp.load_config(CONFIG_PATH))
+    focus_name, stage_name = _first_stage(config)
+    config["focuses"][focus_name]["stages"][stage_name]["capabilities"]["not_a_real_capability"] = 1
+    path = tmp_path / "bad-provider-profile.yaml"
+    path.write_text(yaml.safe_dump(config))
+
+    with pytest.raises(ValueError, match="unknown capability"):
+        drp.load_config(path)


### PR DESCRIPTION
Closes #673. Addresses CultureBotAI/CultureMech#330.

- makes Edison enrichment invalidate a whole stale same-stem sidecar set;
- claims only artifacts refreshed for the current task after a mismatch;
- preserves least-bad provider order when displayed negative fits floor to zero;
- adds the shared credit-free provider behavior contract;
- self-governs the vendored checker and Edison helper;
- updates the pinned validator/chemistry release from the merged hub.

Verification: 34 provider/Edison tests and 69 vendored-validator tests passed;
exact sync against CultureMech 8f7a44ab passed; Ruff/shell/diff checks passed.
No provider call and no provider credits.
