### PR TITLE
Add review-open-issues skill

### DIFF
--- a/.claude/skills/next-tasks/SKILL.md
+++ b/.claude/skills/next-tasks/SKILL.md
@@ -131,6 +131,8 @@ record the new state.
 
 - `scout-communities` — find *new* work from the literature (this skill only
   works the existing backlog).
+- `review-open-issues` — triage the full open-issue queue periodically; use
+  this skill for routine "what's next" checks and `NEXT_TASKS.md` upkeep.
 - `deep-research-community`, `add-growth-conditions`, `review-communities`,
   `evidence-curation`, `manage-identifiers` — the skills a chosen backlog item
   is usually handed off to.

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -41,24 +41,19 @@ ranking; it does not implement fixes.
 ### Step 1 — Fetch the full open-issue queue
 
 ```bash
-gh issue list --state open --limit 300 --json number,title,body,labels,createdAt,updatedAt \
-  -q '.[] | "\(.number)\t\(.createdAt[:10])\t\(.title)"'
+queue_file="${TMPDIR:-/tmp}/communitymech-open-issues.json"
+gh issue list --state open --limit 5000 \
+  --json number,title,body,labels,comments,createdAt,updatedAt > "$queue_file"
+jq -r '.[] | [.number, .createdAt[:10], .title] | @tsv' "$queue_file"
+jq length "$queue_file"
 ```
 
-The `-q` filter above only prints `number`/`createdAt`/`title` for a scannable
-overview — `body` and `labels` are still fetched (Step 2's grouping and Step 3's
-staleness checks need them) but not shown by this line. Use `gh issue view <N>`
-to read an individual issue's body, or widen the `-q` expression if scanning
-bodies in bulk.
-
-Do not truncate silently. `gh issue list --limit` has no hard cap near 300 —
-`gh` auto-paginates through GitHub's API, so a repo with thousands of open
-issues still returns the full set from a single call with a high enough
-`--limit`. If the 300-item fetch above turns out to be short, first confirm
-the true count (`gh issue list --state open --limit 5000 --json number | jq
-length` — omitting `--limit` silently caps at gh's default of 30), then
-re-run Step 1 with `--limit` comfortably above that count rather than
-sampling.
+The first command preserves every requested field; the second derives a
+scannable overview without throwing away the bodies and labels needed below.
+Read and group from the saved JSON, not from the overview alone. Omitting
+`--limit` silently caps at gh's default of 30. If the saved array has exactly
+5000 entries, treat that as possible truncation and re-run with a higher limit
+before claiming full-queue coverage.
 
 ### Step 2 — Group and dedupe
 
@@ -68,23 +63,29 @@ several may describe the same root cause from different angles. Group by:
 - same file/function named,
 - near-identical failure scenario.
 
+Inspect each saved issue object's title, body, labels, and comments while
+grouping. A group is an organizational aid, not permission to skip its
+individual issues.
 Note groups explicitly in the report; do not silently merge them (a human may
 want to close duplicates deliberately, not have them hidden).
 
 ### Step 3 — Check each issue against current reality
 
-For each issue (or each group's representative), spot-check:
+For every issue, check:
 
-- **Already fixed?** `git log --oneline --all --perl-regexp --grep "#<N>\b"`
-  and `gh pr list --state merged --search "<N>"` — an issue whose fix already
-  merged should be flagged STALE/CLOSE, not re-surfaced as open work. Plain
-  `--grep "#<N>"` substring-matches unrelated numbers (`#48` also matches
-  `#480`, `#4823`, ...) — the `\b` word-boundary anchor above is required, not
-  optional. Treat the `gh pr list --search` result as a lead, not proof:
-  GitHub's search matches the number anywhere in the indexed text, not
-  anchored to an issue reference (`--search "248"` also returns unrelated
-  PRs like #14006 that never mention issue 248) — open and read each
-  candidate PR before citing it as evidence.
+- **Already fixed on the default branch?** Refresh the base ref with `git fetch
+  origin main`, then use `git log --oneline origin/main --perl-regexp --grep
+  "#<N>\b"`. Plain `--grep "#<N>"` substring-matches unrelated numbers (`#48`
+  also matches `#480`, `#4823`, ...), so the `\b` boundary is required. Do not
+  use `--all`: commits found only on an unmerged branch are work in progress,
+  not evidence that the issue is fixed.
+- **Closed by a merged PR?** Get exact linked candidates with `gh issue view
+  <N> --json closedByPullRequestsReferences --jq
+  '.closedByPullRequestsReferences[] | [.number, .url] | @tsv'`, then verify
+  each candidate's `mergedAt` using `gh pr view <PR> --json mergedAt`. Do not
+  use a bare-number `gh pr list --search`: it substring-matches unrelated PR
+  text. An issue whose fix actually reached `main` should be flagged
+  STALE/CLOSE, not re-surfaced as open work.
 - **Still reproducible?** If the issue names a specific file/line/function,
   confirm it still exists in that shape (`grep`/`git log -p` the cited
   location) — code moves, and a stale issue pointing at a renamed/removed
@@ -152,12 +153,9 @@ the queue.
 
 ## Notes & limitations
 
-- `gh issue list --json` doesn't include `comments` unless explicitly
-  requested (add `comments` to the `--json` field list) — Step 1's query
-  above doesn't request it, so a "fixed already" claim buried in a later
-  comment thread won't surface from that fetch alone; either widen the
-  `--json` fields or check `gh issue view <N> --comments` for issues that
-  look ambiguous.
+- `comments` must remain in Step 1's explicit `--json` field list; otherwise a
+  "fixed already" claim buried in a later comment thread will not be present
+  in the saved queue.
 - Cross-repo issues (a defect described once but relevant to multiple Mechs)
   are common in this org — note if an issue's fix should propagate elsewhere,
   but do not open issues in sibling repos without being asked.

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -111,9 +111,13 @@ sparingly and justify it; most issues are P1 or P2.
 ### Step 6 — Act only when asked
 
 This skill does not close issues, comment, or create/update a tracker issue on
-its own. When the user confirms:
-- **Closing stale/duplicate issues**: use `gh issue close <N> --comment
-  "<reason>"`, one at a time, with the evidence from Step 3 in the comment.
+its own, and a general "yes, go ahead" is not blanket approval to loop over
+every STALE/CLOSE candidate unattended:
+- **Closing stale/duplicate issues**: confirm with the user which specific
+  issue number(s) to close before each closure — do not treat one general
+  approval as authorization for an unattended `gh issue close` loop. Once
+  confirmed, use `gh issue close <N> --comment "<reason>"`, one at a time,
+  with the evidence from Step 3 in the comment.
 - **Maintaining the tracker issue**: as of this skill's authoring, this repo
   had one open — **#669**, "[P0-P2 tracker] Repository safety, test,
   documentation, CI, and packaging remediation". Verify it's still open

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: review-open-issues
+description: Sweep and triage the full open-issue queue for CommunityMech — not just NEXT_TASKS.md. Fetches every open issue, checks each against the current code/schema for staleness (already fixed, superseded, or no longer reproducible), flags likely duplicates, and assigns a priority tier (P0 blocking/correctness/security, P1 real-but-schedulable, P2 low-severity/process/doc). Produces a short, ranked report; only touches GitHub (closing stale issues, updating/creating a tracker issue) when asked. Use when the user asks to "review issues", "prioritize the backlog", "triage open issues", or the open-issue count has grown large enough that NEXT_TASKS.md-only review is insufficient.
+category: workflow
+requires_database: false
+requires_internet: true
+version: 1.0.0
+---
+
+# Review & Prioritize Open Issues
+
+## Overview
+
+**Purpose**: the raw GitHub issue queue and `NEXT_TASKS.md` are different
+surfaces. `next-tasks` reconciles a small, curated, actively-maintained backlog
+file. This skill sweeps the *entire* open-issue queue — which grows much
+larger and drifts independently (issues opened by review passes, other agents,
+or humans, many of which are never transcribed into `NEXT_TASKS.md`) — and
+produces an honest, current priority ranking.
+
+**Why this is a distinct skill, not a `next-tasks` step**: `next-tasks`
+Step 1 already runs `gh issue list --limit 30` as *context* for reconciling the
+backlog file: it stops at the first page and never assesses issue validity
+individually. This skill is the deep pass: paginate the whole queue, check each
+issue against current code, and produce a full triage — expensive enough that
+it should not run on every "what's next" invocation, only when explicitly
+asked or when the backlog has clearly gone stale.
+
+**When to use**: the user asks to "review issues", "prioritize open issues",
+"triage the backlog", "what issues are actually urgent", or after a large
+review pass (like a fleet PR review) has filed a batch of new issues that need
+sorting. CommunityMech already has an active tracker issue (#669) — this
+skill is how you refresh it, not a replacement for it.
+
+**When NOT to use**: for `NEXT_TASKS.md` upkeep or picking the next unit of
+work to implement — that's `next-tasks`. This skill produces a priority
+ranking; it does not implement fixes.
+
+## Workflow
+
+### Step 1 — Fetch the full open-issue queue
+
+```bash
+gh issue list --state open --limit 300 --json number,title,body,labels,createdAt,updatedAt \
+  -q '.[] | "\(.number)\t\(.createdAt[:10])\t\(.title)"'
+```
+
+Do not truncate silently. If the queue exceeds 300, say so explicitly and
+paginate (`gh issue list ... --json ... -q ...` supports `--limit` up to
+GitHub's cap; beyond that, note the true count via `gh issue list --state open
+--json number | jq length` and sample rather than claim full coverage).
+
+### Step 2 — Group and dedupe
+
+Issues filed from the same review pass (same PR, same session) often overlap —
+several may describe the same root cause from different angles. Group by:
+- shared PR/commit reference in the title or body,
+- same file/function named,
+- near-identical failure scenario.
+
+Note groups explicitly in the report; do not silently merge them (a human may
+want to close duplicates deliberately, not have them hidden).
+
+### Step 3 — Check each issue against current reality
+
+For each issue (or each group's representative), spot-check:
+
+- **Already fixed?** `git log --oneline --all --grep "#<N>"` and `gh pr list
+  --state merged --search "<N>"` — an issue whose fix already merged should be
+  flagged STALE/CLOSE, not re-surfaced as open work.
+- **Still reproducible?** If the issue names a specific file/line/function,
+  confirm it still exists in that shape (`grep`/`git log -p` the cited
+  location) — code moves, and a stale issue pointing at a renamed/removed
+  function is noise, not a live defect.
+- **Superseded?** Does a newer issue or a merged PR's description explicitly
+  supersede this one?
+
+### Step 4 — Assign priority
+
+- **P0 — blocking/correctness/security.** Data corruption, a crash/hang in a
+  path every caller hits, a security-relevant defect (injection, secret
+  exposure, auth bypass), or something that silently produces wrong output
+  with no detection. Fix before anything else ships.
+- **P1 — real, schedulable.** A genuine defect or gap that doesn't block
+  everything but should be fixed soon — most test-coverage gaps for
+  safety-critical code, real (if narrow) bugs, process gaps that have already
+  caused a near-miss.
+- **P2 — low-severity/process/doc.** Documentation drift, stale comments,
+  minor test-coverage gaps in non-critical paths, style/convention issues.
+
+Do not default everything to P1 — that makes the tier meaningless. Use P0
+sparingly and justify it; most issues are P1 or P2.
+
+### Step 5 — Present the report
+
+- Ranked list, P0 first, one line per issue/group with number + one-sentence
+  why.
+- Explicitly call out: issues recommended for closing (fixed/stale/duplicate),
+  with the evidence (commit/PR that fixed it, or why it no longer applies).
+- **Recommend a top 2–3** to act on next, with reasoning.
+- Do not silently drop old issues from the report — if something is 6 months
+  old and still open, say so; that itself is a signal.
+
+### Step 6 — Act only when asked
+
+This skill does not close issues, comment, or create/update a tracker issue on
+its own. When the user confirms:
+- **Closing stale/duplicate issues**: use `gh issue close <N> --comment
+  "<reason>"`, one at a time, with the evidence from Step 3 in the comment.
+- **Maintaining the tracker issue**: this repo already has one — **#669**,
+  "[P0-P2 tracker] Repository safety, test, documentation, CI, and packaging
+  remediation". Update it in place (`gh issue comment 669 --body "..."` or
+  edit its body) rather than creating a second one. Only create a new tracker
+  if the user explicitly says #669 has been superseded/closed and a fresh one
+  is wanted.
+
+Never bulk-close without per-item confirmation of the evidence — an agent
+closing a live issue because it *looks* stale is worse than leaving noise in
+the queue.
+
+## Conventions this skill enforces
+
+- **Full-queue coverage, not first-page sampling.** State exactly how many
+  issues were reviewed and whether coverage was complete.
+- **Evidence over vibes.** Every STALE/CLOSE/duplicate recommendation cites a
+  specific commit, PR, or code location — never "this looks done."
+- **P0 is rare.** If more than ~10% of issues land P0, the tier calibration is
+  probably wrong; recheck.
+- **Read-only by default.** Reporting and ranking happen automatically;
+  closing issues or touching a tracker issue requires explicit confirmation.
+
+## Notes & limitations
+
+- `gh issue list` json mode does not include issue *comments* — a "fixed
+  already" claim in a later comment thread won't surface automatically; check
+  `gh issue view <N> --comments` for issues that look ambiguous.
+- Cross-repo issues (a defect described once but relevant to multiple Mechs)
+  are common in this org — note if an issue's fix should propagate elsewhere,
+  but do not open issues in sibling repos without being asked.
+- No @-mentions in issue comments or tracker updates without explicit
+  per-mention authorization (standing rule).
+- The existing tracker (#669) predates this skill; reconcile it against
+  reality the same as any other issue before trusting its current contents.
+
+## Related
+
+- `next-tasks` — the lighter, `NEXT_TASKS.md`-scoped backlog check; run that
+  for "what's next" during active work. Run this skill for a full-queue sweep.
+
+## Related files
+
+- `NEXT_TASKS.md` — items promoted from this skill's ranking often get logged
+  here too, so `next-tasks` picks them up on the next reconcile.

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -45,6 +45,12 @@ gh issue list --state open --limit 300 --json number,title,body,labels,createdAt
   -q '.[] | "\(.number)\t\(.createdAt[:10])\t\(.title)"'
 ```
 
+The `-q` filter above only prints `number`/`createdAt`/`title` for a scannable
+overview — `body` and `labels` are still fetched (Step 2's grouping and Step 3's
+staleness checks need them) but not shown by this line. Use `gh issue view <N>`
+to read an individual issue's body, or widen the `-q` expression if scanning
+bodies in bulk.
+
 Do not truncate silently. `gh issue list --limit` has no hard cap near 300 —
 `gh` auto-paginates through GitHub's API, so a repo with thousands of open
 issues still returns the full set from a single call with a high enough
@@ -74,7 +80,11 @@ For each issue (or each group's representative), spot-check:
   merged should be flagged STALE/CLOSE, not re-surfaced as open work. Plain
   `--grep "#<N>"` substring-matches unrelated numbers (`#48` also matches
   `#480`, `#4823`, ...) — the `\b` word-boundary anchor above is required, not
-  optional.
+  optional. Treat the `gh pr list --search` result as a lead, not proof:
+  GitHub's search matches the number anywhere in the indexed text, not
+  anchored to an issue reference (`--search "248"` also returns unrelated
+  PRs like #14006 that never mention issue 248) — open and read each
+  candidate PR before citing it as evidence.
 - **Still reproducible?** If the issue names a specific file/line/function,
   confirm it still exists in that shape (`grep`/`git log -p` the cited
   location) — code moves, and a stale issue pointing at a renamed/removed

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -69,9 +69,12 @@ want to close duplicates deliberately, not have them hidden).
 
 For each issue (or each group's representative), spot-check:
 
-- **Already fixed?** `git log --oneline --all --grep "#<N>"` and `gh pr list
-  --state merged --search "<N>"` — an issue whose fix already merged should be
-  flagged STALE/CLOSE, not re-surfaced as open work.
+- **Already fixed?** `git log --oneline --all --perl-regexp --grep "#<N>\b"`
+  and `gh pr list --state merged --search "<N>"` — an issue whose fix already
+  merged should be flagged STALE/CLOSE, not re-surfaced as open work. Plain
+  `--grep "#<N>"` substring-matches unrelated numbers (`#48` also matches
+  `#480`, `#4823`, ...) — the `\b` word-boundary anchor above is required, not
+  optional.
 - **Still reproducible?** If the issue names a specific file/line/function,
   confirm it still exists in that shape (`grep`/`git log -p` the cited
   location) — code moves, and a stale issue pointing at a renamed/removed

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -45,11 +45,14 @@ gh issue list --state open --limit 300 --json number,title,body,labels,createdAt
   -q '.[] | "\(.number)\t\(.createdAt[:10])\t\(.title)"'
 ```
 
-Do not truncate silently. If the queue exceeds 300, say so explicitly and
-paginate (`gh issue list ... --json ... -q ...` supports `--limit` up to
-GitHub's cap; beyond that, note the true count via `gh issue list --state open
---limit 1000 --json number | jq length` — omitting `--limit` silently caps at
-gh's default of 30 — and sample rather than claim full coverage).
+Do not truncate silently. `gh issue list --limit` has no hard cap near 300 —
+`gh` auto-paginates through GitHub's API, so a repo with thousands of open
+issues still returns the full set from a single call with a high enough
+`--limit`. If the 300-item fetch above turns out to be short, first confirm
+the true count (`gh issue list --state open --limit 5000 --json number | jq
+length` — omitting `--limit` silently caps at gh's default of 30), then
+re-run Step 1 with `--limit` comfortably above that count rather than
+sampling.
 
 ### Step 2 — Group and dedupe
 
@@ -132,9 +135,12 @@ the queue.
 
 ## Notes & limitations
 
-- `gh issue list` json mode does not include issue *comments* — a "fixed
-  already" claim in a later comment thread won't surface automatically; check
-  `gh issue view <N> --comments` for issues that look ambiguous.
+- `gh issue list --json` doesn't include `comments` unless explicitly
+  requested (add `comments` to the `--json` field list) — Step 1's query
+  above doesn't request it, so a "fixed already" claim buried in a later
+  comment thread won't surface from that fetch alone; either widen the
+  `--json` fields or check `gh issue view <N> --comments` for issues that
+  look ambiguous.
 - Cross-repo issues (a defect described once but relevant to multiple Mechs)
   are common in this org — note if an issue's fix should propagate elsewhere,
   but do not open issues in sibling repos without being asked.

--- a/.claude/skills/review-open-issues/SKILL.md
+++ b/.claude/skills/review-open-issues/SKILL.md
@@ -48,7 +48,8 @@ gh issue list --state open --limit 300 --json number,title,body,labels,createdAt
 Do not truncate silently. If the queue exceeds 300, say so explicitly and
 paginate (`gh issue list ... --json ... -q ...` supports `--limit` up to
 GitHub's cap; beyond that, note the true count via `gh issue list --state open
---json number | jq length` and sample rather than claim full coverage).
+--limit 1000 --json number | jq length` — omitting `--limit` silently caps at
+gh's default of 30 — and sample rather than claim full coverage).
 
 ### Step 2 — Group and dedupe
 
@@ -107,12 +108,12 @@ This skill does not close issues, comment, or create/update a tracker issue on
 its own. When the user confirms:
 - **Closing stale/duplicate issues**: use `gh issue close <N> --comment
   "<reason>"`, one at a time, with the evidence from Step 3 in the comment.
-- **Maintaining the tracker issue**: this repo already has one — **#669**,
-  "[P0-P2 tracker] Repository safety, test, documentation, CI, and packaging
-  remediation". Update it in place (`gh issue comment 669 --body "..."` or
-  edit its body) rather than creating a second one. Only create a new tracker
-  if the user explicitly says #669 has been superseded/closed and a fresh one
-  is wanted.
+- **Maintaining the tracker issue**: as of this skill's authoring, this repo
+  had one open — **#669**, "[P0-P2 tracker] Repository safety, test,
+  documentation, CI, and packaging remediation". Verify it's still open
+  before trusting this note (`gh issue view 669 --json state`); update it in
+  place rather than creating a second one. Only create a new tracker if #669
+  is confirmed closed/superseded and the user wants a fresh one.
 
 Never bulk-close without per-item confirmation of the evidence — an agent
 closing a live issue because it *looks* stale is worse than leaving noise in


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/review-open-issues/SKILL.md` for periodic, full-queue CommunityMech issue triage.
- Preserves issue bodies, labels, comments, and timestamps while deriving a compact scan view.
- Checks every issue against `origin/main` and exact linked closing PRs, avoiding unmerged-branch and substring-search false positives.
- Keeps GitHub writes explicitly authorized and points tracker maintenance at the existing open issue #669.
- Cross-links the deep triage workflow from `.claude/skills/next-tasks/SKILL.md`.

## Adversarial review fixes

- Closes #676
- Closes #677
- Closes #678
- Closes #679

## Verification

- `just lint`
- `just test`: 2606 passed, 89 skipped, 8 deselected
- Live full-queue fetch retained all requested fields for 29 open issues.
- Exact `closedByPullRequestsReferences` lookup and merged timestamp verification tested against issue #673 / PR #674.
- Confirmed `origin/main` excludes an issue-referencing commit that `git log --all` includes.
- `git diff --check`

The generic Codex `quick_validate.py` validator was also tried. It rejects the repository-wide established frontmatter keys (`category`, `requires_database`, `requires_internet`, and `version`) in both this skill and the pre-existing `next-tasks` skill, so repository-consistent frontmatter was retained.

Generated with Claude Code and corrected through adversarial review.
